### PR TITLE
OOC Escape

### DIFF
--- a/modular_causticcove/code/modules/chompy_vore/eating/belly_obj_vr.dm
+++ b/modular_causticcove/code/modules/chompy_vore/eating/belly_obj_vr.dm
@@ -580,6 +580,8 @@
 		startfx.Add(L)
 		startfx.Add(get_belly_surrounding(L.contents))
 		owner.handle_belly_update() // This is run whenever a belly's contents are changed.
+		if(L.pulledby)					//OV ADD - After vore, grabs persist until you move, which makes things a bit weird!
+			L.pulledby.stop_pulling()	//OV ADD - Let's just clean it up here.
 	if(istype(thing,/obj/item))
 		var/obj/item/I = thing
 		startfx.Add(get_belly_surrounding(I.contents))

--- a/modular_ochrevalley/code/ooc_escape.dm
+++ b/modular_ochrevalley/code/ooc_escape.dm
@@ -1,0 +1,31 @@
+//OV FILE
+/mob/living/verb/ooc_escape()
+	set name = "OOC Escape"
+	set category = "OOC"
+
+	if(isturf(src.loc))	//Doesn't work if you aren't contained in some way
+		to_chat(src,span_warning("You are already on the ground. OOC Escape can not help you here."))
+		return
+	
+	if(!loc)
+		log_and_message_admins(span_warning("is trying to OOC escape, but they appear to be in nullspace, they probably need help."))
+		return
+	
+	if(tgui_alert(src,"Are you sure? This should only be used in situations where you are OOC uncomfortable or otherwise unintentionally stuck.","OOC Escape",list("Cancel","Escape")) != "Escape")
+		return
+
+	var/atom/where = loc
+	var/msg = "has OOC escaped. "
+	forceMove(get_turf(src))
+	if(isbelly(where))	//For vore
+		if(pulledby)
+			pulledby.stop_pulling()
+		var/obj/belly/B = where
+		msg += "They were in [key_name(B.owner)]'s [B]. "
+	else if(istype(where,/obj/item/micro))	//For micros
+		var/obj/item/micro/mh = where
+		mh.dump_mob()
+	else	//For everything else
+		msg += "They were in [where]. "
+	msg += "They have been placed on \the [loc]. [ADMIN_JMP(src)]"
+	log_and_message_admins(msg)

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3070,4 +3070,6 @@
 #include "modular_causticcove\code\modules\events\adventure\random_patrols\random_patrols.dm"
 #include "modular_causticcove\code\modules\events\adventure\random_bosses\random_boss.dm"
 #include "modular_causticcove\code\modules\spells\spell_types\wizard\conjure\conjure_tool.dm"
+#include "modular_ochrevalley\code\ooc_escape.dm"
+
 // END_INCLUDE


### PR DESCRIPTION
## About The Pull Request
Adds OOC Escape verb to all mob/living - When not on a turf (ex, in a belly, or a micro holder) allows a mob to exit whatever is containing it and re-enter the turf after a prompt.

Intended to allow those uncomfortable with an ERP scene to escape associated mechanics.

Also made bellies tell their mob to stop grabbing prey when the prey enters. This was relevant because if the pred ate prey and did not move, the pred would usually still have their grab. If prey then used OOC Escape, they would still be trapped.

## Testing Evidence

Tested several times in different conditions

## Why It's Good For The Game

Allows one to disengage from ERP where prefs may be broken. Also notifies the admins when it happens.


:cl:
add: Added OOC Escape
fix: Fixed predators retaining their grab on their prey after eating them if they did not move.
/:cl:
