### PR TITLE
Choose any size you want

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -151,8 +151,9 @@
 #define MANDATORY_FEATURE_LIST list("mcolor" = "FFF", "mcolor2" = "FFF", "mcolor3" = "FFF", "ethcolor" = "9c3030", "legs" = "Normal Legs", "body_size" = BODY_SIZE_NORMAL)
 
 #define BODY_SIZE_NORMAL 1.00
-#define BODY_SIZE_MAX 1.05
-#define BODY_SIZE_MIN 0.95
+#define BODY_SIZE_MAX 0.25	//OV ADD
+#define BODY_SIZE_MIN 2.00	//OV EDIT
+
 
 #define HAIR_COLOR_LIST list("#8f5a00", "#593800", "#362200", "#4e422e", "#8c8271", "#bfb7ab", "#31302e", "#f0dc48")
 #define EYE_COLOR_LIST list("#865900", "#06b400", "#312f27", "#008e83", "#002d8e", "#c16c00")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -496,7 +496,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 			dat += "<b>Patron:</b> <a href='?_src_=prefs;preference=patron;task=input'>[selected_patron?.name || "FUCK!"]</a><BR>"
 			dat += "<b>Dominance:</b> <a href='?_src_=prefs;preference=domhand'>[domhand == 1 ? "Left-handed" : "Right-handed"]</a><BR>"
 			//Caustic edit
-			dat += "<b>Size Category:</b> <a href='?_src_=prefs;preference=sizecat;task=input'>[sizecat]</a><BR>"
+			dat += "<b>Size Category:</b> [sizecat.name]<BR>" //OV EDIT - No longer needs to be a button
 			dat += "<b>Pickup able:</b> <a href='?_src_=prefs;preference=pickupable'>[pickupable == 1 ? "Yes" : "No"]</a><BR>"
 			//Caustic edit end
 			dat += "<b>Food Preferences:</b> <a href='?_src_=prefs;preference=culinary;task=menu'>Change</a><BR>"
@@ -2476,6 +2476,24 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 					if(new_body_size)
 						new_body_size = clamp(new_body_size * 0.01, BODY_SIZE_MIN, BODY_SIZE_MAX)
 						features["body_size"] = new_body_size
+						//OV edit
+						switch(new_body_size)
+							if(0 to 0.45)
+								sizecat = new /datum/sizecat/micro
+								to_chat(user, span_alert("You are now considered a micro."))
+							if(0.45 to 0.85)
+								sizecat = new /datum/sizecat/small
+								to_chat(user, span_alert("You are now considered small."))
+							if(0.85 to 1.15)
+								sizecat = new /datum/sizecat/none
+								to_chat(user, span_alert("You are now considered a normal height."))
+							if(1.15 to 1.5)
+								sizecat = new /datum/sizecat/giant
+								to_chat(user, span_alert("You are now considered a giant."))
+							if(1.5 to INFINITY)
+								sizecat = new /datum/sizecat/macro
+								to_chat(user, span_alert("You are now considered a macro."))
+						//OV edit end
 				//Caustic edit
 				if("sizecat")
 					select_sizecat(user)

--- a/modular_causticcove/code/modules/sizecats/sizecat_types.dm
+++ b/modular_causticcove/code/modules/sizecats/sizecat_types.dm
@@ -9,8 +9,8 @@
 	custom_text = "Increases your sprite size."
 
 /datum/sizecat/giant/apply_to_human(mob/living/carbon/human/recipient)
-	recipient.transform = recipient.transform.Scale(1.25, 1.25)
-	recipient.transform = recipient.transform.Translate(0, (0.25 * 16))
+//	recipient.transform = recipient.transform.Scale(1.25, 1.25) //OV REMOVE - Determined by sprite scale now
+//	recipient.transform = recipient.transform.Translate(0, (0.25 * 16)) //OV REMOVE
 	recipient.update_transform()
 	recipient.change_stat(STATKEY_STR, 1)
 	recipient.change_stat(STATKEY_CON, 1)
@@ -23,8 +23,8 @@
 	custom_text = "Greatly increases your sprite size. Makes you stronger and more durable but reduces your movement speed. Your speed stat remains unaffected."
 
 /datum/sizecat/macro/apply_to_human(mob/living/carbon/human/recipient)
-	recipient.transform = recipient.transform.Scale(2, 2)
-	recipient.transform = recipient.transform.Translate(0, (0.25 * 35))
+//	recipient.transform = recipient.transform.Scale(2, 2) //OV REMOVE
+//	recipient.transform = recipient.transform.Translate(0, (0.25 * 35)) //OV REMOVE
 	recipient.update_transform()
 	recipient.change_stat(STATKEY_STR, 2)
 	recipient.change_stat(STATKEY_CON, 2)
@@ -38,8 +38,8 @@
 	custom_text = "Reduces your sprite size.  Your stealth and agility is strengthened.  Your strength and durability will be lower than average."
 
 /datum/sizecat/small/apply_to_human(mob/living/carbon/human/recipient)
-	recipient.transform = recipient.transform.Scale(0.75, 0.75)
-	recipient.transform = recipient.transform.Translate(0, (0.5 * -5))
+//	recipient.transform = recipient.transform.Scale(0.75, 0.75) //OV REMOVE
+//	recipient.transform = recipient.transform.Translate(0, (0.5 * -5)) //OV REMOVE
 	recipient.update_transform()
 	recipient.change_stat(STATKEY_STR, -2)
 	recipient.change_stat(STATKEY_WIL, -2)
@@ -57,8 +57,8 @@
 	custom_text = "Greatly reduces your sprite size. Your stealth and agility will be strengthened greatly, however your strength, durability, and movement speed will be reduced greatly."
 
 /datum/sizecat/micro/apply_to_human(mob/living/carbon/human/recipient)
-	recipient.transform = recipient.transform.Scale(0.2, 0.2)
-	recipient.transform = recipient.transform.Translate(0, (0.25 * 8))
+//	recipient.transform = recipient.transform.Scale(0.2, 0.2) //OV REMOVE
+//	recipient.transform = recipient.transform.Translate(0, (0.25 * 8)) //OV REMOVE
 	recipient.update_transform()
 	recipient.change_stat(STATKEY_STR, -5) // Lets try keeping stat maluses to -5, and explore other options if this isnt enough for them.
 	recipient.change_stat(STATKEY_WIL, -5)


### PR DESCRIPTION
Added the ability to choose any scale you want from 25% to 200%. Size categories are now determined by the size that you choose and still apply all the stats and traits that they normally would.

## About The Pull Request

Added the ability to choose any scale you want from 25% to 200%. Size categories are now determined by the size that you choose and still apply all the stats and traits that they normally would.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///Ochre edit
Your code
///Ochre edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Tested ingame, spawned as the character at various sizes and observed size changes. Tested a shrinking spell and it worked as expected.

## Why It's Good For The Game

Much better character customisation without losing the stat effects.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added the ability to choose any scale you want from 25% to 200%. Size categories are now determined by the size that you choose and still apply all the stats and traits that they normally would.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
