### PR TITLE
Scrying privacy for scenes [WIP]

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -117,6 +117,8 @@
 
 	var/coven_protected = FALSE
 
+	var/scrying_blocked = FALSE //OV ADD
+
 
 /**
   * A list of teleport locations

--- a/code/game/objects/items/rogueitems/magic.dm
+++ b/code/game/objects/items/rogueitems/magic.dm
@@ -143,7 +143,7 @@
 	if (target == null)
 		return
 
-	if(HAS_TRAIT(target, TRAIT_ANTISCRYING))
+	if(scrying_blocked(target)) //OV EDIT
 		to_chat(user, span_warning("They are not within the gaze of the Orb."))
 		return
 
@@ -338,6 +338,19 @@
 	//Caustic Edit End
 	user.emote("scream")
 
+//OV edit
+/obj/item/scrying/proc/scrying_blocked(mob/living/target)
+	if(HAS_TRAIT(target, TRAIT_ANTISCRYING))
+		return TRUE
+	var/area/target_area = get_area(target)
+	if(target_area.scrying_blocked)
+		return TRUE
+	if(isbelly(target.loc))
+		var/obj/belly/preds_belly = target.loc
+		if(preds_belly.mode_flags & DM_FLAG_JAMSENSORS)
+			return TRUE
+	return FALSE
+//OV edit end
 /////////////////////////////////////////Crystal ball ghsot vision///////////////////
 
 /obj/item/crystalball/attack_self(mob/user)


### PR DESCRIPTION

## About The Pull Request

Added a few extra ways to block scrying.
Currently includes:
* In an area where scrying is blocked (not set).
* In a belly with jammed sensors.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [ ] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [ ] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///Ochre edit
Your code
///Ochre edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [ ] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence



## Why It's Good For The Game

Better privacy for scenes without disabling scrying.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Added a few extra ways to block scrying.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
