### PR TITLE
Fixes Natural Armor

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -852,7 +852,7 @@
 				def_zone = BODY_ZONE_R_LEG
 	if(istype(skin_armor, /obj/item/clothing/suit/roguetown/armor/skin_armor/natural_armor)) //Always return early if natural armor is present, it doesn't allow other armors to work
 		var/obj/item/clothing/suit/roguetown/armor/skin_armor/natural_armor/C = skin_armor
-		if(skin_armor.obj_integrity > 0)
+		if(C.obj_integrity > 0)
 			used = C
 			return used
 		return //return null if no armor
@@ -892,8 +892,10 @@
 	if(istype(skin_armor, /obj/item/clothing/suit/roguetown/armor/skin_armor/natural_armor)) //Always return early if natural armor is present, it doesn't allow other armors to work
 		var/obj/item/clothing/suit/roguetown/armor/skin_armor/natural_armor/C = skin_armor
 		var/list/used_armor = list()
-		if(C.obj_integrity <= 0)
-			used_armor[C] = C.armor.getRating(d_type)
+		if(C.obj_integrity > 0)
+			var/val = C.armor.getRating(d_type)
+			if(val > 0)
+				used_armor[C] = C.armor.getRating(d_type)
 		return used_armor
 	var/list/body_parts = list(skin_armor, head, wear_mask, wear_wrists, gloves, wear_neck, cloak, wear_armor, wear_shirt, shoes, wear_pants, backr, backl, belt, s_store, glasses, ears, wear_ring) //Everything but pockets. Pockets are l_store and r_store. (if pockets were allowed, putting something armored, gloves or hats for example, would double up on the armor)
 	var/list/used_armor = list()


### PR DESCRIPTION

## About The Pull Request

Fixed natural armor not working as intended, where it should ignore all other armor even if broken. 
Fixes https://github.com/Ochre-Valley/Ochre-Valley/issues/7

After testing, it seems that the deathless trait has been fixed already.


## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///Ochre edit
Your code
///Ochre edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Tested ingame, works fine now.
<img width="600" height="567" alt="image" src="https://github.com/user-attachments/assets/5dd67f04-cb05-4c8f-9412-1fa8d9dd78a0" />


## Why It's Good For The Game

bug fix, it allowed people to essentially have double armour

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixed natural armor not working as intended, where it should ignore all other armor even if broken. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
