### PR TITLE
Better loading of sizecat

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -249,8 +249,10 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	migrant  = new /datum/migrant_pref(src)
 	familiar_prefs = new /datum/familiar_prefs(src)
 
+	//OV edit
 	if(!sizecat)
 		sizecat = new /datum/sizecat/none
+	//OV edit end
 
 	for(var/custom_name_id in GLOB.preferences_custom_names)
 		custom_names[custom_name_id] = get_default_name(custom_name_id)
@@ -301,6 +303,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	validate_customizer_entries()
 	reset_all_customizer_accessory_colors()
 	randomize_all_customizer_accessories()
+	ensure_sizecat() //OV ADD
 	reset_descriptors()
 	taur_type = null
 
@@ -2480,21 +2483,17 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 						new_body_size = clamp(new_body_size * 0.01, BODY_SIZE_MIN, BODY_SIZE_MAX)
 						features["body_size"] = new_body_size
 						//OV edit
+						ensure_sizecat(new_body_size)
 						switch(new_body_size)
 							if(0 to 0.45)
-								sizecat = new /datum/sizecat/micro
 								to_chat(user, span_alert("You are now considered a micro."))
 							if(0.45 to 0.85)
-								sizecat = new /datum/sizecat/small
 								to_chat(user, span_alert("You are now considered small."))
 							if(0.85 to 1.15)
-								sizecat = new /datum/sizecat/none
 								to_chat(user, span_alert("You are now considered a normal height."))
 							if(1.15 to 1.5)
-								sizecat = new /datum/sizecat/giant
 								to_chat(user, span_alert("You are now considered a giant."))
 							if(1.5 to INFINITY)
-								sizecat = new /datum/sizecat/macro
 								to_chat(user, span_alert("You are now considered a macro."))
 						//OV edit end
 				//Caustic edit
@@ -3215,3 +3214,23 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 	dat += GLOB.roleplay_readme
 	popup.set_content(dat.Join())
 	popup.open(FALSE)
+
+//OV edit
+/datum/preferences/proc/ensure_sizecat(new_body_size)
+	if(!new_body_size)
+		new_body_size = features["body_size"]
+		if(!new_body_size)
+			new_body_size = 1
+	switch(new_body_size)
+		if(0 to 0.45)
+			sizecat = new /datum/sizecat/micro
+		if(0.45 to 0.85)
+			sizecat = new /datum/sizecat/small
+		if(0.85 to 1.15)
+			sizecat = new /datum/sizecat/none
+		if(1.15 to 1.5)
+			sizecat = new /datum/sizecat/giant
+		if(1.5 to INFINITY)
+			sizecat = new /datum/sizecat/macro
+//	message_admins("ensure_sizecat run for [sizecat.name] at [new_body_size]")
+//OV edit end

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -514,7 +514,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	_load_virtue(S)
 	_load_flaw(S)
 	//Caustic edit
-	_load_sizecat(S)
+//	_load_sizecat(S) //OV EDIT - Not needed, set based on scale now
 	_load_pickupable(S)
 	//Caustic edit end
 	_load_culinary_preferences(S)
@@ -619,6 +619,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["body_size"] >> features["body_size"]
 	if (!features["body_size"])
 		features["body_size"] = BODY_SIZE_NORMAL
+	ensure_sizecat() //OV ADD - Replacing sizecat load based on scale
 	//try to fix any outdated data if necessary
 	if(needs_update >= 0)
 		update_character(needs_update, S)		//needs_update == savefile_version if we need an update (positive integer)


### PR DESCRIPTION


## About The Pull Request

Just ensures that sizecat is properly checked when loading. However, there's a bug where changing to a different sizecat and then switching to an unused slot carries the sizecat over but still at 100% scale. I am not sure how to force calculating the sizecat again in this case, I've been trying a lot of thing, so help would be appreciated.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///Ochre edit
Your code
///Ochre edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Just ensures that sizecat is properly checked when loading.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
