### PR TITLE
Adds belly examine messages and clothing toggle

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -775,6 +775,7 @@
 //			else if(!client)
 //				msg += "[m3] a blank, absent-minded stare and appears completely unresponsive to anything. [t_He] may snap out of it soon."
 
+
 	if(length(msg))
 		. += span_warning("[msg.Join("\n")]")
 
@@ -851,6 +852,17 @@
 			medical_text = "[heartbeat ? "[heartbeat] | " : ""]<a href='?src=[REF(src)];inspect_limb=[checked_zone]'>Inspect [parse_zone(checked_zone)]</a>"
 
 	. += medical_text
+
+	
+	//OV edit 
+	// VORE BELLY EXAMINES
+	var/list/vorestrings = list()
+	vorestrings += formatted_vore_examine()
+	for(var/entry in vorestrings)
+		if(entry == "" || entry == null)
+			vorestrings -= entry
+	. += vorestrings
+	//OV edit end
 
 	if(!HAS_TRAIT(src, TRAIT_DECEIVING_MEEKNESS) && user != src)
 		if(isliving(user))

--- a/modular_causticcove/code/modules/chompy_vore/eating/belly_import.dm
+++ b/modular_causticcove/code/modules/chompy_vore/eating/belly_import.dm
@@ -581,6 +581,15 @@
 			if(new_item_digest_logs == 1)
 				new_belly.item_digest_logs = TRUE
 
+		//OV edit		
+		if(isnum(belly_data["hidden_by_armor"]))
+			var/new_hidden_by_armor = belly_data["hidden_by_armor"]
+			if(new_hidden_by_armor == 0)
+				new_belly.hidden_by_armor = FALSE
+			if(new_hidden_by_armor == 1)
+				new_belly.hidden_by_armor = TRUE
+		//OV edit end
+
 		if(istext(belly_data["selective_preference"]))
 			var/new_selective_preference = belly_data["selective_preference"]
 			if(new_selective_preference == "Digest")

--- a/modular_causticcove/code/modules/chompy_vore/eating/belly_obj_vr.dm
+++ b/modular_causticcove/code/modules/chompy_vore/eating/belly_obj_vr.dm
@@ -274,6 +274,7 @@
 	var/entrance_logs = TRUE				// Belly-specific entry message toggle.
 	var/noise_freq = 42500					// Tasty sound prefs.
 	var/item_digest_logs = FALSE			// Chat messages for digested items.
+	var/hidden_by_armor = FALSE				// OV ADD - Hides belly if covered by clothing
 	var/storing_nutrition = FALSE			// Storing gained nutrition as paste instead of absorbing it.
 	var/belchchance = 0						// % Chance of pred belching on prey struggle
 
@@ -464,6 +465,7 @@
 	"absorbedrename_enabled",
 	"absorbedrename_name",
 	"item_digest_logs",
+	"hidden_by_armor",//OV ADD
 	"show_fullness_messages",
 	"digest_max",
 	"egg_type",
@@ -1741,6 +1743,7 @@
 	dupe.entrance_logs = entrance_logs
 	dupe.noise_freq = noise_freq
 	dupe.item_digest_logs = item_digest_logs
+	dupe.hidden_by_armor = hidden_by_armor //OV ADD
 	dupe.show_fullness_messages = show_fullness_messages
 	dupe.belchchance = belchchance
 	dupe.digest_max = digest_max

--- a/modular_causticcove/code/modules/chompy_vore/eating/exportpanel_vr.dm
+++ b/modular_causticcove/code/modules/chompy_vore/eating/exportpanel_vr.dm
@@ -315,6 +315,7 @@
 			belly_data["storing_nutrition"] = B.storing_nutrition
 			belly_data["entrance_logs"] = B.entrance_logs
 			belly_data["item_digest_logs"] = B.item_digest_logs
+			belly_data["hidden_by_armor"] = B.hidden_by_armor //OV ADD
 			belly_data["eating_privacy_local"] = B.eating_privacy_local
 			belly_data["private_struggle"] = B.private_struggle
 			belly_data["absorbedrename_enabled"] = B.absorbedrename_enabled

--- a/modular_causticcove/code/modules/chompy_vore/eating/living_vr.dm
+++ b/modular_causticcove/code/modules/chompy_vore/eating/living_vr.dm
@@ -299,11 +299,16 @@
 // Returns examine messages for bellies
 //
 /mob/living/proc/examine_bellies()
-	if(!show_pudge()) //Some clothing or equipment can hide this.
-		return list()
+//	if(!show_pudge()) //OV REMOVE - Some clothing or equipment can hide this.
+//		return list() //OV REMOVE
 
 	var/list/message_list = list()
 	for(var/obj/belly/B as anything in vore_organs)
+		//OV edit
+		if(B.hidden_by_armor)
+			if(!show_pudge())
+				continue
+		//OV edit end
 		var/bellymessage = B.get_examine_msg()
 		if(bellymessage) message_list += bellymessage
 
@@ -348,7 +353,7 @@
 	/*if(!client?.prefs?.read_preference(/datum/preference/toggle/vchat_enable))
 		return vore_examine_data*/
 
-	return span_details("🤰 | Vore Descriptions", vore_examine_data.Join("\n"))
+	return span_details("Vore Descriptions", vore_examine_data.Join("\n")) //OV EDIT
 
 
 //

--- a/modular_causticcove/code/modules/chompy_vore/eating/panel_databackend/vorepanel_set_attribute.dm
+++ b/modular_causticcove/code/modules/chompy_vore/eating/panel_databackend/vorepanel_set_attribute.dm
@@ -515,6 +515,11 @@
 		if("b_item_digest_logs")
 			host.vore_selected.item_digest_logs = !host.vore_selected.item_digest_logs
 			. = TRUE
+		//OV edit
+		if("b_hidden_by_armor")
+			host.vore_selected.hidden_by_armor = !host.vore_selected.hidden_by_armor
+			. = TRUE
+		//OV edit end
 		if("b_bulge_size")
 			var/new_bulge = text2num(params["val"])
 			if(!isnum(new_bulge))

--- a/modular_causticcove/code/modules/chompy_vore/eating/panel_databackend/vorepanel_vore_data.dm
+++ b/modular_causticcove/code/modules/chompy_vore/eating/panel_databackend/vorepanel_vore_data.dm
@@ -147,6 +147,7 @@
 				"emote_active" = selected.emote_active,
 				"entrance_logs" = selected.entrance_logs,
 				"item_digest_logs" = selected.item_digest_logs,
+				"hidden_by_armor" = selected.hidden_by_armor, //OV ADD
 				"name_min" = BELLIES_NAME_MIN,
 				"name_length" = BELLIES_NAME_MAX,
 			)

--- a/tgui/packages/tgui/interfaces/VorePanel/VoreSelectedBellyTabs/VoreSelectedBellyDescriptions.tsx
+++ b/tgui/packages/tgui/interfaces/VorePanel/VoreSelectedBellyTabs/VoreSelectedBellyDescriptions.tsx
@@ -30,6 +30,7 @@ export const VoreSelectedBellyDescriptions = (props: {
     show_liq_fullness,
     entrance_logs,
     item_digest_logs,
+    hidden_by_armor,
     name_length,
     name_min,
   } = bellyDescriptionData;
@@ -195,6 +196,18 @@ export const VoreSelectedBellyDescriptions = (props: {
                     tooltip={
                       (item_digest_logs ? 'Dis' : 'En') +
                       'ables item digest messages being shown to yourself.'
+                    }
+                  />
+                </LabeledList.Item>
+                <LabeledList.Item label="Hidden By Clothes">
+                  <VorePanelEditSwitch
+                    action="set_attribute"
+                    subAction="b_hidden_by_armor"
+                    editMode={editMode}
+                    active={!!hidden_by_armor}
+                    tooltip={
+                      (hidden_by_armor ? 'Dis' : 'En') +
+                      'ables some torso clothes hiding your belly examine info.'
                     }
                   />
                 </LabeledList.Item>

--- a/tgui/packages/tgui/interfaces/VorePanel/types.ts
+++ b/tgui/packages/tgui/interfaces/VorePanel/types.ts
@@ -83,6 +83,7 @@ export type bellyDescriptionData = {
   show_liq_fullness: BooleanLike;
   entrance_logs: BooleanLike;
   item_digest_logs: BooleanLike;
+  hidden_by_armor: BooleanLike;
   name_length: number;
   name_min: number;
   displayed_message_types: {


### PR DESCRIPTION

## About The Pull Request

Added belly examine messages to the examines in the text window, just like virgo.

Added a toggle in the vore panel on a per-belly basis for whether that belly examine is visible with clothes covering the torso.

NOTE: Be careful about test merging this as it will obviously add the belly option to the save file, so once it's added it shouldn't be removed.

Fixes https://github.com/Ochre-Valley/Ochre-Valley/issues/12

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///Ochre edit
Your code
///Ochre edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Wearing a gambeson in both:
With hidden by clothing disabled:
<img width="632" height="478" alt="image" src="https://github.com/user-attachments/assets/70600f2a-7593-48d2-9a1f-50e9d1f8eab1" />

With it enabled:
<img width="620" height="426" alt="image" src="https://github.com/user-attachments/assets/f1d51600-63fb-42e6-aedb-28516e2a09ee" />


## Why It's Good For The Game

Feature was always intended, just nobody bother adding it to the examine proc.
Also the toggle for whether it's hidden by clothing is just fun.

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added belly examine messages to the examines in the text window, just like virgo.
add: Added a toggle in the vore panel on a per-belly basis for whether that belly examine is visible with clothes covering the torso.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
