### PR TITLE
Vore Player

### DIFF
--- a/modular_ochrevalley/code/vore_verb.dm
+++ b/modular_ochrevalley/code/vore_verb.dm
@@ -1,0 +1,66 @@
+//OV FILE
+/mob/living/verb/vore_player()
+	set name = "Vore Player"
+	set desc = "Attempt to eat an adjacent player."
+	set category = "Vore"
+
+	if(stat)
+		to_chat(src,span_warning("You can't do that right now."))
+		return
+	if(restrained(FALSE))
+		to_chat(src,span_warning("You can't do that while restrained."))
+		return
+	if(IsSleeping())
+		to_chat(src,span_warning("You can't do that while sleeping."))
+		return
+	if(!isturf(loc))
+		to_chat(src,span_warning("You need to be on the open ground to do that."))
+		return
+	
+	var/list/potential_targets = list()
+
+	for(var/mob/living/L in view(1))
+		if(L == src)	//Don't eat yourself
+			continue
+		if(!isliving(L))	//Only target living
+			continue
+		if(!vore_pref_compat(src,L))
+			continue
+		potential_targets |= L
+	
+	for(var/thing in contents)
+		if(!istype(thing,/obj/item/micro))	//U can also eat players in your hand
+			continue
+		var/obj/item/micro/M = thing
+		if(M.held_mob == src)
+			continue
+		if(!vore_pref_compat(src,M.held_mob))
+			continue
+	
+		potential_targets |= M.held_mob
+		
+	if(potential_targets.len <= 0)
+		to_chat(src, span_warning("There are no valid targets in range."))
+		return
+	
+	var/mob/living/choice = tgui_input_list(src,"Who would you like to eat?","Vore Target",potential_targets)
+
+	if(!choice)
+		return
+	if(get_dist(get_turf(src),get_turf(choice)) > 1)
+		to_chat(src, span_warn("\The [choice] is too far away."))
+		return
+
+	return feed_grabbed_to_self(src,choice)
+
+/proc/vore_pref_compat(var/mob/living/pred,var/mob/living/prey,var/reject_combat = TRUE)	//The other vore check sends an admin log to complain about you eating people against their prefs, so I made this one quieter since it only happens when gathering a list of compatible targets
+	if(!pred || !prey)
+		return FALSE
+	if(reject_combat)	//We probably shouldn't target people who are trying to fight you unless you want that.
+		if(prey.cmode)
+			return FALSE
+
+	if(!prey.devourable)
+		return FALSE
+	
+	return TRUE

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3071,5 +3071,7 @@
 #include "modular_causticcove\code\modules\events\adventure\random_bosses\random_boss.dm"
 #include "modular_causticcove\code\modules\spells\spell_types\wizard\conjure\conjure_tool.dm"
 #include "modular_ochrevalley\code\ooc_escape.dm"
+#include "modular_ochrevalley\code\vore_verb.dm"
+
 
 // END_INCLUDE


### PR DESCRIPTION
## About The Pull Request

Adds the 'Vore Player' verb into the 'Vore' tab. This allows you to select an adjacent player to eat, which initiates the usual vore timer (about 10 seconds). This verb ONLY allows you to target players who are not in combat and and with an enabled devourable preference. It also allows you to target micros in your hands. Either player moving interrupts this.


## Testing Evidence

Tested on local

## Why It's Good For The Game

For those who just want to eat someone, there are a number of mechanics that need to be configured correctly and messed with to make that happen. This provides an easy, no fuss alternative to those mechanics for those who are just doing a scene.

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Adds 'Vore Player' verb

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
