### PR TITLE
Allows muting ERP [Needs rework]

### DIFF
--- a/code/datums/sexcon2/actions/_base_action.dm
+++ b/code/datums/sexcon2/actions/_base_action.dm
@@ -56,6 +56,8 @@
 	var/intensity = 2
 	///Used for determining whether the good lover bonus can apply
 	var/masturbation = FALSE
+	///Used to mute sounds
+	var/mute_sound = FALSE //OV ADD
 
 /datum/sex_action/Destroy()
 	for(var/datum/sex_session_lock/lock in sex_locks)
@@ -151,7 +153,7 @@
 		user.visible_message(message)
 
 	var/sound = get_start_sound(user, target)
-	if(sound)
+	if(sound && !mute_sound) //OV EDIT
 		playsound(target, sound, 20, TRUE, ignore_walls = FALSE)
 
 	return TRUE

--- a/code/datums/sexcon2/actions/masturbation/anus.dm
+++ b/code/datums/sexcon2/actions/masturbation/anus.dm
@@ -25,7 +25,8 @@
 /datum/sex_action/masturbate/anus/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fingers [user.p_their()] butt..."))
-	playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 
 	sex_session.perform_sex_action(user, 2, 6, TRUE)
 	sex_session.handle_passive_ejaculation()

--- a/code/datums/sexcon2/actions/masturbation/finger_vagina.dm
+++ b/code/datums/sexcon2/actions/masturbation/finger_vagina.dm
@@ -31,7 +31,8 @@
 /datum/sex_action/masturbate/vagina_finger/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fingers [user.p_their()] [pick("slit","cunt","pussy","snatch")]..."))
-	playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 
 	sex_session.perform_sex_action(user, 2, 4, TRUE)
 

--- a/code/datums/sexcon2/actions/masturbation/other/anus.dm
+++ b/code/datums/sexcon2/actions/masturbation/other/anus.dm
@@ -26,7 +26,8 @@
 /datum/sex_action/masturbate/other/anus/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fingers [target]'s butt..."))
-	playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 
 	sex_session.perform_sex_action(target, 2, 6, TRUE)
 	sex_session.handle_passive_ejaculation(target)

--- a/code/datums/sexcon2/actions/masturbation/other/clit.dm
+++ b/code/datums/sexcon2/actions/masturbation/other/clit.dm
@@ -28,7 +28,8 @@
 /datum/sex_action/masturbate/other/clit/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] strokes [target]'s clit..."))
-	playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 
 	sex_session.perform_sex_action(target, 2, 4, TRUE)
 

--- a/code/datums/sexcon2/actions/masturbation/other/penis.dm
+++ b/code/datums/sexcon2/actions/masturbation/other/penis.dm
@@ -30,7 +30,8 @@
 /datum/sex_action/masturbate/other/penis/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] jerks [target]'s cock off..."))
-	playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 
 	sex_session.perform_sex_action(target, 2, 0, TRUE)
 

--- a/code/datums/sexcon2/actions/masturbation/other/vagina.dm
+++ b/code/datums/sexcon2/actions/masturbation/other/vagina.dm
@@ -32,7 +32,8 @@
 /datum/sex_action/masturbate/other/vagina/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fingers [target]'s [pick("slit","cunt","pussy","snatch")]..."))
-	playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 
 	sex_session.perform_sex_action(target, 2, 4, TRUE)
 

--- a/code/datums/sexcon2/actions/masturbation/penis.dm
+++ b/code/datums/sexcon2/actions/masturbation/penis.dm
@@ -32,7 +32,8 @@
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/chosen_verb = pick(list("jerks [user.p_their()] cock", "strokes [user.p_their()] cock", "masturbates", "jerks off"))
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] [chosen_verb]..."))
-	playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 
 	do_onomatopoeia(user)
 

--- a/code/datums/sexcon2/actions/masturbation/penis_over.dm
+++ b/code/datums/sexcon2/actions/masturbation/penis_over.dm
@@ -34,7 +34,8 @@
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/chosen_verb = pick(list("jerks [user.p_their()] cock", "strokes [user.p_their()] cock", "masturbates", "jerks off"))
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] [chosen_verb] over [target]"))
-	playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 
 	sex_session.perform_sex_action(user, 2, 4, TRUE)
 

--- a/code/datums/sexcon2/actions/masturbation/vagina.dm
+++ b/code/datums/sexcon2/actions/masturbation/vagina.dm
@@ -27,7 +27,8 @@
 /datum/sex_action/masturbate/vagina/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] strokes [user.p_their()] clit..."))
-	playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 
 	sex_session.perform_sex_action(user, 2, 4, TRUE)
 

--- a/code/datums/sexcon2/actions/oral/blowjob.dm
+++ b/code/datums/sexcon2/actions/oral/blowjob.dm
@@ -31,9 +31,10 @@
 	user.visible_message(span_warning("[user] starts sucking [target]'s cock..."))
 
 /datum/sex_action/blowjob/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
-	user.make_sucking_noise()
+	if(!mute_sound) //OV EDIT
+		user.make_sucking_noise() //OV EDIT
 	// you want to know how i got these scars?
-	if(istype(user.head, /obj/item/clothing/head/roguetown/jester))
+	if(istype(user.head, /obj/item/clothing/head/roguetown/jester) && !mute_sound) //OV EDIT
 		playsound(user, SFX_JINGLE_BELLS, 30, TRUE, -2, ignore_walls = FALSE)
 
 	var/datum/sex_session/sex_session = get_sex_session(user, target)

--- a/code/datums/sexcon2/actions/oral/cunnilingus.dm
+++ b/code/datums/sexcon2/actions/oral/cunnilingus.dm
@@ -36,9 +36,10 @@
 /datum/sex_action/cunnilingus/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] sucks [target]'s clit..."))
-	user.make_sucking_noise()
+	if(!mute_sound) //OV EDIT
+		user.make_sucking_noise() //OV EDIT
 	// my father. birthed me into the class of yeoman.
-	if(istype(user.head, /obj/item/clothing/head/roguetown/jester))
+	if(istype(user.head, /obj/item/clothing/head/roguetown/jester) && !mute_sound) //OV EDIT
 		playsound(user, SFX_JINGLE_BELLS, 30, TRUE, -2, ignore_walls = FALSE)
 	do_thrust_animate(user, target, sex_session)
 

--- a/code/datums/sexcon2/actions/oral/foot_lick.dm
+++ b/code/datums/sexcon2/actions/oral/foot_lick.dm
@@ -32,7 +32,8 @@
 /datum/sex_action/foot_lick/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] licks [target]'s feet..."))
-	user.make_sucking_noise()
+	if(!mute_sound) //OV EDIT
+		user.make_sucking_noise() //OV EDIT
 
 /datum/sex_action/foot_lick/on_finish(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	. = ..()

--- a/code/datums/sexcon2/actions/oral/kissing.dm
+++ b/code/datums/sexcon2/actions/oral/kissing.dm
@@ -31,7 +31,8 @@
 /datum/sex_action/kissing/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] makes out with [target]..."))
-	user.make_sucking_noise()
+	if(!mute_sound) //OV EDIT
+		user.make_sucking_noise() //OV EDIT
 
 	sex_session.perform_sex_action(user, 1, 2, TRUE)
 	sex_session.handle_passive_ejaculation()

--- a/code/datums/sexcon2/actions/oral/rimming.dm
+++ b/code/datums/sexcon2/actions/oral/rimming.dm
@@ -31,7 +31,8 @@
 /datum/sex_action/rimming/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] rims [target]'s butt..."))
-	user.make_sucking_noise()
+	if(!mute_sound) //OV EDIT
+		user.make_sucking_noise() //OV EDIT
 	do_thrust_animate(user, target, sex_session)
 
 	sex_session.perform_sex_action(target, 2, 0, TRUE)

--- a/code/datums/sexcon2/actions/oral/suck_balls.dm
+++ b/code/datums/sexcon2/actions/oral/suck_balls.dm
@@ -35,7 +35,8 @@
 /datum/sex_action/suck_balls/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] sucks [target]'s balls..."))
-	user.make_sucking_noise()
+	if(!mute_sound) //OV EDIT
+		user.make_sucking_noise() //OV EDIT
 
 	sex_session.perform_sex_action(target, 1, 3, TRUE)
 	sex_session.handle_passive_ejaculation(target)

--- a/code/datums/sexcon2/actions/oral/suck_nipples.dm
+++ b/code/datums/sexcon2/actions/oral/suck_nipples.dm
@@ -36,7 +36,8 @@
 /datum/sex_action/suck_nipples/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] sucks [target]'s nipples..."))
-	user.make_sucking_noise()
+	if(!mute_sound) //OV EDIT
+		user.make_sucking_noise() //OV EDIT
 
 	sex_session.perform_sex_action(target, 1, 3, TRUE)
 	sex_session.handle_passive_ejaculation(target)

--- a/code/datums/sexcon2/actions/other/facesitting.dm
+++ b/code/datums/sexcon2/actions/other/facesitting.dm
@@ -37,7 +37,8 @@
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/verbstring = pick(list("rubs", "smushes", "forces"))
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] [verbstring] [user.p_their()] butt against [target] face."))
-	target.make_sucking_noise()
+	if(!mute_sound) //OV EDIT
+		target.make_sucking_noise() //OV EDIT
 	do_thrust_animate(user, target, sex_session)
 
 	sex_session.perform_sex_action(user, 1, 3, TRUE)

--- a/code/datums/sexcon2/actions/other/frotting.dm
+++ b/code/datums/sexcon2/actions/other/frotting.dm
@@ -38,7 +38,8 @@
 /datum/sex_action/frotting/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] frots cocks together with [target]."))
-	playsound(user, 'sound/misc/mat/fingering.ogg', 20, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(user, 'sound/misc/mat/fingering.ogg', 20, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 
 	sex_session.perform_sex_action(user, 1, 4, TRUE)
 	sex_session.handle_passive_ejaculation()

--- a/code/datums/sexcon2/actions/other/grinding.dm
+++ b/code/datums/sexcon2/actions/other/grinding.dm
@@ -22,7 +22,8 @@
 /datum/sex_action/grind_body/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] grinds against [target]."))
-	playsound(target, 'sound/misc/mat/segso.ogg', 50, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(target, 'sound/misc/mat/segso.ogg', 50, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 	do_thrust_animate(user, target, sex_session)
 
 	sex_session.perform_sex_action(user, 1, 0.5, TRUE)

--- a/code/datums/sexcon2/actions/other/rub_body.dm
+++ b/code/datums/sexcon2/actions/other/rub_body.dm
@@ -28,7 +28,8 @@
 /datum/sex_action/rub_body/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] rubs [target]'s body..."))
-	user.make_sucking_noise()
+	if(!mute_sound) //OV EDIT
+		user.make_sucking_noise() //OV EDIT
 
 	sex_session.perform_sex_action(target, 0.5, 0, TRUE)
 	sex_session.handle_passive_ejaculation(target)

--- a/code/datums/sexcon2/actions/other/spanking.dm
+++ b/code/datums/sexcon2/actions/other/spanking.dm
@@ -33,7 +33,8 @@
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/force = sex_session.force
 	var/sound = pick('sound/foley/slap.ogg', 'sound/foley/smackspecial.ogg')
-	playsound(target, sound, 50, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(target, sound, 50, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 
 	var/msg = "[user] [sex_session.get_generic_force_adjective()] spanks [target]'s butt."
 	user.visible_message(sex_session.spanify_force(msg))

--- a/code/datums/sexcon2/actions/other/tongue_bath.dm
+++ b/code/datums/sexcon2/actions/other/tongue_bath.dm
@@ -28,7 +28,8 @@
 /datum/sex_action/tonguebath/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] bathes [target]'s body with [user.p_their()] tongue..."))
-	user.make_sucking_noise()
+	if(!mute_sound) //OV EDIT
+		user.make_sucking_noise() //OV EDIT
 
 	sex_session.perform_sex_action(target, 0.5, 0, TRUE)
 	sex_session.handle_passive_ejaculation(target)

--- a/code/datums/sexcon2/actions/sex/anal.dm
+++ b/code/datums/sexcon2/actions/sex/anal.dm
@@ -36,7 +36,8 @@
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/is_knotting = sex_session.do_knot_action
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] [is_knotting ? "knot-fucks" : "fucks"] [target]'s ass."))
-	playsound(target, sex_session.get_force_sound(), 50, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(target, sex_session.get_force_sound(), 50, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 	do_thrust_animate(user, target, sex_session)
 
 	do_onomatopoeia(user)
@@ -85,7 +86,8 @@
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/is_knotting = sex_session.do_knot_action
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] [is_knotting ? "double-knots" : "double-fucks" ] [target]'s ass."))
-	playsound(target, sex_session.get_force_sound(), 50, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(target, sex_session.get_force_sound(), 50, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 	do_thrust_animate(user, target, sex_session)
 
 	do_onomatopoeia(user)

--- a/code/datums/sexcon2/actions/sex/boobjob.dm
+++ b/code/datums/sexcon2/actions/sex/boobjob.dm
@@ -35,7 +35,8 @@
 /datum/sex_action/sex/boobjob/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fucks [target]'s tits."))
-	playsound(user, 'sound/misc/mat/fingering.ogg', 20, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(user, 'sound/misc/mat/fingering.ogg', 20, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 
 	sex_session.perform_sex_action(user, 2, 4, TRUE)
 

--- a/code/datums/sexcon2/actions/sex/double_penetration.dm
+++ b/code/datums/sexcon2/actions/sex/double_penetration.dm
@@ -40,7 +40,8 @@
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/is_knotting = sex_session.do_knot_action
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] [is_knotting ? "knot-fucks" : "fucks"] [target]'s holes together."))
-	playsound(target, sex_session.get_force_sound(), 50, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(target, sex_session.get_force_sound(), 50, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 	do_thrust_animate(user, target, sex_session)
 
 	do_onomatopoeia(user)

--- a/code/datums/sexcon2/actions/sex/other/anal.dm
+++ b/code/datums/sexcon2/actions/sex/other/anal.dm
@@ -37,7 +37,8 @@
 /datum/sex_action/sex/other/anal/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] rides [target]."))
-	playsound(target, sex_session.get_force_sound(), 50, TRUE, -2, ignore_walls = FALSE)
+	if(mute_sound) //OV EDIT
+		playsound(target, sex_session.get_force_sound(), 50, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 	do_thrust_animate(user, target, sex_session)
 
 	do_onomatopoeia(user)

--- a/code/datums/sexcon2/actions/sex/other/boobjob.dm
+++ b/code/datums/sexcon2/actions/sex/other/boobjob.dm
@@ -35,7 +35,8 @@
 /datum/sex_action/sex/other/boobjob/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	target.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fucks [target]'s tits."))
-	playsound(target, 'sound/misc/mat/fingering.ogg', 20, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(target, 'sound/misc/mat/fingering.ogg', 20, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 
 	sex_session.perform_sex_action(target, 2, 4, TRUE)
 

--- a/code/datums/sexcon2/actions/sex/other/footjob.dm
+++ b/code/datums/sexcon2/actions/sex/other/footjob.dm
@@ -34,9 +34,10 @@
 /datum/sex_action/sex/other/footjob/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] jerks [target]'s cock with [user.p_their()] feet..."))
-	playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 	// and i had never had c hance to interact with the jesters...
-	if(istype(user.shoes, /obj/item/clothing/shoes/roguetown/jester))
+	if(istype(user.shoes, /obj/item/clothing/shoes/roguetown/jester) && !mute_sound) //OV EDIT
 		playsound(user, SFX_JINGLE_BELLS, 30, TRUE, -2, ignore_walls = FALSE)
 
 

--- a/code/datums/sexcon2/actions/sex/other/thighjob.dm
+++ b/code/datums/sexcon2/actions/sex/other/thighjob.dm
@@ -29,7 +29,8 @@
 /datum/sex_action/sex/other/thighjob/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] jerks [target]'s cock with [user.p_their()] thighs..."))
-	playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(user, 'sound/misc/mat/fingering.ogg', 30, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 	do_thrust_animate(user, target, sex_session)
 
 	sex_session.perform_sex_action(target, 2, 4, TRUE)

--- a/code/datums/sexcon2/actions/sex/other/vagina.dm
+++ b/code/datums/sexcon2/actions/sex/other/vagina.dm
@@ -40,9 +40,10 @@
 /datum/sex_action/sex/other/vagina/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] rides [target]."))
-	playsound(target, sex_session.get_force_sound(), 50, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(target, sex_session.get_force_sound(), 50, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 	// i became a man at arms to get access to the keep...
-	if(istype(user.head, /obj/item/clothing/head/roguetown/jester))
+	if(istype(user.head, /obj/item/clothing/head/roguetown/jester) && !mute_sound) //OV EDIT
 		playsound(user, SFX_JINGLE_BELLS, 30, TRUE, -2, ignore_walls = FALSE)
 	do_thrust_animate(user, target, sex_session)
 

--- a/code/datums/sexcon2/actions/sex/scissoring.dm
+++ b/code/datums/sexcon2/actions/sex/scissoring.dm
@@ -37,7 +37,8 @@
 /datum/sex_action/scissoring/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] scissors with [target]'s cunt."))
-	playsound(target, 'sound/misc/mat/segso.ogg', 50, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(target, 'sound/misc/mat/segso.ogg', 50, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 	do_thrust_animate(user, target, sex_session)
 
 	sex_session.perform_sex_action(user, 1, 4, TRUE)

--- a/code/datums/sexcon2/actions/sex/slit.dm
+++ b/code/datums/sexcon2/actions/sex/slit.dm
@@ -40,7 +40,8 @@
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/is_knotting = sex_session.do_knot_action
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] [is_knotting ? "knot-fucks" : "fucks"] [target]'s slit."))
-	playsound(target, sex_session.get_force_sound(), 50, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(target, sex_session.get_force_sound(), 50, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 	do_thrust_animate(user, target, sex_session)
 
 	do_onomatopoeia(user)

--- a/code/datums/sexcon2/actions/sex/tail/tailjob.dm
+++ b/code/datums/sexcon2/actions/sex/tail/tailjob.dm
@@ -34,7 +34,8 @@
 /datum/sex_action/sex/tailjob/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] strokes [target]'s cock with their tail."))
-	playsound(user, 'sound/misc/mat/fingering.ogg', 50, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(user, 'sound/misc/mat/fingering.ogg', 50, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 
 	sex_session.perform_sex_action(target, 2.4, 7, TRUE)
 	sex_session.handle_passive_ejaculation(target)

--- a/code/datums/sexcon2/actions/sex/tail/tailpegging_anal.dm
+++ b/code/datums/sexcon2/actions/sex/tail/tailpegging_anal.dm
@@ -31,7 +31,8 @@
 /datum/sex_action/sex/tailpegging_anal/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fucks [target]'s ass with [user.p_their()] tail."))
-	playsound(target, sex_session.get_force_sound(), 50, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(target, sex_session.get_force_sound(), 50, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 	do_thrust_animate(user, target, sex_session)
 
 	do_onomatopoeia(user)

--- a/code/datums/sexcon2/actions/sex/tail/tailpegging_oral.dm
+++ b/code/datums/sexcon2/actions/sex/tail/tailpegging_oral.dm
@@ -31,7 +31,8 @@
 /datum/sex_action/sex/tailpegging_oral/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fucks [target]'s throat with [user.p_their()] tail."))
-	playsound(target, sex_session.get_force_sound(), 50, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(target, sex_session.get_force_sound(), 50, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 	do_thrust_animate(user, target, sex_session)
 
 	do_onomatopoeia(user)

--- a/code/datums/sexcon2/actions/sex/tail/tailpegging_vaginal.dm
+++ b/code/datums/sexcon2/actions/sex/tail/tailpegging_vaginal.dm
@@ -35,7 +35,8 @@
 /datum/sex_action/sex/tailpegging_vaginal/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fucks [target]'s pussy with [user.p_their()] tail."))
-	playsound(target, sex_session.get_force_sound(), 50, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(target, sex_session.get_force_sound(), 50, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 	do_thrust_animate(user, target, sex_session)
 
 	do_onomatopoeia(user)

--- a/code/datums/sexcon2/actions/sex/thighjob.dm
+++ b/code/datums/sexcon2/actions/sex/thighjob.dm
@@ -31,7 +31,8 @@
 /datum/sex_action/sex/thighjob/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fucks [target]'s thighs."))
-	playsound(user, 'sound/misc/mat/fingering.ogg', 20, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(user, 'sound/misc/mat/fingering.ogg', 20, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 	do_thrust_animate(user, target, sex_session)
 
 	sex_session.perform_sex_action(user, 2, 4, TRUE)

--- a/code/datums/sexcon2/actions/sex/throat.dm
+++ b/code/datums/sexcon2/actions/sex/throat.dm
@@ -83,7 +83,8 @@
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/is_knotting = sex_session.do_knot_action
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] [is_knotting ? "double-knots" : "double-fucks"] [target]'s throat."))
-	playsound(target, 'sound/misc/mat/segso.ogg', 50, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(target, 'sound/misc/mat/segso.ogg', 50, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 	do_thrust_animate(user, target, sex_session)
 
 	do_onomatopoeia(user)

--- a/code/datums/sexcon2/actions/sex/vaginal.dm
+++ b/code/datums/sexcon2/actions/sex/vaginal.dm
@@ -40,7 +40,8 @@
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/is_knotting = sex_session.do_knot_action
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] [is_knotting ? "knot-fucks" : "fucks"] [target]'s pussy."))
-	playsound(target, sex_session.get_force_sound(), 50, TRUE, -2, ignore_walls = FALSE)
+	if(!mute_sound) //OV EDIT
+		playsound(target, sex_session.get_force_sound(), 50, TRUE, -2, ignore_walls = FALSE) //OV EDIT
 	do_thrust_animate(user, target, sex_session)
 
 	do_onomatopoeia(user)

--- a/code/datums/sexcon2/actions/toy/oral.dm
+++ b/code/datums/sexcon2/actions/toy/oral.dm
@@ -34,7 +34,8 @@
 	user.visible_message(span_warning("[user] starts sucking off a dildo..."))
 
 /datum/sex_action/toy/oral/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
-	user.make_sucking_noise()
+	if(!mute_sound) //OV EDIT
+		user.make_sucking_noise() //OV EDIT
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/obj/item/dildo/used_item = user.get_active_held_item()
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] sucks off a dildo!"))

--- a/code/datums/sexcon2/actions/toy/other/oral.dm
+++ b/code/datums/sexcon2/actions/toy/other/oral.dm
@@ -33,7 +33,8 @@
 	user.visible_message(span_warning("[user] slides a dildo into [target]'s mouth!"))
 
 /datum/sex_action/toy/other/oral/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
-	user.make_sucking_noise()
+	if(!mute_sound) //OV EDIT
+		user.make_sucking_noise() //OV EDIT
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/obj/item/dildo/used_item = user.get_active_held_item()
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fucks [target]'s throat with a dildo!"))

--- a/code/datums/sexcon2/sex_session.dm
+++ b/code/datums/sexcon2/sex_session.dm
@@ -30,6 +30,8 @@
 	var/static/sex_id = 0
 	var/our_sex_id = 0 //this is so we can have more then 1 sex id open at once
 
+	var/mute_sound = FALSE //Whether we allow sounds to play or not
+
 
 /datum/sex_session/New(mob/living/carbon/human/session_user, mob/living/carbon/human/session_target)
 	user = session_user
@@ -129,6 +131,7 @@
 	current_action = action_type
 	inactivity = 0
 	var/datum/sex_action/action = SEX_ACTION(current_action)
+	action.mute_sound = mute_sound
 	log_combat(user, target, "Started sex action: [action.name] with [target.name].")
 	INVOKE_ASYNC(src, PROC_REF(sex_action_loop))
 
@@ -177,6 +180,9 @@
 			break
 		if(desire_stop)
 			break
+		
+		if(action.mute_sound != mute_sound)
+			action.mute_sound = mute_sound
 
 		action.on_perform(user, target)
 
@@ -421,6 +427,7 @@
 	var/current_arousal = arousal_data["arousal"] || 0
 	data["arousal"] = min(100, (current_arousal / ACTIVE_EJAC_THRESHOLD) * 100)
 	data["frozen"] = arousal_data["frozen"] || FALSE
+	data["mute_sound"] = mute_sound
 
 	// Which actions can be performed
 	var/list/can_perform = list()
@@ -481,6 +488,11 @@
 		if("freeze_arousal")
 			SEND_SIGNAL(user, COMSIG_SEX_FREEZE_AROUSAL)
 			. = TRUE
+		//OV edit
+		if("toggle_sound")
+			mute_sound = !mute_sound
+			. = TRUE
+		//OV edit end
 		if("update_session_name")
 			if(collective)
 				collective.collective_display_name = params["name"]

--- a/code/modules/sexcon/components/arousal.dm
+++ b/code/modules/sexcon/components/arousal.dm
@@ -169,8 +169,8 @@
 	else
 		climaxer = highest_priority.user
 		partner = highest_priority.target
-
-	playsound(parent, 'sound/misc/mat/endout.ogg', 50, TRUE, ignore_walls = FALSE)
+	if(!highest_priority.mute_sound) //OV EDIT
+		playsound(parent, 'sound/misc/mat/endout.ogg', 50, TRUE, ignore_walls = FALSE) //OV EDIT
 	// Special case for when the climaxer has a penis but no testicles
 	if(!mob.getorganslot(ORGAN_SLOT_TESTICLES) && mob.getorganslot(ORGAN_SLOT_PENIS))
 		mob.visible_message(span_love("[mob] climaxes, yet nothing is released!"))
@@ -204,20 +204,24 @@
 		parent.emote("groan", forced = TRUE)
 
 /datum/component/arousal/proc/handle_climax(climax_type, mob/living/carbon/human/climaxer, mob/living/carbon/human/partner, action)
-
+	var/list/parent_sessions = return_sessions_with_user(parent) //OV EDIT
+	var/datum/sex_session/highest_priority = return_highest_priority_action(parent_sessions, parent) //OV EDIT
 	switch(climax_type)
 		if("onto")
 			log_combat(climaxer, partner, "Came onto [partner]")
-			playsound(partner, 'sound/misc/mat/endout.ogg', 50, TRUE, ignore_walls = FALSE)
+			if(!highest_priority.mute_sound) //OV EDIT
+				playsound(partner, 'sound/misc/mat/endout.ogg', 50, TRUE, ignore_walls = FALSE) //OV EDIT
 			var/turf/turf = get_turf(partner)
 			new /obj/effect/decal/cleanable/coom(turf)
 		if("into")
 			log_combat(climaxer, partner, "Came inside [partner]")
-			playsound(partner, 'sound/misc/mat/endin.ogg', 50, TRUE, ignore_walls = FALSE)
+			if(!highest_priority.mute_sound) //OV EDIT
+				playsound(partner, 'sound/misc/mat/endin.ogg', 50, TRUE, ignore_walls = FALSE) //OV EDIT
 		if("self")
 			log_combat(climaxer, climaxer, "Ejaculated")
 			climaxer.visible_message(span_love("[climaxer] makes a mess!"))
-			playsound(climaxer, 'sound/misc/mat/endout.ogg', 50, TRUE, ignore_walls = FALSE)
+			if(!highest_priority.mute_sound)
+				playsound(climaxer, 'sound/misc/mat/endout.ogg', 50, TRUE, ignore_walls = FALSE)
 			var/turf/turf = get_turf(partner)
 			new /obj/effect/decal/cleanable/coom(turf)
 
@@ -238,16 +242,19 @@
 
 	if(climaxer.has_flaw(/datum/charflaw/addiction/thrillseeker))
 		var/datum/charflaw/addiction/thrill = climaxer.get_flaw(/datum/charflaw/addiction/thrillseeker)
-		climaxer.playsound_local(climaxer, 'sound/misc/mat/end.ogg', 100)
+		if(!action.mute_sound) //OV EDIT
+			climaxer.playsound_local(climaxer, 'sound/misc/mat/end.ogg', 100) //OV EDIT
 		last_ejaculation_time = world.time
 		if(!thrill.sated)
 			climaxer.add_stress(/datum/stressevent/thrillsex)
 		if(prob(10))
 			climaxer.emote("groan", forced = TRUE)
 		return	
-
-	climaxer.emote("moan", forced = TRUE)
-	climaxer.playsound_local(climaxer, 'sound/misc/mat/end.ogg', 100)
+	//OV edit
+	if(!action.mute_sound)
+		climaxer.emote("moan", forced = TRUE)
+		climaxer.playsound_local(climaxer, 'sound/misc/mat/end.ogg', 100)
+	//OV edit end
 	last_ejaculation_time = world.time
 
 	if(HAS_TRAIT(climaxer, TRAIT_UNSATISFIED)) //Given for 30 seconds when someone sets their arousal, it prevents gaining any benefits from orgasm
@@ -341,6 +348,12 @@
 
 /datum/component/arousal/proc/try_do_moan(arousal_amt, pain_amt, applied_force, giving)
 	var/mob/user = parent
+	//OV edit
+	var/list/parent_sessions = return_sessions_with_user(parent)
+	var/datum/sex_session/highest_priority = return_highest_priority_action(parent_sessions, parent)
+	if(highest_priority.mute_sound)
+		return
+	//OV edit end
 	if(arousal_amt < 1.5)
 		return
 	if(user.stat != CONSCIOUS)

--- a/tgui/packages/tgui/interfaces/SexSession.tsx
+++ b/tgui/packages/tgui/interfaces/SexSession.tsx
@@ -208,6 +208,15 @@ export const SexSession = () => {
                     >
                       STOP
                     </Button>
+                    {' | '}
+                    <Button
+                      inline
+                      compact
+                      color="transparent"
+                      onClick={() => act('toggle_sound')}
+                    >
+                      {data.mute_sound ? 'UNMUTE' : 'MUTE'}
+                    </Button>
                   </Box>
                 </Stack.Item>
               </Stack>

--- a/tgui/packages/tgui/interfaces/sexcon/types.ts
+++ b/tgui/packages/tgui/interfaces/sexcon/types.ts
@@ -34,6 +34,9 @@ export interface SexSessionData {
   pain: number;
   frozen: boolean;
 
+  // Sound tracking
+  mute_sound: boolean;
+
   // Which actions can be performed
   can_perform: string[];
 


### PR DESCRIPTION


## About The Pull Request

Allows you to mute mechanical ERP sounds via a toggle in the ERP menu

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///Ochre edit
Your code
///Ochre edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Tested and it seems to work totally fine to me!

## Why It's Good For The Game

There's a few reasons you'd want to do this. Perhaps it's getting annoying after an hour of a scene, or perhaps you want some more privacy if it's near a more populated area, or maybe you just don't like the sounds that the game has.

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: Allows you to mute mechanical ERP sounds via a toggle in the ERP menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
