### PR TITLE
Change Asset Size

### DIFF
--- a/code/modules/client/customizer/customizers/organ/genitals.dm
+++ b/code/modules/client/customizer/customizers/organ/genitals.dm
@@ -180,18 +180,12 @@
 		to_chat(user, "<span class='warning'>What penis?</span>")
 		return
 	if (!prefs)
-	{
 		return
-	}
 
 	for (var/datum/customizer_entry/entry in prefs.customizer_entries)
-	{
 		if (istype(entry, /datum/customizer_entry/organ/penis))
-		{
 			penis_entry = entry
 			break
-		}
-	}
 
 	var/named_size = input(user, "Choose your penis size:", "Penis", find_key_by_value(PENIS_SIZES_BY_NAME, penis_entry.penis_size)) as anything in PENIS_SIZES_BY_NAME
 
@@ -301,18 +295,12 @@
 		to_chat(user, "<span class='warning'>What testicles?</span>")
 		return
 	if (!prefs)
-	{
 		return
-	}
 
 	for (var/datum/customizer_entry/entry in prefs.customizer_entries)
-	{
 		if (istype(entry, /datum/customizer_entry/organ/testicles))
-		{
 			testicles_entry = entry
 			break
-		}
-	}
 
 	var/named_size = input(user, "Choose your ball size:", "Testicles", find_key_by_value(TESTICLE_SIZES_BY_NAME, testicles_entry.ball_size)) as anything in TESTICLE_SIZES_BY_NAME
 
@@ -406,18 +394,12 @@
 		to_chat(user, "<span class='warning'>What breasts?</span>")
 		return
 	if (!prefs)
-	{
 		return
-	}
 
 	for (var/datum/customizer_entry/entry in prefs.customizer_entries)
-	{
 		if (istype(entry, /datum/customizer_entry/organ/breasts))
-		{
 			breasts_entry = entry
 			break
-		}
-	}
 
 	var/named_size = input(user, "Choose your breast size:", "Breasts", find_key_by_value(BREAST_SIZES_BY_NAME, breasts_entry.breast_size)) as anything in BREAST_SIZES_BY_NAME
 

--- a/modular_causticcove/code/modules/client/customizers/organ/genitals.dm
+++ b/modular_causticcove/code/modules/client/customizers/organ/genitals.dm
@@ -80,7 +80,6 @@
 			change_penis_size_customizer(src)
 		if("Testicles")
 			change_testicle_size_customizer(src)
-//OV edit end
 
 /mob/living/carbon/proc/change_belly_size_customizer(mob/living/carbon/user) // This could have been done better, but i'm too stupid and tired to get something out of it
 	var/obj/item/organ/belly/_belly = getorganslot("belly")
@@ -90,18 +89,12 @@
 		to_chat(user, "<span class='warning'>What belly?</span>")
 		return
 	if (!prefs)
-	{
 		return
-	}
 
 	for (var/datum/customizer_entry/entry in prefs.customizer_entries)
-	{
 		if (istype(entry, /datum/customizer_entry/organ/belly))
-		{
 			belly_entry = entry
 			break
-		}
-	}
 
 	var/named_size = input(user, "Choose your belly size:", "Belly", find_key_by_value(GLOB.named_belly_sizes, belly_entry.belly_size)) as anything in GLOB.named_belly_sizes
 
@@ -114,6 +107,7 @@
 
 	_belly.belly_size = belly_entry.belly_size
 	user.regenerate_icons()
+//OV edit end
 
 /datum/customizer_entry/organ/butt
 	var/organ_size = DEFAULT_BUTT_SIZE
@@ -181,18 +175,12 @@
 		to_chat(user, "<span class='warning'>What butt?</span>")
 		return
 	if (!prefs)
-	{
 		return
-	}
 
 	for (var/datum/customizer_entry/entry in prefs.customizer_entries)
-	{
 		if (istype(entry, /datum/customizer_entry/organ/butt))
-		{
 			butt_entry = entry
 			break
-		}
-	}
 
 	var/named_size = input(user, "Choose your butt size:", "Butt", find_key_by_value(GLOB.named_butt_sizes, butt_entry.organ_size)) as anything in GLOB.named_butt_sizes
 


### PR DESCRIPTION
## About The Pull Request

Changed "Change Belly Size" to now be "Change Asset Size", which allows you to pick from all the main ERP assets and resize them at will.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///Ochre edit
Your code
///Ochre edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Tested and it works fine ingame!

## Why It's Good For The Game

Allows people to engage in WG more easily in-round.

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Changed "Change Belly Size" to now be "Change Asset Size", which allows you to pick from all the main ERP assets and resize them at will.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
