### PR TITLE
No longer lonely crash out in vore

### DIFF
--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -253,8 +253,9 @@ GLOBAL_LIST_INIT(averse_factions, list(
 			var/cnt = 0
 			//OV edit - If you have prey or are in prey, always count as having 1 person nearby (no matter how many you've eaten)
 			for(var/obj/belly/our_belly in user.vore_organs)
-				for(var/mob/living in our_belly.contents)
-					cnt = 1
+				for(var/mob/living/our_prey in our_belly.contents)
+					if(our_prey.client)
+						cnt = 1
 			if(istype(user.loc,/obj/belly))
 				cnt = 1
 			//OV edit end
@@ -300,10 +301,11 @@ GLOBAL_LIST_INIT(averse_factions, list(
 			for(var/obj/belly/our_belly in user.vore_organs)
 				if(cnt > 3)
 					break
-				for(var/mob/living in our_belly.contents)
-					cnt++
-					if(cnt > 3)
-						break
+				for(var/mob/living/our_prey in our_belly.contents)
+					if(our_prey.client)
+						cnt++
+						if(cnt > 3)
+							break
 			if(istype(user.loc,/obj/belly))
 				cnt++
 			//OV edit end
@@ -364,12 +366,13 @@ GLOBAL_LIST_INIT(averse_factions, list(
 			var/distfound = FALSE
 			//OV edit - Always remove stress if there's vore, can't get clingier than that
 			for(var/obj/belly/our_belly in user.vore_organs)
-				for(var/mob/living in our_belly.contents)
-					cnt++
-					distfound = TRUE
-					user.remove_stress(/datum/stressevent/nopeople)
-					if(cnt >= 2)
-						break
+				for(var/mob/living/our_prey in our_belly.contents)
+					if(our_prey.client)
+						cnt++
+						distfound = TRUE
+						user.remove_stress(/datum/stressevent/nopeople)
+						if(cnt >= 2)
+							break
 			if(istype(user.loc,/obj/belly))
 				distfound = TRUE
 				user.remove_stress(/datum/stressevent/nopeople)


### PR DESCRIPTION
## About The Pull Request

Makes having someone in a belly, or being in a belly, always prevent lonely, finicky and clingy crashouts. Prey need to have a client attached so you can't powergame with a simple mob in there.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Seems to work on testing!

## Why It's Good For The Game

Prevents vore scenes causing people with these traits from having disruptive ingame effects such as the screen going dark and ominous.

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: Makes having someone in a belly, or being in a belly, always prevent lonely, finicky and clingy crashouts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
