### PR TITLE
Restores Empowerment Buff Rituals

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -1778,6 +1778,167 @@
 	desc = "I am magically astute."
 	icon_state = "buff"
 
+/datum/status_effect/buff/magic/strength
+	id = "strength"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/magic/strength
+	effectedstats = list("strength" = 3)
+	duration = 20 MINUTES
+
+/datum/status_effect/buff/magic/strength/on_apply()
+	if(owner.has_status_effect(/datum/status_effect/buff/magic/strength_lesser))
+		owner.remove_status_effect(/datum/status_effect/buff/magic/strength_lesser)
+	return ..()
+
+/atom/movable/screen/alert/status_effect/buff/magic/strength
+	name = "arcane reinforced strength"
+	desc = "I am magically strengthened."
+	icon_state = "buff"
+
+/datum/status_effect/buff/magic/strength_lesser
+	id = "lesser strength"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/magic/strength/lesser
+	effectedstats = list("strength" = 1)
+	duration = 20 MINUTES
+
+/datum/status_effect/buff/magic/strength_lesser/on_apply()
+	if(owner.has_status_effect(/datum/status_effect/buff/magic/strength))
+		return FALSE
+	return ..()
+
+/atom/movable/screen/alert/status_effect/buff/magic/strength/lesser
+	name = "lesser arcane strength"
+	desc = "I am magically strengthened."
+	icon_state = "buff"
+
+
+/datum/status_effect/buff/magic/speed
+	id = "speed"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/magic/speed
+	effectedstats = list("speed" = 3)
+	duration = 20 MINUTES
+
+/datum/status_effect/buff/magic/speed/on_apply()
+	if(owner.has_status_effect(/datum/status_effect/buff/magic/speed_lesser))
+		owner.remove_status_effect(/datum/status_effect/buff/magic/speed_lesser)
+	return ..()
+
+/atom/movable/screen/alert/status_effect/buff/magic/speed
+	name = "arcane swiftness"
+	desc = "I am magically swift."
+	icon_state = "buff"
+
+/datum/status_effect/buff/magic/speed_lesser
+	id = "lesser speed"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/magic/speed/lesser
+	effectedstats = list("speed" = 1)
+	duration = 20 MINUTES
+
+/datum/status_effect/buff/magic/speed_lesser/on_apply()
+	if(owner.has_status_effect(/datum/status_effect/buff/magic/speed))
+		return FALSE
+	return ..()
+
+/atom/movable/screen/alert/status_effect/buff/magic/speed/lesser
+	name = "arcane swiftness"
+	desc = "I am magically swift."
+	icon_state = "buff"
+
+/datum/status_effect/buff/magic/willpower
+	id = "willpower"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/magic/willpower
+	effectedstats = list("willpower" = 3)
+	duration = 20 MINUTES
+
+/datum/status_effect/buff/magic/willpower/on_apply()
+	if(owner.has_status_effect(/datum/status_effect/buff/magic/willpower_lesser))
+		owner.remove_status_effect(/datum/status_effect/buff/magic/willpower_lesser)
+	return ..()
+
+/atom/movable/screen/alert/status_effect/buff/magic/willpower
+	name = "arcane willpower"
+	desc = "I am magically resilient."
+	icon_state = "buff"
+
+/datum/status_effect/buff/magic/willpower_lesser
+	id = "lesser willpower"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/magic/willpower/lesser
+	effectedstats = list("willpower" = 1)
+	duration = 20 MINUTES
+
+/datum/status_effect/buff/magic/willpower_lesser/on_apply()
+	if(owner.has_status_effect(/datum/status_effect/buff/magic/willpower))
+		return FALSE
+	return ..()
+
+/atom/movable/screen/alert/status_effect/buff/magic/willpower/lesser
+	name = "lesser arcane willpower"
+	desc = "I am magically resilient."
+	icon_state = "buff"
+
+/datum/status_effect/buff/magic/constitution
+	id = "constitution"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/magic/constitution
+	effectedstats = list("constitution" = 3)
+	duration = 20 MINUTES
+
+/datum/status_effect/buff/magic/constitution/on_apply()
+	if(owner.has_status_effect(/datum/status_effect/buff/magic/constitution_lesser))
+		owner.remove_status_effect(/datum/status_effect/buff/magic/constitution_lesser)
+	return ..()
+
+/atom/movable/screen/alert/status_effect/buff/magic/constitution
+	name = "arcane constitution"
+	desc = "I feel reinforced by magick."
+	icon_state = "buff"
+
+/datum/status_effect/buff/magic/constitution_lesser
+	id = "lesser constitution"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/magic/constitution/lesser
+	effectedstats = list("constitution" = 1)
+	duration = 20 MINUTES
+
+/datum/status_effect/buff/magic/constitution_lesser/on_apply()
+	if(owner.has_status_effect(/datum/status_effect/buff/magic/constitution))
+		return FALSE
+	return ..()
+
+/atom/movable/screen/alert/status_effect/buff/magic/constitution/lesser
+	name = "lesser arcane constitution"
+	desc = "I feel reinforced by magick."
+	icon_state = "buff"
+
+/datum/status_effect/buff/magic/perception
+	id = "perception"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/magic/perception
+	effectedstats = list("perception" = 3)
+	duration = 20 MINUTES
+
+/datum/status_effect/buff/magic/perception/on_apply()
+	if(owner.has_status_effect(/datum/status_effect/buff/magic/perception_lesser))
+		owner.remove_status_effect(/datum/status_effect/buff/magic/perception_lesser)
+	return ..()
+
+/atom/movable/screen/alert/status_effect/buff/magic/perception
+	name = "arcane perception"
+	desc = "I can see everything."
+	icon_state = "buff"
+
+/datum/status_effect/buff/magic/perception_lesser
+	id = "lesser perception"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/magic/perception/lesser
+	effectedstats = list("perception" = 1)
+	duration = 20 MINUTES
+
+/datum/status_effect/buff/magic/perception_lesser/on_apply()
+	if(owner.has_status_effect(/datum/status_effect/buff/magic/perception))
+		return FALSE
+	return ..()
+
+/atom/movable/screen/alert/status_effect/buff/magic/perception/lesser
+	name = "lesser arcane perception"
+	desc = "I can see somethings."
+	icon_state = "buff"
+
 /datum/status_effect/buff/nocblessing
 	id = "nocblessing"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/nocblessing

--- a/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
+++ b/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
@@ -371,6 +371,65 @@ GLOBAL_LIST(teleport_runes)
 	do_invoke_glow()
 
 
+/obj/effect/decal/cleanable/roguerune/arcyne/empowerment
+	name = "Empowerment Array"
+	desc = "arcane symbols pulse upon the ground..."
+	icon = 'icons/effects/96x96.dmi'
+	icon_state = "empowerment"
+	tier = 2
+	runesize = 1
+	pixel_x = -32 //So the big ol' 96x96 sprite shows up right
+	pixel_y = -32
+	invocation = "Vires Augeantur!"
+	layer = SIGIL_LAYER
+	can_be_scribed = TRUE
+
+/obj/effect/decal/cleanable/roguerune/arcyne/empowerment/New()
+	. = ..()
+	rituals += GLOB.t2buffrunerituallist
+
+/obj/effect/decal/cleanable/roguerune/arcyne/empowerment/collect_invokers(mob/living/user)
+	var/list/invoker_list = ..()
+
+	for(var/mob/living/invoker in invoker_list)
+		if(!isliving(invoker))
+			continue
+
+		var/mob/living/living_invoker = invoker
+		var/empower_count
+		for(var/datum/status_effect/effect in living_invoker.status_effects)
+			if(istype(effect, /datum/status_effect/buff/magic))
+				empower_count++
+
+		if(empower_count >= 3)
+			to_chat(living_invoker, span_warning("I'm already imbued by too many arcyne energies, this ritual does nothing for me!"))
+			invoker_list.Remove(living_invoker)
+
+	return invoker_list
+
+/obj/effect/decal/cleanable/roguerune/arcyne/empowerment/invoke(list/invokers, datum/runeritual/buff/runeritual)
+	if(!..())	//VERY important. Calls parent and checks if it fails. parent/invoke has all the checks for ingredients
+		return
+
+	var/buffedstat = runeritual.buff
+	for(var/mob/living/invoker in range(runesize, src))
+		invoker.apply_status_effect(buffedstat)
+	if(ritual_result)
+		pickritual.cleanup_atoms(selected_atoms)
+
+	for(var/atom/invoker in invokers)
+		if(!isliving(invoker))
+			continue
+		var/mob/living/living_invoker = invoker
+
+		if(invocation)
+			living_invoker.say(invocation, language = /datum/language/common, ignore_spam = TRUE, forced = "cult invocation")
+		if(invoke_damage)
+			living_invoker.apply_damage(invoke_damage, BRUTE)
+			to_chat(living_invoker,  span_italics("[src] saps your strength!"))
+
+	do_invoke_glow()
+
 /obj/effect/decal/cleanable/roguerune/arcyne/enchantment
 	name = "Imbuement Array"
 	desc = "arcane symbols pulse upon the ground..."

--- a/code/modules/roguetown/roguejobs/mages/rituals/_ritual.dm
+++ b/code/modules/roguetown/roguejobs/mages/rituals/_ritual.dm
@@ -6,6 +6,8 @@ GLOBAL_LIST_INIT(t3summoningrunerituallist, generate_t3summoning_rituallist())
 GLOBAL_LIST_INIT(t4summoningrunerituallist, generate_t4summoning_rituallist())
 GLOBAL_LIST_INIT(t2wallrunerituallist, generate_t2wall_rituallist())
 GLOBAL_LIST_INIT(t4wallrunerituallist, generate_t4wall_rituallist())
+GLOBAL_LIST_INIT(buffrunerituallist, generate_buff_rituallist())
+GLOBAL_LIST_INIT(t2buffrunerituallist, generate_t2buff_rituallist())
 GLOBAL_LIST_INIT(t2enchantmentrunerituallist,generate_t2enchantment_rituallist())
 GLOBAL_LIST_INIT(t4enchantmentrunerituallist,generate_t4enchantment_rituallist())
 
@@ -82,6 +84,26 @@ GLOBAL_LIST_INIT(t4enchantmentrunerituallist,generate_t4enchantment_rituallist()
 	var/list/runerituals = list()
 	for(var/datum/runeritual/runeritual as anything in subtypesof(/datum/runeritual/other/wall))
 		if(runeritual.tier < 3)
+			continue
+		runerituals[initial(runeritual.name)] = runeritual
+	return runerituals
+
+/proc/generate_buff_rituallist()	//list of all rituals for player use
+	RETURN_TYPE(/list)
+	var/list/runerituals = list()
+	for(var/datum/runeritual/runeritual as anything in subtypesof(/datum/runeritual/buff))
+		if(runeritual.tier > 1)
+			continue
+		if(runeritual.blacklisted)
+			continue
+		runerituals[initial(runeritual.name)] = runeritual
+	return runerituals
+
+/proc/generate_t2buff_rituallist()	//list of all rituals for player use
+	RETURN_TYPE(/list)
+	var/list/runerituals = list()
+	for(var/datum/runeritual/runeritual as anything in subtypesof(/datum/runeritual/buff))
+		if(runeritual.blacklisted)
 			continue
 		runerituals[initial(runeritual.name)] = runeritual
 	return runerituals

--- a/code/modules/roguetown/roguejobs/mages/rituals/buffs.dm
+++ b/code/modules/roguetown/roguejobs/mages/rituals/buffs.dm
@@ -72,16 +72,16 @@
 	buff = /datum/status_effect/buff/magic/willpower
 	tier = 2
 	blacklisted = FALSE
-	required_atoms = list(/obj/item/magic/obsidian = 2, /obj/item/magic/iridescentscale = 1)
+	required_atoms = list(/obj/item/magic/obsidian = 2, /obj/item/magic/fae/iridescentscale = 1)
 
 /datum/runeritual/buff/lesserwillpower
 	name = "lesser vitalized willpower"
 	buff = /datum/status_effect/buff/magic/willpower_lesser
 	blacklisted = FALSE
-	required_atoms = list(/obj/item/magic/obsidian = 2, /obj/item/magic/fairydust = 2)
+	required_atoms = list(/obj/item/magic/obsidian = 2, /obj/item/magic/fae/fairydust = 2)
 
 /datum/runeritual/buff/nightvision
 	name = "darksight"
 	buff = /datum/status_effect/buff/darkvision
 	blacklisted = FALSE
-	required_atoms = list(/obj/item/magic/manacrystal = 2, /obj/item/magic/iridescentscale = 1, /obj/item/magic/elemental/shard = 1)
+	required_atoms = list(/obj/item/magic/manacrystal = 2, /obj/item/magic/fae/iridescentscale = 1, /obj/item/magic/elemental/shard = 1)

--- a/code/modules/roguetown/roguejobs/mages/rituals/buffs.dm
+++ b/code/modules/roguetown/roguejobs/mages/rituals/buffs.dm
@@ -7,3 +7,81 @@
 /datum/runeritual/knowledge/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	return TRUE
 
+/datum/runeritual/buff
+	blacklisted = TRUE
+	tier = 1
+	var/buff
+
+/datum/runeritual/buff/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
+	return TRUE
+
+/datum/runeritual/buff/strength
+	name = "arcane augmentation of strength"
+	buff = /datum/status_effect/buff/magic/strength
+	tier = 2
+	blacklisted = FALSE
+	required_atoms = list(/obj/item/magic/manacrystal = 2,/obj/item/magic/elemental/shard = 2)
+
+/datum/runeritual/buff/lesserstrength
+	name = "lesser arcane augmentation of strength"
+	buff = /datum/status_effect/buff/magic/strength_lesser
+	blacklisted = FALSE
+	required_atoms = list(/obj/item/magic/elemental/mote = 2,/obj/item/magic/manacrystal = 1)
+
+/datum/runeritual/buff/constitution
+	name = "fortify constitution"
+	buff = /datum/status_effect/buff/magic/constitution
+	tier = 2
+	blacklisted = FALSE
+	required_atoms = list(/obj/item/magic/manacrystal = 2, /obj/item/magic/obsidian = 4)
+
+/datum/runeritual/buff/lesserconstitution
+	name = "lesser fortify constitution"
+	buff = /datum/status_effect/buff/magic/constitution_lesser
+	blacklisted = FALSE
+	required_atoms = list(/obj/item/magic/manacrystal = 1, /obj/item/magic/obsidian = 2)
+
+/datum/runeritual/buff/speed
+	name = "haste"
+	buff = /datum/status_effect/buff/magic/speed
+	tier = 2
+	blacklisted = FALSE
+	required_atoms = list(/obj/item/magic/artifact = 2, /obj/item/magic/leyline = 2)
+
+/datum/runeritual/buff/lesserspeed
+	name = "lesser haste"
+	buff = /datum/status_effect/buff/magic/speed_lesser
+	blacklisted = FALSE
+	required_atoms = list(/obj/item/magic/artifact = 1, /obj/item/magic/leyline = 1)
+
+/datum/runeritual/buff/perception
+	name = "arcane eyes"
+	buff = /datum/status_effect/buff/magic/perception
+	tier = 2
+	blacklisted = FALSE
+	required_atoms = list(/obj/item/reagent_containers/food/snacks/grown/manabloom = 2, /obj/item/magic/infernal/fang = 1)
+
+/datum/runeritual/buff/lesserperception
+	name = "lesser arcane eyes"
+	buff = /datum/status_effect/buff/magic/perception_lesser
+	blacklisted = FALSE
+	required_atoms = list(/obj/item/reagent_containers/food/snacks/grown/manabloom = 1, /obj/item/magic/infernal/ash = 2)
+
+/datum/runeritual/buff/willpower
+	name = "vitalized willpower"
+	buff = /datum/status_effect/buff/magic/willpower
+	tier = 2
+	blacklisted = FALSE
+	required_atoms = list(/obj/item/magic/obsidian = 2, /obj/item/magic/iridescentscale = 1)
+
+/datum/runeritual/buff/lesserwillpower
+	name = "lesser vitalized willpower"
+	buff = /datum/status_effect/buff/magic/willpower_lesser
+	blacklisted = FALSE
+	required_atoms = list(/obj/item/magic/obsidian = 2, /obj/item/magic/fairydust = 2)
+
+/datum/runeritual/buff/nightvision
+	name = "darksight"
+	buff = /datum/status_effect/buff/darkvision
+	blacklisted = FALSE
+	required_atoms = list(/obj/item/magic/manacrystal = 2, /obj/item/magic/iridescentscale = 1, /obj/item/magic/elemental/shard = 1)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->

Reverts https://github.com/Azure-Peak/Azure-Peak/pull/5737 , thus restoring empowerment rituals. Also changes some of their item paths to account for new fae item paths.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [X] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [X] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [X] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->
I could draw the relevant runes, and tested a couple rituals, which correctly accounted for ritual costs and applied buffs.
<img width="668" height="455" alt="dreamseeker_2026-03-04_17-20-02" src="https://github.com/user-attachments/assets/d08ce5e2-3ab8-4d13-a628-470e7153c3de" />


## Why It's Good For The Game

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

As stated in my other reversion PRs, we are a PvE server primarily. We do not need to worry anywhere near as much about the listed problems that prompted the removal of these features.

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl: Ryumi
add: Restored Empowerment buff rituals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
