### PR TITLE
Restores Noc's T3 Kytherian Grimoire

### DIFF
--- a/code/datums/gods/patrons/divine/noc.dm
+++ b/code/datums/gods/patrons/divine/noc.dm
@@ -14,6 +14,7 @@
 					/obj/effect/proc_holder/spell/invoked/blood_heal			= CLERIC_T1,
 					/obj/effect/proc_holder/spell/invoked/invisibility/miracle	= CLERIC_T1,
 					/obj/effect/proc_holder/spell/self/blindnessorsilence		= CLERIC_T2,
+					/obj/effect/proc_holder/spell/self/wisescroll	     		= CLERIC_T3,
 					/obj/effect/proc_holder/spell/self/noc_spell_bundle			= CLERIC_T3,
 					/obj/effect/proc_holder/spell/invoked/resurrect/noc			= CLERIC_T4,
 	)


### PR DESCRIPTION
## About The Pull Request

AP said the miracle was too powerful and disabled it. This PR simply reenables it.

## Testing Evidence

I've not tested it yet, BUT it's the restoration of a single line of code that was snipped out before. It _should_ work. I hope. Admins can gibsmite me if it doesn't.

## Why It's Good For The Game

It's a cool miracle on a long cooldown that allows Noc miracle casters to synergize with mages by giving them access to more spells, one at a time, on a decently long cooldown. The other classes that get access to this, namely Heretic and Heretic Spy, have this as a Noc-alternative to Zizo's more selfish Rituo. Both give them access to arcyne spells on T4 Miracle havers, one is evil, one is THE MOON. Noc deserves a win for once.

## Changelog

:cl:
add: Added the scroll-making Noc T3
/:cl:
