### PR TITLE
Option to permanently hide PQ from yourself

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -24,6 +24,11 @@
 	if(!M)
 		to_chat(usr, "<span class='warning'>I seem to be selecting a mob that doesn't exist anymore.</span>")
 		return
+	//OV edit
+	var/same_user = FALSE
+	if(usr.key == M.key)
+		same_user = TRUE
+	//OV edit end
 
 	var/body = "<html><head><title>Options for [M.key]</title><style>"
 	body += "<style>"
@@ -83,9 +88,12 @@
 
 		var/pq = get_playerquality(M.ckey, TRUE)
 		var/pq_num = get_playerquality(M.ckey, FALSE)
-		body += "<br><br>Player Quality: [pq] ([pq_num])"
-		body += "<br><a href='?_src_=holder;[HrefToken()];editpq=add;mob=[REF(M)]'>\[Modify PQ\]</a> "
-		body += "<a href='?_src_=holder;[HrefToken()];showpq=add;mob=[REF(M)]'>\[Check PQ\]</a> "
+		//OV edit
+		if(!same_user || !M.client.prefs.hide_pq) //If you are looking at yourself and don't want to see PQ, hide this
+			body += "<br><br>Player Quality: [pq] ([pq_num])"
+			body += "<br><a href='?_src_=holder;[HrefToken()];editpq=add;mob=[REF(M)]'>\[Modify PQ\]</a> "
+			body += "<a href='?_src_=holder;[HrefToken()];showpq=add;mob=[REF(M)]'>\[Check PQ\]</a> "
+		//OV edit end
 		body += "<br><a href='?_src_=holder;[HrefToken()];edittriumphs=add;mob=[REF(M)]'>\[Modify Triumphs\]</a> "
 		body += "<br>"
 		body += "<a href='?_src_=holder;[HrefToken()];roleban=add;mob=[REF(M)]'>\[Role Ban Panel\]</a> "

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -114,6 +114,7 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	/datum/admins/proc/wake_view,
 	/datum/admins/proc/extend_round,
 	/client/proc/cmd_admin_set_ic_date, /* Set custom IC date for events */
+	/client/proc/reenable_pq, //OV ADD
 	)
 GLOBAL_LIST_INIT(admin_verbs_ban, list(
 	/client/proc/unban_panel,

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -957,3 +957,32 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			REMOVE_TRAIT(D,chosen_trait,source)
 			message_admins("Admin [key_name_admin(usr)] remove trait [chosen_trait] from [D]!")
 			log_admin("Admin [key_name_admin(usr)] remove trait [chosen_trait] from [D]!")
+
+//OV edit
+//reenable PQ on request
+/client/proc/reenable_pq()
+	set category = "-Admin-"
+	set name = "Reenable players PQ"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	var/list/pq_off = list()
+	for(var/client/the_client in GLOB.clients)
+		if(the_client.prefs)
+			if(the_client.prefs.hide_pq)
+				pq_off += the_client
+	
+	if(!pq_off.len)
+		to_chat(usr, "No clients found with PQ disabled")
+		return
+	
+	var/client/chosen_one = tgui_input_list(usr, "Which client wants their PQ values enabled again?", "Enable PQ", pq_off)
+	if(!chosen_one)
+		return
+	chosen_one.prefs.hide_pq = FALSE
+	chosen_one.prefs.save_preferences()
+	to_chat(chosen_one, "You can now see PQ again.")
+	to_chat(usr, "[chosen_one] can now see PQ again.")
+	log_and_message_admins("[usr] has re-enabled PQ for [chosen_one]")
+//OV edit end

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -110,6 +110,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/shake = TRUE
 	var/sexable = FALSE
 	var/compliance_notifs = TRUE
+	var/hide_pq = FALSE //OV ADD
 
 	var/list/custom_names = list()
 	var/preferred_ai_core_display = "Blue"
@@ -418,7 +419,10 @@ GLOBAL_LIST_EMPTY(chosen_names)
 			// ANOTHER ROW HOLY SHIT WE FINALLY A GOD DAMN GRID NOW! WHOA!
 			dat += "<tr style='padding-top: 0px;padding-bottom:0px'>"
 			dat += "<td style='width:33%; text-align:left'>"
-			dat += "<a href='?_src_=prefs;preference=playerquality;task=menu'><b>PQ:</b></a> [get_playerquality(user.ckey, text = TRUE)]"
+			//OV edit
+			if(!hide_pq)
+				dat += "<a href='?_src_=prefs;preference=playerquality;task=menu'><b>PQ:</b></a> [get_playerquality(user.ckey, text = TRUE)]"
+			//OV edit end
 			dat += "</td>"
 
 			dat += "<td style='width:33%;text-align:center'>"

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -173,6 +173,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["crt"]				>> crt
 	S["grain"]				>> grain
 	S["sexable"]			>> sexable
+	S["hide_pq"]			>> hide_pq //OV ADD
 	S["shake"]				>> shake
 	S["mastervol"]			>> mastervol
 	S["lastclass"]			>> lastclass
@@ -302,6 +303,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["no_redflash"], no_redflash)
 	WRITE_FILE(S["crt"], crt)
 	WRITE_FILE(S["sexable"], sexable)
+	WRITE_FILE(S["hide_pq"], hide_pq) //OV ADD
 	WRITE_FILE(S["shake"], shake)
 	WRITE_FILE(S["lastclass"], lastclass)
 	WRITE_FILE(S["mastervol"], mastervol)

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -784,4 +784,20 @@ GLOBAL_LIST_INIT(ghost_orbits, list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 		else
 			to_chat(src, "Examines will have some information behind dropdowns.")
 
+//OV edit
+/client/verb/toggle_PQ() // Totally hides PQ values from yourself to prevent bad brain.
+	set category = "Options"
+	set name = "Hide PQ"
+	if(prefs)
+		var/check1 = tgui_alert(src, "This will permanently hide your player quality values and they cant be reenabled without contancting staff. Are you sure?", "Hide PQ", list("Yes, hide them", "No"))
+		if(!check1 || (check1 == "No"))
+			return
+		var/check2 = tgui_alert(src, "Just to double check and avoid misclicks, this WILL make you unable to see commends and other PQ data. Are you sure?", "Hide PQ", list("Yes, I'm sure", "No"))
+		if(!check2 || (check2 == "No"))
+			return
+		prefs.hide_pq = TRUE
+		to_chat(src, "You will no longer be able to view your PQ values until you contact a staff member to reenable them.")
+		prefs.save_preferences()
+//OV edit end
+
 #undef TOGGLE_CHECKBOX


### PR DESCRIPTION


## About The Pull Request

Added an option to permanently hide PQ values from yourself, removing the PQ button and info from the character setup, and even from the player panel if a staff member with it disabled looks at their own info.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Tested and seems to work perfectly fine in game for hiding, and bringing back the PQ via the verbs.

## Why It's Good For The Game

Most people will probably not need this. However, for some people like me having what is essentially a statistical social score and count of how liked you are by others creates a huge amount of social anxiety. I am simply incapable of just ignoring the number as much as I am trying to and find myself checking it constantly, and it has been genuinely harming my fun of the game massively. I just want to never be able to see the value again.

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added an option to permanently hide PQ values from yourself, removing the PQ button and info from the character setup, and even from the player panel if a staff member with it disabled looks at their own info.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
