### PR TITLE
Polishing guns (used to be fixing guns but other people fixed all the most major issues)

### DIFF
--- a/code/game/objects/items/quiver.dm
+++ b/code/game/objects/items/quiver.dm
@@ -614,7 +614,7 @@
 ////////////
 
 /obj/item/quiver/sling
-	name = "bullet pouch" // OV Edit, works for all bullets.
+	name = "sling bullet pouch"
 	desc = "A pouch that can be packed with a perplexing amount of pebble-like projectiles. </br>'This pouch packs the ouch!' </br>I can quickly ready a bullet by left-clicking on the pouch with my sling."
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "slingpouch"
@@ -624,7 +624,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	grid_height = 64
 	grid_width = 32
-	allowed_ammo_type = list(/obj/item/ammo_casing/caseless/rogue/sling_bullet,/obj/item/ammo_casing/caseless/rogue/bullet) // OV Edit, made a list so I can use other bullets
+	allowed_ammo_type = /obj/item/ammo_casing/caseless/rogue/sling_bullet
 
 /obj/item/quiver/sling/attack_turf(turf/T, mob/living/user)
 	if(get_current_weight() >= max_storage)

--- a/code/game/objects/items/quiver.dm
+++ b/code/game/objects/items/quiver.dm
@@ -614,7 +614,7 @@
 ////////////
 
 /obj/item/quiver/sling
-	name = "bullet pouch" // Ochre Valley edit, works for all bullets.
+	name = "bullet pouch" // OV Edit, works for all bullets.
 	desc = "A pouch that can be packed with a perplexing amount of pebble-like projectiles. </br>'This pouch packs the ouch!' </br>I can quickly ready a bullet by left-clicking on the pouch with my sling."
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "slingpouch"
@@ -624,7 +624,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	grid_height = 64
 	grid_width = 32
-	allowed_ammo_type = list(/obj/item/ammo_casing/caseless/rogue/sling_bullet,/obj/item/ammo_casing/caseless/rogue/bullet) // Ochre Valley edit, made a list so I can use other bullets
+	allowed_ammo_type = list(/obj/item/ammo_casing/caseless/rogue/sling_bullet,/obj/item/ammo_casing/caseless/rogue/bullet) // OV Edit, made a list so I can use other bullets
 
 /obj/item/quiver/sling/attack_turf(turf/T, mob/living/user)
 	if(get_current_weight() >= max_storage)

--- a/code/game/objects/items/quiver.dm
+++ b/code/game/objects/items/quiver.dm
@@ -614,7 +614,7 @@
 ////////////
 
 /obj/item/quiver/sling
-	name = "sling bullet pouch"
+	name = "bullet pouch" // Ochre Valley edit, works for all bullets.
 	desc = "A pouch that can be packed with a perplexing amount of pebble-like projectiles. </br>'This pouch packs the ouch!' </br>I can quickly ready a bullet by left-clicking on the pouch with my sling."
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "slingpouch"
@@ -624,7 +624,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	grid_height = 64
 	grid_width = 32
-	allowed_ammo_type = /obj/item/ammo_casing/caseless/rogue/sling_bullet
+	allowed_ammo_type = list(/obj/item/ammo_casing/caseless/rogue/sling_bullet,/obj/item/ammo_casing/caseless/rogue/bullet) // Ochre Valley edit, made a list so I can use other bullets
 
 /obj/item/quiver/sling/attack_turf(turf/T, mob/living/user)
 	if(get_current_weight() >= max_storage)

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_verbs.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_verbs.dm
@@ -1,5 +1,5 @@
 /////////////////////////////////////////////////////////////////////////////////////////////
-// Wolf modular verb time : Added by Ochre Valley / OV									   //
+// Wolf modular verb time : Added by Ochre Valley / OV Edit								   //
 // Add your verb here and then add it to the list at werewolf.dm : var/list/werewolf_verbs //
 // Hopefully this is self explanatory of how to handle things.							   //
 /////////////////////////////////////////////////////////////////////////////////////////////
@@ -43,7 +43,7 @@
 			src.name = newname
 		to_chat(src, span_notice("Your wolf name is now [newname]."))
 		return TRUE
-	else 
+	else
 		to_chat(src, span_warning("Not allowed to rename! Currently: [W.wolfname]  If there is a mistake, ahelp and ask an admin to set your character's mind > Werewolf antag datum > 'allow_rename' var back to TRUE or 1!"))
 		return FALSE
 

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/grenzelhoft.dm
@@ -396,7 +396,7 @@
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants
 	shoes = /obj/item/clothing/shoes/roguetown/grenzelhoft
 	gloves = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves
-	//backl = /obj/item/rogueweapon/scabbard/gwstrap // OV Edit, removal until fixed, or maybe forever
+	backl = /obj/item/rogueweapon/scabbard/gwstrap
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	backpack_contents = list(
 		/obj/item/roguekey/mercenary = 1,

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/grenzelhoft.dm
@@ -342,7 +342,7 @@
 		ADD_TRAIT(H, TRAIT_ARCYNE_T2, TRAIT_GENERIC) // Only T2 arcyne (Unless they're old) so if they get spell points from something they can only pick from the curated spellblade list
 	H.merctype = 7
 
-/datum/advclass/mercenary/grenzelhoft/arquebusier 
+/datum/advclass/mercenary/grenzelhoft/arquebusier
 	name = "Armbrustschutze Garten"
 	tutorial = "You are a former veteran arbalest, outfitted with the latest technologies known to man. Your weapons remain as deadly to the enemy as to you, but your training should overcome it. Run them down, with fire and sword."
 	outfit = /datum/outfit/job/roguetown/mercenary/grenzelhoft_arquebusier
@@ -396,7 +396,7 @@
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants
 	shoes = /obj/item/clothing/shoes/roguetown/grenzelhoft
 	gloves = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves
-	//backl = /obj/item/rogueweapon/scabbard/gwstrap // Ochre Valley edit - removal until fixed, or maybe forever
+	//backl = /obj/item/rogueweapon/scabbard/gwstrap // OV Edit, removal until fixed, or maybe forever
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	backpack_contents = list(
 		/obj/item/roguekey/mercenary = 1,

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/grenzelhoft.dm
@@ -396,7 +396,7 @@
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants
 	shoes = /obj/item/clothing/shoes/roguetown/grenzelhoft
 	gloves = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves
-	backl = /obj/item/rogueweapon/scabbard/gwstrap
+	//backl = /obj/item/rogueweapon/scabbard/gwstrap // Ochre Valley edit - removal until fixed, or maybe forever
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	backpack_contents = list(
 		/obj/item/roguekey/mercenary = 1,

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/hangyaku.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/hangyaku.dm
@@ -64,19 +64,19 @@
 		if("Sword")
 			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
 			H.put_in_hands(new /obj/item/rogueweapon/sword/long/kriegmesser/ssangsudo)
-			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sword/kazengun/noparry, SLOT_BELT_L, TRUE)	
+			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sword/kazengun/noparry, SLOT_BELT_L, TRUE)
 		if("Great Mace")
 			H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT, TRUE)
 			H.put_in_hands(new /obj/item/rogueweapon/mace/goden/kanabo)
 			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/gwstrap, SLOT_BACK_R, TRUE)
 		if("Spear")
 			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_EXPERT, TRUE)
-			H.put_in_hands(new /obj/item/rogueweapon/spear/naginata) 
+			H.put_in_hands(new /obj/item/rogueweapon/spear/naginata)
 			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/gwstrap, SLOT_BACK_R, TRUE)
 		if("Bow")
 			H.adjust_skillrank_up_to(/datum/skill/combat/bows, SKILL_LEVEL_EXPERT, TRUE)
-			H.put_in_hands(new /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve) 
-			H.equip_to_slot_or_del(new /obj/item/quiver/arrows, SLOT_BELT_L, TRUE) 
+			H.put_in_hands(new /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve)
+			H.equip_to_slot_or_del(new /obj/item/quiver/arrows, SLOT_BELT_L, TRUE)
 	var/armors = list("Heavy Armor","Medium Armor")
 	var/armor_choice = input(H, "Choose your armor.", "...THE TONGUE MUST STAY QUIET.") as anything in armors
 	switch(armor_choice)
@@ -110,20 +110,20 @@
 	category_tags = list(CTAG_MERCENARY)
 	traits_applied = list(TRAIT_DECEIVING_MEEKNESS, TRAIT_MEDIUMARMOR) //peasant levy turned mercenary. the underdog.
 	cmode_music = 'sound/music/combat_kazengite.ogg'
-	subclass_stats = list(  
+	subclass_stats = list(
 		STATKEY_STR = 2,
 		STATKEY_CON = 2,
 		STATKEY_WIL = 2,
 		STATKEY_PER = 1,
 	)
-	subclass_skills = list( 
+	subclass_skills = list(
 		/datum/skill/misc/swimming = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE, 
+		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/crafting = SKILL_LEVEL_JOURNEYMAN
 	)
@@ -194,7 +194,7 @@
 			ADD_TRAIT(H, TRAIT_SEEPRICES, TRAIT_GENERIC)
 			H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_JOURNEYMAN, TRUE)
 			H.adjust_skillrank_up_to(/datum/skill/misc/sneaking, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			H.equip_to_slot_or_del(new /obj/item/storage/belt/rogue/pouch/coins/mid, SLOT_BELT_L, TRUE) 
+			H.equip_to_slot_or_del(new /obj/item/storage/belt/rogue/pouch/coins/mid, SLOT_BELT_L, TRUE)
 			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sheath/kazengun, SLOT_BELT_R, TRUE)
 			H.put_in_hands(new /obj/item/rogueweapon/huntingknife/idagger/steel/kazengun)
 		if("Levy") //straight-up fighter. gets a naginata AND a tanto.
@@ -207,7 +207,7 @@
 		if("Ashigaru") // Caustic Cove edit - A dishonorable weapon, only fit for a peasant! Or maybe that's just your enemies coping and seething because they're losing. :)
 			H.adjust_skillrank_up_to(/datum/skill/combat/firearms, SKILL_LEVEL_EXPERT, TRUE)
 			H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			//H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/gwstrap, SLOT_BACK_R, TRUE) // Ochre Valley edit - removal until fixed, or maybe forever
+			//H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/gwstrap, SLOT_BACK_R, TRUE) // OV Edit, removal until fixed, or maybe forever
 			H.put_in_hands(new /obj/item/gun/ballistic/arquebus)
 			H.put_in_hands(new /obj/item/powderflask)
 			H.put_in_hands(new /obj/item/rogueweapon/huntingknife/idagger/steel/kazengun)

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/hangyaku.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/hangyaku.dm
@@ -207,7 +207,7 @@
 		if("Ashigaru") // Caustic Cove edit - A dishonorable weapon, only fit for a peasant! Or maybe that's just your enemies coping and seething because they're losing. :)
 			H.adjust_skillrank_up_to(/datum/skill/combat/firearms, SKILL_LEVEL_EXPERT, TRUE)
 			H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/gwstrap, SLOT_BACK_R, TRUE)
+			//H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/gwstrap, SLOT_BACK_R, TRUE) // Ochre Valley edit - removal until fixed, or maybe forever
 			H.put_in_hands(new /obj/item/gun/ballistic/arquebus)
 			H.put_in_hands(new /obj/item/powderflask)
 			H.put_in_hands(new /obj/item/rogueweapon/huntingknife/idagger/steel/kazengun)

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/hangyaku.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/hangyaku.dm
@@ -207,8 +207,8 @@
 		if("Ashigaru") // Caustic Cove edit - A dishonorable weapon, only fit for a peasant! Or maybe that's just your enemies coping and seething because they're losing. :)
 			H.adjust_skillrank_up_to(/datum/skill/combat/firearms, SKILL_LEVEL_EXPERT, TRUE)
 			H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			//H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/gwstrap, SLOT_BACK_R, TRUE) // OV Edit, removal until fixed, or maybe forever
-			H.equip_to_slot_or_del(new /obj/item/gun/ballistic/arquebus, SLOT_BACK_R, TRUE) // OV Edit, see above.
+			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/gwstrap, SLOT_BACK_R, TRUE)
+			H.put_in_hands(new /obj/item/gun/ballistic/arquebus)
 			H.put_in_hands(new /obj/item/powderflask)
 			H.put_in_hands(new /obj/item/rogueweapon/huntingknife/idagger/steel/kazengun)
 			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sheath/kazengun, SLOT_BELT_R, TRUE)

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/hangyaku.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/hangyaku.dm
@@ -208,7 +208,7 @@
 			H.adjust_skillrank_up_to(/datum/skill/combat/firearms, SKILL_LEVEL_EXPERT, TRUE)
 			H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_JOURNEYMAN, TRUE)
 			//H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/gwstrap, SLOT_BACK_R, TRUE) // OV Edit, removal until fixed, or maybe forever
-			H.put_in_hands(new /obj/item/gun/ballistic/arquebus)
+			H.equip_to_slot_or_del(new /obj/item/gun/ballistic/arquebus, SLOT_BACK_R, TRUE) // OV Edit, see above.
 			H.put_in_hands(new /obj/item/powderflask)
 			H.put_in_hands(new /obj/item/rogueweapon/huntingknife/idagger/steel/kazengun)
 			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sheath/kazengun, SLOT_BELT_R, TRUE)

--- a/code/modules/roguetown/roguecrafting/crafting/ammo_and_ranged.dm
+++ b/code/modules/roguetown/roguecrafting/crafting/ammo_and_ranged.dm
@@ -345,7 +345,7 @@
 	craftdiff = 1 //you should make some ammo first!
 	
 /datum/crafting_recipe/roguetown/survival/slingpouchcraft
-	name = "bullet pouch" // OV Edit
+	name = "sling bullet pouch"
 	category = "Ranged"
 	result = /obj/item/quiver/sling/
 	reqs = list(

--- a/code/modules/roguetown/roguecrafting/crafting/ammo_and_ranged.dm
+++ b/code/modules/roguetown/roguecrafting/crafting/ammo_and_ranged.dm
@@ -387,3 +387,16 @@
 	verbage_simple = "smooth"
 	verbage = "smooths"
 	craftdiff = 0
+
+// OV Edit, at least temporarily adds arquebus bullet pouch until I have a better solution -Ace
+/datum/crafting_recipe/roguetown/survival/arquebuspouchcraft
+	name = "arquebus bullet pouch"
+	category = "Ranged"
+	result = /obj/item/ingot/iron
+	reqs = list(
+		/obj/item/natural/fibers = 1,
+		/obj/item/natural/cloth = 1,
+		)
+	verbage_simple = "craft"
+	verbage = "crafts"
+	craftdiff = 0

--- a/code/modules/roguetown/roguecrafting/crafting/ammo_and_ranged.dm
+++ b/code/modules/roguetown/roguecrafting/crafting/ammo_and_ranged.dm
@@ -345,7 +345,7 @@
 	craftdiff = 1 //you should make some ammo first!
 	
 /datum/crafting_recipe/roguetown/survival/slingpouchcraft
-	name = "sling bullet pouch"
+	name = "bullet pouch" // Ochre Valley edit, it works for all bullets.
 	category = "Ranged"
 	result = /obj/item/quiver/sling/
 	reqs = list(
@@ -367,7 +367,7 @@
 	verbage_simple = "smooth"
 	verbage = "smooths"
 	craftdiff = 0
-	
+
 /datum/crafting_recipe/roguetown/survival/stonebullets10x
 	name = "sling bullets - stone (x10)"
 	category = "Ranged"

--- a/code/modules/roguetown/roguecrafting/crafting/ammo_and_ranged.dm
+++ b/code/modules/roguetown/roguecrafting/crafting/ammo_and_ranged.dm
@@ -345,7 +345,7 @@
 	craftdiff = 1 //you should make some ammo first!
 	
 /datum/crafting_recipe/roguetown/survival/slingpouchcraft
-	name = "bullet pouch" // Ochre Valley edit, it works for all bullets.
+	name = "bullet pouch" // OV Edit
 	category = "Ranged"
 	result = /obj/item/quiver/sling/
 	reqs = list(

--- a/code/modules/roguetown/roguejobs/engineer/anvil_recipes/mechanical.dm
+++ b/code/modules/roguetown/roguejobs/engineer/anvil_recipes/mechanical.dm
@@ -289,7 +289,7 @@
 	created_item = /obj/item/powderflask
 	craftdiff = 3
 
-/* // OV Edit, pointless now.
+/* // OV Edit, because the sling bullet pouch is supposed to work just fine.
 /datum/anvil_recipe/engineering/bulletpouch
 	name = "Bullet Pouch (+1 Cured Leather)"
 	req_bar = /obj/item/ingot/iron

--- a/code/modules/roguetown/roguejobs/engineer/anvil_recipes/mechanical.dm
+++ b/code/modules/roguetown/roguejobs/engineer/anvil_recipes/mechanical.dm
@@ -289,7 +289,7 @@
 	created_item = /obj/item/powderflask
 	craftdiff = 3
 
-/* // Pointless now.
+/* // OV Edit, pointless now.
 /datum/anvil_recipe/engineering/bulletpouch
 	name = "Bullet Pouch (+1 Cured Leather)"
 	req_bar = /obj/item/ingot/iron

--- a/code/modules/roguetown/roguejobs/engineer/anvil_recipes/mechanical.dm
+++ b/code/modules/roguetown/roguejobs/engineer/anvil_recipes/mechanical.dm
@@ -289,12 +289,14 @@
 	created_item = /obj/item/powderflask
 	craftdiff = 3
 
+/* // Pointless now.
 /datum/anvil_recipe/engineering/bulletpouch
 	name = "Bullet Pouch (+1 Cured Leather)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/natural/hide/cured) //Bag of bullets
 	created_item = /obj/item/quiver/bulletpouch
 	craftdiff = 0
+*/
 
 /datum/anvil_recipe/engineering/leadbullets
 	name = "Firearm Bullets (x10)"

--- a/code/modules/spells/spell_types/wizard/conjure/conjure_tool_ov.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_tool_ov.dm
@@ -25,7 +25,7 @@
 	// R.smeltresult = null
 	// R.salvage_result = null
 	// R.fiber_salvage = FALSE
-	// Ochre Valley Edit; These are resolved in conjure_weapon calling conjured item dataum? I don't see a difference if there is one.
+	// OV Edit; These are resolved in conjure_weapon calling conjured item dataum? I don't see a difference if there is one.
 	if(!QDELETED(R))
 		R.AddComponent(/datum/component/conjured_item, GLOW_COLOR_ARCANE, user)
 	user.put_in_hands(R)

--- a/modular_causticcove/code/game/objects/items/weapons/ranged/ammo.dm
+++ b/modular_causticcove/code/game/objects/items/weapons/ranged/ammo.dm
@@ -4,4 +4,4 @@
 /obj/item/ammo_casing/caseless/rogue/bullet
 	name = "arquebus shot"
 	desc = "A small metal sphere to be fired from a gun."
-	dropshrink = 0.9 // Stop shrinking these so much, I can't fuckin see them. Q_Q
+	dropshrink = 0.9 // OV Edit because stop shrinking these so much, I can't fuckin see them. Q_Q

--- a/modular_causticcove/code/game/objects/items/weapons/ranged/ammo.dm
+++ b/modular_causticcove/code/game/objects/items/weapons/ranged/ammo.dm
@@ -4,3 +4,4 @@
 /obj/item/ammo_casing/caseless/rogue/bullet
 	name = "arquebus shot"
 	desc = "A small metal sphere to be fired from a gun."
+	dropshrink = 0.9 // Stop shrinking these so much, I can't fuckin see them. Q_Q

--- a/modular_causticcove/code/game/objects/items/weapons/ranged/arquebus.dm
+++ b/modular_causticcove/code/game/objects/items/weapons/ranged/arquebus.dm
@@ -22,8 +22,8 @@
 	w_class = WEIGHT_CLASS_BULKY
 	randomspread = 1
 	spread = 0
-	equip_delay_self = 1.5
-	unequip_delay_self = 1.5
+	equip_delay_self = 1.5 SECONDS
+	unequip_delay_self = 1.5 SECONDS
 	inv_storage_delay = 1.5 SECONDS
 	can_parry = TRUE
 	minstr = 6

--- a/modular_causticcove/code/game/objects/items/weapons/ranged/arquebus.dm
+++ b/modular_causticcove/code/game/objects/items/weapons/ranged/arquebus.dm
@@ -18,13 +18,13 @@
 	bigboy = TRUE
 	gripsprite = TRUE
 	wlength = WLENGTH_LONG
-	slot_flags = ITEM_SLOT_BACK // It can be inferred that this has a sling.
+	slot_flags = null
 	w_class = WEIGHT_CLASS_BULKY
 	randomspread = 1
 	spread = 0
-	equip_delay_self = 2 SECONDS // Same as sheathe time for a greatweapon strap.
-	unequip_delay_self = 2 SECONDS
-	inv_storage_delay = 2 SECONDS
+	equip_delay_self = 1.5
+	unequip_delay_self = 1.5
+	inv_storage_delay = 1.5 SECONDS
 	can_parry = TRUE
 	minstr = 6
 	walking_stick = TRUE
@@ -290,7 +290,7 @@
 	can_parry = TRUE
 	equip_delay_self = 1.5 SECONDS
 	unequip_delay_self = 1.5 SECONDS
-	inv_storage_delay = 2 SECONDS // Either use a bandolier holster or deal with the slowdown.
+	inv_storage_delay = 2 SECONDS // OV Edit, either use a bandolier holster or deal with the slowdown.
 	minstr = 6
 	walking_stick = FALSE
 	cartridge_wording = "musketball"

--- a/modular_causticcove/code/game/objects/items/weapons/ranged/arquebus.dm
+++ b/modular_causticcove/code/game/objects/items/weapons/ranged/arquebus.dm
@@ -176,7 +176,6 @@
 		playsound(src, "modular_causticcove/sound/arquebus/insert.ogg",  100)
 		user.visible_message("<span class='notice'>[user] forces [A] down the barrel of [src].</span>")
 		..()
-
 	if(istype(A, /obj/item/powderflask))
 		if(gunpowder)
 			user.visible_message("<span class='warning'>[src] is already filled with gunpowder!</span>")
@@ -217,6 +216,8 @@
 			to_chat(user, span_warning("There's already a [R.name] inside of [src]."))
 			return
 		user.stop_sound_channel(gunchannel)
+	else
+		..()
 
 /obj/item/gun/ballistic/arquebus/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 

--- a/modular_causticcove/code/game/objects/items/weapons/ranged/arquebus.dm
+++ b/modular_causticcove/code/game/objects/items/weapons/ranged/arquebus.dm
@@ -4,7 +4,7 @@
 	icon = 'modular_causticcove/icons/weapons/arquebus.dmi'
 	icon_state = "arquebus"
 	item_state = "arquebus"
-	dropshrink = 0.6
+	dropshrink = 0.6 // OV Edit, I think this might look nicer.
 	force = 10
 	force_wielded = 15
 	possible_item_intents = list(/datum/intent/mace/strike/wood)
@@ -216,8 +216,8 @@
 			to_chat(user, span_warning("There's already a [R.name] inside of [src]."))
 			return
 		user.stop_sound_channel(gunchannel)
-	else
-		..()
+	else // OV Edit, should hopefully fix issues with repairs.
+		..() // OV Edit
 
 /obj/item/gun/ballistic/arquebus/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 
@@ -278,7 +278,7 @@
 	icon = 'icons/roguetown/weapons/32.dmi'
 	icon_state = "pistol"
 	item_state = "pistol"
-	dropshrink = 0.6
+	dropshrink = 0.6 // OV Edit, I think this might look nicer.
 	force = 10
 	possible_item_intents = list(/datum/intent/shoot/arquebus_pistol, /datum/intent/arc/arquebus_pistol, /datum/intent/mace/strike/wood)
 	internal_magazine = TRUE
@@ -288,8 +288,8 @@
 	randomspread = 1
 	spread = 0
 	can_parry = TRUE
-	equip_delay_self = 1.5 SECONDS
-	unequip_delay_self = 1.5 SECONDS
+	equip_delay_self = 1.5 SECONDS // OV Edit, this is supposed to denote seconds.
+	unequip_delay_self = 1.5 SECONDS // OV Edit, this is supposed to denote seconds.
 	inv_storage_delay = 2 SECONDS // OV Edit, either use a bandolier holster or deal with the slowdown.
 	minstr = 6
 	walking_stick = FALSE
@@ -432,8 +432,8 @@
 			to_chat(user, span_warning("There's already a [R.name] inside of [src]."))
 			return
 		user.stop_sound_channel(gunchannel)
-	else
-		..()
+	else // OV Edit, should hopefully fix issues with repairs.
+		..() // OV Edit
 
 
 /obj/item/gun/ballistic/arquebus_pistol/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)

--- a/modular_causticcove/code/game/objects/items/weapons/ranged/arquebus.dm
+++ b/modular_causticcove/code/game/objects/items/weapons/ranged/arquebus.dm
@@ -432,6 +432,8 @@
 			to_chat(user, span_warning("There's already a [R.name] inside of [src]."))
 			return
 		user.stop_sound_channel(gunchannel)
+	else
+		..()
 
 
 /obj/item/gun/ballistic/arquebus_pistol/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)

--- a/modular_causticcove/code/game/objects/items/weapons/ranged/arquebus.dm
+++ b/modular_causticcove/code/game/objects/items/weapons/ranged/arquebus.dm
@@ -1,10 +1,10 @@
-
 /obj/item/gun/ballistic/arquebus
 	name = "arquebus rifle"
 	desc = "A gunpowder weapon that shoots an armor piercing metal ball."
 	icon = 'modular_causticcove/icons/weapons/arquebus.dmi'
 	icon_state = "arquebus"
 	item_state = "arquebus"
+	dropshrink = 0.6
 	force = 10
 	force_wielded = 15
 	possible_item_intents = list(/datum/intent/mace/strike/wood)
@@ -18,13 +18,13 @@
 	bigboy = TRUE
 	gripsprite = TRUE
 	wlength = WLENGTH_LONG
-	slot_flags = null
+	slot_flags = ITEM_SLOT_BACK // It can be inferred that this has a sling.
 	w_class = WEIGHT_CLASS_BULKY
 	randomspread = 1
 	spread = 0
-	equip_delay_self = 1.5 SECONDS
-	unequip_delay_self = 1.5 SECONDS
-	inv_storage_delay = 1.5 SECONDS
+	equip_delay_self = 2 SECONDS // Same as sheathe time for a greatweapon strap.
+	unequip_delay_self = 2 SECONDS
+	inv_storage_delay = 2 SECONDS
 	can_parry = TRUE
 	minstr = 6
 	walking_stick = TRUE
@@ -277,6 +277,7 @@
 	icon = 'icons/roguetown/weapons/32.dmi'
 	icon_state = "pistol"
 	item_state = "pistol"
+	dropshrink = 0.6
 	force = 10
 	possible_item_intents = list(/datum/intent/shoot/arquebus_pistol, /datum/intent/arc/arquebus_pistol, /datum/intent/mace/strike/wood)
 	internal_magazine = TRUE
@@ -286,9 +287,9 @@
 	randomspread = 1
 	spread = 0
 	can_parry = TRUE
-	equip_delay_self = 1.5
-	unequip_delay_self = 1.5
-	inv_storage_delay = 1 SECONDS	
+	equip_delay_self = 1.5 SECONDS
+	unequip_delay_self = 1.5 SECONDS
+	inv_storage_delay = 2 SECONDS // Either use a bandolier holster or deal with the slowdown.
 	minstr = 6
 	walking_stick = FALSE
 	cartridge_wording = "musketball"
@@ -372,7 +373,7 @@
 	gunchannel = SSsounds.random_available_channel()
 
 	if(istype(A, /obj/item/ammo_box) || istype(A, /obj/item/ammo_casing))
-		/*if(A in user.held_items) // Todo: Unfuck this before merging. -Ace
+		/*if(A in user.held_items) // Todo: Unfuck this later. -Ace
 			to_chat(user, "<span class='warning'>You need to be holding [A] to reload it.")
 			return*/
 		if(chambered)


### PR DESCRIPTION
## About The Pull Request

This started as restoring functionality of the arquebus back to what it should be and making a couple of planned tweaks that never got implemented because I left CC, but now it's gotten turned into more of a polish for arquebuses in general. I can't really call this _just_ a bug fix thread anymore.

Fixes guns not being possible to repair if damaged
- Rebalances some draw times for the arquebus and pistol, because being able to draw a handgun faster than a sword from _inside a bag_ is either a typo or someone is abusing their dev powers for evil
- Makes bullets stop SHRINKING SO GOD DAMN MUCH WHEN YOU SHOOT THEM GOD THIS ANNOYED ME
- I can't easily restore bullet pouches being used for all bullets sling or arquebus, so I just made the arquebus bullet pouch just as easy to make for now. I have opinions of how this should be handled but that is out of scope. Let me return it to normal first.
- Removes "iron bullet pouch" recipe.

Also not shown in the changelog but there is inconsistent use of OV edit elsewhere which I also fix.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

**Haven't tested yet.** Merge at your own risk.

## Why It's Good For The Game

This PR fixes a lot of neglected issues, restores function that was lost during an upstream change, or makes reasonable changes like not giving pistols an unfair advantage in draw time.

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
code: Pistols and rifles, when dropped, shrink in size by about half for better visuals.
balance: Pistol now require 2 seconds to draw out of inventories like bags. (Not bandoliers. Those are fine.)
balance: Arquebus bullet pouches can be made again without requiring an anvil.
del: Anvil recipe for bullet pouches is removed.
fix: Probably fixes arquebuses not being possible to repair.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
