### PR TITLE
Bump cross revival player threshold to 999

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1190,7 +1190,7 @@
 	. = ..()
 	var/mob/living/carbon/H = user
 	if(user.mind?.antag_datums)
-		if(living_player_count() <= 25) //Only works if less than 25 people in a round. Otherwise good fucking luck lol
+		if(living_player_count() <= 999) //Only works if less than 25 people in a round. Otherwise good fucking luck lol // OV Edit: raised to 999
 			for(var/datum/antagonist/D in user.mind?.antag_datums)
 				if(istype(D, /datum/antagonist/zombie))
 					to_chat(H, span_warning("I press my palm to the cross and focus..."))


### PR DESCRIPTION
## About The Pull Request
This is the least intrusive way to effectively just disable the player threshold.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

There's no conceivable way that this doesn't do exactly what it says on the tin, it modifies one numerical literal lol

## Why It's Good For The Game
We're experiencing a medic crisis at the moment and admins have been having to resurrect people from deadite fairly often. 

See https://discord.com/channels/1473048818802229523/1477378300748890213 for discussion.

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Player cap removed from deadite self-revival at the cross.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
