### PR TITLE
Gives Ashigaru (Kazengun Levy) a sword

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/hangyaku.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/hangyaku.dm
@@ -206,10 +206,10 @@
 			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sheath/kazengun, SLOT_BELT_R, TRUE)
 		if("Ashigaru") // Caustic Cove edit - A dishonorable weapon, only fit for a peasant! Or maybe that's just your enemies coping and seething because they're losing. :)
 			H.adjust_skillrank_up_to(/datum/skill/combat/firearms, SKILL_LEVEL_EXPERT, TRUE)
-			H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_JOURNEYMAN, TRUE)
+			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE) // OV Edit, I already tried the knife and player feedback prefers the sword.
 			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/gwstrap, SLOT_BACK_R, TRUE)
 			H.put_in_hands(new /obj/item/gun/ballistic/arquebus)
 			H.put_in_hands(new /obj/item/powderflask)
-			H.put_in_hands(new /obj/item/rogueweapon/huntingknife/idagger/steel/kazengun)
-			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sheath/kazengun, SLOT_BELT_R, TRUE)
+			H.put_in_hands(new /obj/item/rogueweapon/sword/short/kazengun) // OV Edit, again sword instead of knife
+			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sword/kazengun/kodachi, SLOT_BELT_R, TRUE) // OV Edit
 			H.equip_to_slot_or_del(new /obj/item/quiver/bulletpouch/iron, SLOT_BELT_L, TRUE)


### PR DESCRIPTION
## About The Pull Request

I had been struggling to find a decent sword to give to the Ashigaru mercenary that wasn't broken or out of place. Turns out there is a seldom used arming sword for Kazengun, which I have decided to also use here. Would be nice to breathe some life into this almost completely unused weapon.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

I just shuffle some values from something we already know works.

## Why It's Good For The Game

Players felt the tanto was sorely underwhelming, but this will push the role into the range-skirmishing hybrid class it's supposed to be. Now you can handle your own okay in the melee.

Otherwise, the first thing many Ashigaru players do is dump their knife and get an arming sword.

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Ashigaru no longer have knife fighting skill.
balance: Ashigaru no longer have a tanto.
balance: Ashigaru now have sword fighting skill at Journeyman.
balance: Ashigaru now have a kodachi arming sword.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
