### PR TITLE
Gives thieves a choice of normal arrows

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -106,7 +106,7 @@
 	var/trades = list("Normal arrows","Arrows with a glass ampule full of water")
 	var/trade_choice = input(H, "Choose your quiver.", "WHICH ARROWS?") as anything in trades
 	switch(trade_choice)
-		if("Normal arrows") //alchemy and medicine. that's pretty strong as-is, so...
+		if("Normal arrows")
 			beltl = /obj/item/quiver/arrows
 		if("Arrows with a glass ampule full of water")
 			beltl = /obj/item/quiver/Warrows


### PR DESCRIPTION
## About The Pull Request

Fulfills this request: https://discord.com/channels/1473048818802229523/1478352330394046627/1478352330394046627

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game

See the Discord post, I'm just the messenger.

Also you can just take the archer perk if you want arrows at round start, which most thieves do to get around this odd limitation. So why limit this?

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Thief adventurers can now choose to equip normal arrows at round start.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
