### PR TITLE
Resurrection Fix + Runtime Fixes Port from Upstream

### DIFF
--- a/code/game/objects/effects/track.dm
+++ b/code/game/objects/effects/track.dm
@@ -415,14 +415,14 @@
 				this_track.ambiguous_track_type = "humanoid footprints"
 
 		var/bonus_weight = 0
-		if(wear_armor)
+		if(wear_armor && wear_armor.armor_class) //OV Edit: Port of CC Runtime Spam 330
 			switch(wear_armor.armor_class)
 				if(ARMOR_CLASS_HEAVY)
 					bonus_weight += 1
 				if(ARMOR_CLASS_MEDIUM)
 					bonus_weight = 0.5
 				else
-		if(wear_shirt)
+		if(wear_shirt && wear_shirt.armor_class) //OV Edit: Port of CC Runtime Spam 330
 			switch(wear_shirt.armor_class)
 				if(ARMOR_CLASS_HEAVY)
 					bonus_weight += 1

--- a/code/game/objects/items/scabbard.dm
+++ b/code/game/objects/items/scabbard.dm
@@ -719,7 +719,7 @@
 
 /obj/item/rogueweapon/scabbard/gwstrap/getonmobprop(tag)
 	..()
-	if(!hol_comp.sheathed)
+	if(!hol_comp || !hol_comp.sheathed) //CC Edit: Checking if we have hol_comp in the first place
 		return
 	if(istype(hol_comp.sheathed, /obj/item/rogueweapon/estoc) || istype(hol_comp.sheathed, /obj/item/rogueweapon/greatsword))
 		switch(tag)

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -104,6 +104,8 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	//We do this here so anything that doesn't want to persist can clear itself
 	var/list/old_comp_lookup = comp_lookup?.Copy()
 	var/list/old_signal_procs = signal_procs?.Copy()
+	if(!path) //CC Edit: This shouldn't runtime yet here we are... it's already checked above, so the path was nulled sometime between here and there? Logs don't lie.
+		return
 	var/turf/W = new path(src)
 
 	// WARNING WARNING

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -46,15 +46,15 @@
 		if(hostagetaker) // If we are TAKEN hostage. Confusing vars at first but then it makes sense.
 			attackhostage()
 
-		if(wear_armor)
+		if(wear_armor && istype(wear_armor, /obj/item/clothing)) //CC Edit: More powder flask shitcode runtimes
 			if(mobility_flags & MOBILITY_STAND)
 				wear_armor.step_action()
 
-		if(wear_shirt)
+		if(wear_shirt && istype(wear_shirt, /obj/item/clothing)) //CC Edit: More powder flask shitcode runtimes
 			if(mobility_flags & MOBILITY_STAND)
 				wear_shirt.step_action()
 
-		if(cloak)
+		if(cloak && istype(cloak, /obj/item/clothing)) //CC Edit: More powder flask shitcode runtimes
 			if(mobility_flags & MOBILITY_STAND)
 				var/obj/item/clothing/C = isclothing(cloak) ? cloak : null
 				C?.step_action()

--- a/code/modules/spells/roguetown/acolyte/resurrect.dm
+++ b/code/modules/spells/roguetown/acolyte/resurrect.dm
@@ -87,10 +87,11 @@
 			)
 			target.gib()
 			return TRUE
+		to_chat(user, span_notice("You feel the energies of life flow through you, and into [target.name]... All that's left is hope for the best...")) //CC Edit: Feedback
 		if(alert(target, "They are calling for you. Are you ready?", "Revival", "I need to wake up", "Don't let me go") != "I need to wake up")
 			target.visible_message(span_notice("Nothing happens. They are not being let go."))
 			return FALSE
-		target.adjustOxyLoss(-target.getOxyLoss()) //Ye Olde CPR
+		target.setOxyLoss(0, TRUE, TRUE) //Ye Olde CPR //OV Edit, commenting to mark as changed on CC Revival bugfix thread 334
 		if(!target.revive(full_heal = FALSE))
 			to_chat(user, span_warning("Nothing happens."))
 			revert_cast()

--- a/modular_causticcove/code/modules/chompy_vore/eating/bellymodes_vr.dm
+++ b/modular_causticcove/code/modules/chompy_vore/eating/bellymodes_vr.dm
@@ -272,8 +272,10 @@
 			did_an_item = digest_item(I, touchable_amount)
 		if(IM_SMELTING)
 			if(I.smeltresult && I.smeltresult != /obj/item/rogueore/coal/charcoal && !istype(I, /obj/item/ingot) && I.smeltresult != /obj/item/rogueore/coal)
-				var/obj/item/ingot/newingot = new I.smeltresult(src)
-				newingot.quality = SMELTERY_LEVEL_SPOIL
+				var/obj/item/newingot = new I.smeltresult(src)
+				if(istype(newingot, /obj/item/ingot))
+					var/obj/item/ingot/newdefinietlyingot = newingot
+					newdefinietlyingot.quality = SMELTERY_LEVEL_SPOIL //OV Edit: Ported fix from CC Runtime Spam 330
 				qdel(I)
 	return did_an_item
 


### PR DESCRIPTION
Porting several file corrections from upstream, related to runtime issues we hadn't yet received fixes for in our files + correcting an issue with resurrection related to oxyloss.

## About The Pull Request

<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->

Porting in changes from upstream.
NONE of this is my own code or findings, all credit goes to the upstream wizards:
https://github.com/CausticCove/CC/pull/330
https://github.com/CausticCove/CC/pull/334

All code pulled from these requests, with the only exceptions being not porting the GNOLL adjustments (as we got the fix from Azure Peak) and not touching the FOOD rotting code (as it seems we ALSO got changes from upstream for that, so didn't wanna poke it and make it angry)

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->
Should be working unless I slapped a typo somewhere.....

## Why It's Good For The Game

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

Ports fixes upstream has had in the files for a while to our branch, hopefully aiding in making down-streaming smoother for the future.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Feedback to revivals to hopefully be less black box-y
fix: Revivals not possible if the patient had (emphasis on HAD) more than 200 oxyloss
fix: fixed belly smelted gems trying to get a bad quality
fix: fixed trying to querry powder flasks for AC and stepsound
fix: holder component disappearing and causing a runtime checked for
fix: path for new tiles disappearing causing a runtime checked for
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
