### PR TITLE
Adds admin logging messages for when users blow the warden signal horn

### DIFF
--- a/code/game/objects/items/signal_horn.dm
+++ b/code/game/objects/items/signal_horn.dm
@@ -101,7 +101,7 @@
 				player.playsound_local(get_turf(player), 'sound/items/horn/signalhorn.ogg', 35, FALSE, pressure_affected = FALSE)
 		to_chat(player, span_warning("I hear the horn of the Wardens somewhere [dirtext]"))
 
-	var/mobs_spawned = 0
+	var/mobs_spawned = 0 // OV Add
 	var/random_ambushes = 4 + rand(0,2) // 4 - 6 ambushes
 	var/did_ambush = FALSE
 	for(var/i = 0, i < random_ambushes, i++)
@@ -109,11 +109,13 @@
 		var/success = user.consider_ambush(TRUE, TRUE, min_dist = WARDEN_AMBUSH_MIN, max_dist = WARDEN_AMBUSH_MAX, silent = silent)
 		if(success)
 			did_ambush = TRUE
-			mobs_spawned++
+			mobs_spawned++ // OV Add
+	// OV Edit Start
 	if(did_ambush)
 		user.log_message("blew \the [src], spawning [mobs_spawned] ambush mobs around [user.p_them()].", LOG_ATTACK, color="red")
 	else
 		user.log_message("blew \the [src], but failed to spawn any ambush mobs.", LOG_ATTACK, color="red")
+	// OV Edit End
 	return did_ambush
 
 #undef WARDEN_AMBUSH_MIN

--- a/code/game/objects/items/signal_horn.dm
+++ b/code/game/objects/items/signal_horn.dm
@@ -101,6 +101,7 @@
 				player.playsound_local(get_turf(player), 'sound/items/horn/signalhorn.ogg', 35, FALSE, pressure_affected = FALSE)
 		to_chat(player, span_warning("I hear the horn of the Wardens somewhere [dirtext]"))
 
+	var/mobs_spawned = 0
 	var/random_ambushes = 4 + rand(0,2) // 4 - 6 ambushes
 	var/did_ambush = FALSE
 	for(var/i = 0, i < random_ambushes, i++)
@@ -108,6 +109,11 @@
 		var/success = user.consider_ambush(TRUE, TRUE, min_dist = WARDEN_AMBUSH_MIN, max_dist = WARDEN_AMBUSH_MAX, silent = silent)
 		if(success)
 			did_ambush = TRUE
+			mobs_spawned++
+	if(did_ambush)
+		user.log_message("blew \the [src], spawning [mobs_spawned] ambush mobs around [user.p_them()].", LOG_ATTACK, color="red")
+	else
+		user.log_message("blew \the [src], but failed to spawn any ambush mobs.", LOG_ATTACK, color="red")
 	return did_ambush
 
 #undef WARDEN_AMBUSH_MIN


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->
See title

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [X] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [X] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<img width="459" height="51" alt="image" src="https://github.com/user-attachments/assets/254ac8c4-c100-4425-ad9c-43823773624d" />


<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

These things can (and have) been used in ways that cause some serious disruption to a round, (even if it isn't done intentionally.) It's important for admins to know who used this potentially powerful griefing tool in case it's used for NEFARIOUS ENDS.

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl: Ryumi
admin: Signal horns now add combat logs when blown.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
