### PR TITLE
Enable macros and skins

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -295,7 +295,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 
 /client/proc/add_admin_verbs()
 	if(holder)
-		control_freak = CONTROL_FREAK_SKIN | CONTROL_FREAK_MACROS
+		// control_freak = CONTROL_FREAK_SKIN | CONTROL_FREAK_MACROS // OV Edit: disabled control_freak
 
 		var/rights = holder.rank.rights
 		verbs += GLOB.admin_verbs_default

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -55,7 +55,7 @@
 		//SECURITY//
 		////////////
 	// comment out the line below when debugging locally to enable the options & messages menu
-	control_freak = 1
+	// control_freak = 1 // OV Edit: disabled control_freak
 
 		////////////////////////////////////
 		//things that require the database//

--- a/modular_ochrevalley/code/modules/mob/mob_helpers.dm
+++ b/modular_ochrevalley/code/modules/mob/mob_helpers.dm
@@ -1,0 +1,12 @@
+// https://github.com/ParadiseSS13/Paradise/pull/6631
+/mob/verb/ClickSubstitute(params as command_text)
+	set hidden = 1
+	set name = ".click"
+
+/mob/verb/DblClickSubstitute(params as command_text)
+	set hidden = 1
+	set name = ".dblclick"
+
+/mob/verb/MouseSubstitute(params as command_text)
+	set hidden = 1
+	set name = ".mouse"

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3214,6 +3214,7 @@
 #include "modular_ochrevalley\code\datums\loadout\loadout_accessories.dm"
 #include "modular_ochrevalley\code\datums\loadout\loadout_hats.dm"
 #include "modular_ochrevalley\code\modules\jobs\job_types\roguetown\adventurer\types\combat\spellblade_pre_rework.dm"
+#include "modular_ochrevalley\code\modules\mob\mob_helpers.dm"
 #include "modular_ochrevalley\code\modules\mob\dead\new_player\sprite_accessory\antennas.dm"
 #include "modular_ochrevalley\code\modules\mob\dead\new_player\sprite_accessory\wings.dm"
 #include "modular_ochrevalley\code\modules\mob\living\carbon\human\hand_games.dm"


### PR DESCRIPTION
## About The Pull Request

This one will probably be a little controversial! 

This PR enables custom user skins and macros. 
This means that, for instance, someone can macro "say "*meow"" to a keybinding.
They could also macro stand up, and resist, and toggle run in one button.

Includes https://github.com/ParadiseSS13/Paradise/pull/6631 for some semblance of safety

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game

My primary argument comes down to making things more accessible.

Custom skins allow people to tweak things like the default colors, font size, and proportions of the UI, if the default doesn't work for them.

Custom macros are more contentious. Obviously, being able to invoke any verb or series of verbs is invaluable for accessibility. They allow people to come up with keybindings that we didn't think of or feel like implementing, like `say "*meow"`. They also let powergamers do some really fucked up shit that should probably take multiple button presses! The worst exploit, click macros, are prevented, but there's still plenty of stuff you can come up with that will give you a bit of an edge. 

My argument is that obvious abuse of this is obvious, and subtle abuse shouldn't pose that much of a problem for us, given our server's goals and environment. Most combat verbs can already be bound to keys and rapidly pressed together. It also doesn't stop the really dedicated people, who will prefer an external program like AutoHotKey.

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
config: Users may now have custom skins and macros.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
