### PR TITLE
Frostbolt gets its arc back

### DIFF
--- a/code/modules/spells/spell_types/wizard/projectiles_single/frost_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/frost_bolt.dm
@@ -39,7 +39,7 @@
 		projectile_type = /obj/projectile/magic/frostbolt
 	. = ..()
 // OV Edit End
-// OV Edit End
+
 /obj/projectile/magic/frostbolt
 	name = "Frost Dart"
 	icon_state = "ice_2"


### PR DESCRIPTION
## About The Pull Request

Frostbolt used to be able to be arced due to a change CC made, and a recent upstream sync killed that. This un-kills the frostbolt arcing.

## Testing Evidence

It just works (tm)

## Why It's Good For The Game

Ice magic is pretty not great in PvE with carbon mobs ignoring stamina and simplemobs not using stamina. This doesn't do anything to buff it, it just allows it to be lobbed from a backline for some ice mage QoL.

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added frostbolt's ability to arc back in
/:cl: