### PR TITLE
Rebalances pistol draw time from inside of bags, fixes draw from hip times

### DIFF
--- a/modular_causticcove/code/game/objects/items/weapons/ranged/arquebus.dm
+++ b/modular_causticcove/code/game/objects/items/weapons/ranged/arquebus.dm
@@ -286,9 +286,9 @@
 	randomspread = 1
 	spread = 0
 	can_parry = TRUE
-	equip_delay_self = 1.5 SECONDS
-	unequip_delay_self = 1.5 SECONDS
-	inv_storage_delay = 2 SECONDS
+	equip_delay_self = 1.5 SECONDS // OV Edit - Fixed this
+	unequip_delay_self = 1.5 SECONDS // OV Edit - Fixed this
+	inv_storage_delay = 2 SECONDS // OV Edit - Because we make our code fair and balanced.
 	minstr = 6
 	walking_stick = FALSE
 	cartridge_wording = "musketball"


### PR DESCRIPTION
## About The Pull Request

Splits off a change from https://github.com/Ochre-Valley/Ochre-Valley/pull/89 into its own PR since the scope of that PR has changed so much.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game

How is it fair that a pistol can be drawn out of a bag _faster than_ if you draw it off your hip?

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Pistols now need 2 seconds to draw out of item inventories.
fix: Pistols draw time from hip slots now uses seconds like it was always supposed to.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
