### PR TITLE
Merk round-end votes

### DIFF
--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -597,6 +597,18 @@ SUBSYSTEM_DEF(gamemode)
 		to_chat(world, "\n<h1><font color='purple'>Game will end in [ROUND_END_TIME_VERBAL]</font></h1>")
 		roundvoteend = TRUE
 		round_ends_at = world.time + ROUND_END_TIME
+
+		var/sound/vote_alert = new()
+		vote_alert.file = 'sound/roundend/roundend-vote-sound.ogg'
+		vote_alert.priority = 250
+		vote_alert.channel = CHANNEL_ADMIN
+		vote_alert.frequency = 1
+		vote_alert.wait = 1
+		vote_alert.repeat = 0
+		vote_alert.status = SOUND_STREAM
+		vote_alert.volume = 100
+		for(var/mob/M in GLOB.player_list)
+			SEND_SOUND(M, vote_alert)
 // 		if(roundvoteend)
 // 			if(world.time >= round_ends_at)
 // //				for(var/mob/living/carbon/human/H in GLOB.human_list)

--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -592,20 +592,26 @@ SUBSYSTEM_DEF(gamemode)
 		return TRUE
 
 	var/ttime = world.time - SSticker.round_start_time
-	if(ttime >= GLOB.round_timer)
-		if(roundvoteend)
-			if(world.time >= round_ends_at)
-//				for(var/mob/living/carbon/human/H in GLOB.human_list)
-//					if(H.stat != DEAD)
-//						if(H.allmig_reward)
-//							H.adjust_triumphs(H.allmig_reward)
-//							H.allmig_reward = 0
-				return TRUE
-		else
-			if(!SSvote.mode)
-				SSvote.initiate_vote("endround", pick("Zlod", "Sun King", "Gaia", "Moon Queen", "Aeon", "Gemini", "Aries"))
-	else if(roundvoteend && world.time >= round_ends_at)
+// OV Edit: No round end votes
+	if(ttime >= GLOB.round_timer && !roundvoteend)
+		to_chat(world, "\n<h1><font color='purple'>Game will end in [ROUND_END_TIME_VERBAL]</font></h1>")
+		roundvoteend = TRUE
+		round_ends_at = world.time + ROUND_END_TIME
+// 		if(roundvoteend)
+// 			if(world.time >= round_ends_at)
+// //				for(var/mob/living/carbon/human/H in GLOB.human_list)
+// //					if(H.stat != DEAD)
+// //						if(H.allmig_reward)
+// //							H.adjust_triumphs(H.allmig_reward)
+// //							H.allmig_reward = 0
+// 				return TRUE
+// 		else
+// 			if(!SSvote.mode)
+// 				SSvote.initiate_vote("endround", pick("Zlod", "Sun King", "Gaia", "Moon Queen", "Aeon", "Gemini", "Aries"))
+	if(roundvoteend && world.time >= round_ends_at)
 		return TRUE
+// OV Edit End
+
 	if(SSmapping.retainer.head_rebel_decree)
 		if(reb_end_time == 0)
 			to_chat(world, span_boldannounce("The peasant rebels took control of the throne, hail the new community!"))


### PR DESCRIPTION
## About The Pull Request
The staff have decided that we want round-end to consistently be at 4 hours 15 minutes. This PR disables the round-end extension voting and makes it always end at 4 hours, 15 minutes. There is a 15 minute warning.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<img width="255" height="36" alt="image" src="https://github.com/user-attachments/assets/ae61de5c-65c9-4989-b388-b3c7d4a01b18" />
<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game
More consistent for people to get in on the action

Admins can always manually extend if necessary

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
config: Rounds now *always* end at 4 hours, 15 minutes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
