### PR TITLE
Disables escaping predator who is dead or asleep

### DIFF
--- a/modular_causticcove/code/modules/chompy_vore/eating/belly_obj_vr.dm
+++ b/modular_causticcove/code/modules/chompy_vore/eating/belly_obj_vr.dm
@@ -1237,7 +1237,7 @@
 	var/escape_attempt_prey_message = span_warning(belly_format_string(escape_attempt_messages_prey, R))
 	var/escape_fail_owner_message = span_warning(belly_format_string(escape_fail_messages_owner, R))
 	var/escape_fail_prey_message = span_notice(belly_format_string(escape_fail_messages_prey, R))
-
+	/* // OV Edit - Stop ruining my scenes by making me escape from sleeping pred bellies. I'll OOC-Escape if I want out.
 	if(owner.stat) //If owner is stat (dead, KO) we can actually escape
 		escape_attempt_prey_message = span_warning("[escape_attempt_prey_message] (will take around [escapetime/10] seconds.)")
 		to_chat(R, escape_attempt_prey_message)
@@ -1258,7 +1258,7 @@
 				to_chat(owner, escape_fail_owner_message)
 				return
 			return
-
+	*/
 	var/struggle_user_message = span_alert(belly_format_string(struggle_messages_inside, R))
 
 	if(displayed_message_flags & MS_FLAG_STRUGGLE_OUTSIDE)


### PR DESCRIPTION
## About The Pull Request

SPITE CODE GO BRRRRR

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [ ] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game

I joke that this is spite code but struggling has accidentally screwed up many scenes and I'm getting quite tired of it. It should check if a player is actually DEAD and not just KO'd but here's a stop gap until someone figures that out.

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
code: Struggling no longer escapes from sleeping or dead predator bellies. Use OOC Escape if you need to.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
