### PR TITLE
Add modular_ochrevalley to build file patterns

### DIFF
--- a/tools/build/build.ts
+++ b/tools/build/build.ts
@@ -113,6 +113,7 @@ export const DmTarget = new Juke.Target({
     "tgui/public/tgui.html",
     "modular/**",
     "modular_causticcove/**",
+    "modular_ochrevalley/**",
     `${DME_NAME}.dme`,
     NamedVersionFile,
   ],


### PR DESCRIPTION
## About The Pull Request
These patterns tell the build system what files to look at for deciding if it needs to recompile DM; without this line, changing only a file in modular_ochrevalley won't trigger a recompile.

Probably doesn't need an edit tag?

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [ ] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence
shouldn't need testing

## Why It's Good For The Game
better dev UX

## Changelog
no cl