### PR TITLE
You can no longer disarm nodrop items from outlaws

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/deranged_knight.dm
+++ b/code/modules/mob/living/carbon/human/npc/deranged_knight.dm
@@ -68,8 +68,11 @@ GLOBAL_LIST_INIT(hedgeknight_aggro, world.file2list("strings/rt/hedgeknightaggro
 		return
 	equipOutfit(outfit)
 	// Apply dust-on-drop to all equipped gear so it can't be looted via dismemberment or stripping.
+	// TRAIT_NODROP on held items prevents grab disarming.
 	for(var/obj/item/equipped_item in get_equipped_items() + held_items)
 		equipped_item.AddComponent(/datum/component/item_on_drop/dust)
+	for(var/obj/item/held_item in held_items)
+		ADD_TRAIT(held_item, TRAIT_NODROP, TRAIT_GENERIC)
 
 /mob/living/carbon/human/species/human/northern/deranged_knight/after_creation()
 	..()

--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -369,7 +369,11 @@
 				if(I.wielded)
 					probby -= 20
 				if(prob(probby))
-					M.dropItemToGround(I, force = FALSE, silent = FALSE)
+					if(!M.dropItemToGround(I, force = FALSE, silent = FALSE))
+						M.visible_message(span_warning("[user] tries to take [I] from [M]'s hand, but can't pry it away!"), \
+								span_userdanger("[user] tries to take [I] from my hand, but I keep my grip!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE)
+						user.stop_pulling()
+						return
 					user.stop_pulling()
 					user.put_in_active_hand(I)
 					M.visible_message(span_danger("[user] takes [I] from [M]'s hand!"), \
@@ -379,7 +383,10 @@
 				else
 					probby += 20
 					if(prob(probby))
-						M.dropItemToGround(I, force = FALSE, silent = FALSE)
+						if(!M.dropItemToGround(I, force = FALSE, silent = FALSE))
+							M.visible_message(span_warning("[user] tries to disarm [M] of [I], but can't pry it away!"), \
+									span_userdanger("[user] tries to disarm me of [I], but I keep my grip!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE)
+							return
 						M.visible_message(span_danger("[user] disarms [M] of [I]!"), \
 								span_userdanger("[user] disarms me of [I]!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE)
 						M.Stun(6)//slight delay to pick up the weapon


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->
Cherry picks https://github.com/Azure-Peak/Azure-Peak/pull/6349 , Which makes outlaw knights be PHYSICALLY unable to drop their weapons even when they normally should.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [X] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [X] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [X] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->
Spawned an outlaw knight, fought him into paincrit. Even when he fell, he did not drop his edgy heretic weapon. 

## Why It's Good For The Game

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
https://github.com/Ochre-Valley/Ochre-Valley/pull/162 Works as intended, but now heretic outlaws are a little too easy due to becoming effectively harmless once disarmed due to their weapons going kaput. Hopefully with this they should serve a proper challenge!

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
