### PR TITLE
Extend CI timeout because our codebase is slowwwww

### DIFF
--- a/.github/workflows/compile_all_maps.yml
+++ b/.github/workflows/compile_all_maps.yml
@@ -11,7 +11,7 @@ jobs:
   compile_all_stations:
     name: Compile All Station Maps
     runs-on: ubuntu-22.04
-    timeout-minutes: 5
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
   compile_all_templates:
     name: Compile All Templates
     runs-on: ubuntu-22.04
-    timeout-minutes: 5
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
@@ -67,7 +67,7 @@ jobs:
   compile_all_dungeons:
     name: Compile All Dungeons
     runs-on: ubuntu-22.04
-    timeout-minutes: 5
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run_linters.yml
+++ b/.github/workflows/run_linters.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   linters:
     runs-on: ubuntu-22.04
-    timeout-minutes: 5
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code

--- a/.github/workflows/setup_build_artifact.yml
+++ b/.github/workflows/setup_build_artifact.yml
@@ -12,7 +12,7 @@ jobs:
   setup_build_artifact:
     name: Setup build artifact (${{ format('{0}.{1}', inputs.major, inputs.minor) }})
     runs-on: ubuntu-22.04
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## About The Pull Request
Keep getting spurious failures on PRs from the workflows just taking too long, so... let them! This extends it from a 5 minute timeout to 15 minutes.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence
Check the CI logs

## Why It's Good For The Game
Less of me having to kick workflows twenty times 