### PR TITLE
Lesser Mending Removed From Learnable Spells

### DIFF
--- a/code/modules/spells/spell_types/wizard/spell_list.dm
+++ b/code/modules/spells/spell_types/wizard/spell_list.dm
@@ -41,7 +41,7 @@ GLOBAL_LIST_INIT(learnable_spells, (list(/obj/effect/proc_holder/spell/invoked/p
 		/obj/effect/proc_holder/spell/invoked/giants_strength,
 		/obj/effect/proc_holder/spell/invoked/create_campfire,
 		/obj/effect/proc_holder/spell/invoked/mending,
-		/obj/effect/proc_holder/spell/invoked/mending/lesser, //Caustic Edit: For those who need to be cheap...
+//		/obj/effect/proc_holder/spell/invoked/mending/lesser, //Caustic Edit: For those who need to be cheap... // OV EDIT: Commented out from Learnables
 		/obj/effect/proc_holder/spell/self/light,
 		/obj/effect/proc_holder/spell/invoked/conjure_weapon,
 		/obj/effect/proc_holder/spell/self/conjure_armor,


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->
Struck down with a mighty hammer, may Malum suffer not the lesser craft

Comments Out Lesser Mending from the LEARNABLE spells list. This keeps it intact for the classes that get it gifted (heretic on summoning their deathcasket, iconoclast if we ever do anything with bandits to repair his golden arm) but otherwise prevents the spell from showing up. This removes it from ARCYNE POTENTIAL as a learnable option
## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->
<img width="780" height="455" alt="image" src="https://github.com/user-attachments/assets/0bb59a22-de7d-4aad-a446-55ebdf902dd9" />


## Why It's Good For The Game

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->
An option for Maintainers and Admins to consider. Arcyne Potential was recently adjusted with it's tool usage allowances, and this further removes it's ability to be the Best Repair Option in terms of virtue. This should open up more people using repair virtues like blacksmith's apprentice or failed squire, making use of repair kits, or visiting blacksmiths/tailors
<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
del: Commented Lesser Mending out of the learnable list
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
