### PR TITLE
Fix summoning runes sometimes leaving mobs immortal

### DIFF
--- a/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
+++ b/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
@@ -778,7 +778,7 @@ GLOBAL_LIST(teleport_runes)
 /obj/effect/decal/cleanable/roguerune/arcyne/summoning/Destroy()
 	if(summoning)
 		REMOVE_TRAIT(summoned_mob, TRAIT_PACIFISM, TRAIT_GENERIC)	//can't kill while planar bound.
-		summoned_mob.status_flags -= GODMODE//remove godmode
+		summoned_mob.status_flags &= ~GODMODE//remove godmode // OV Edit: Use bitflag operations
 		summoned_mob.candodge = TRUE
 		summoned_mob.binded = FALSE
 		summoned_mob.move_resist = MOVE_RESIST_DEFAULT
@@ -808,7 +808,7 @@ GLOBAL_LIST(teleport_runes)
 
 		animate(S, color = null, time = 5)
 		REMOVE_TRAIT(S, TRAIT_PACIFISM, TRAIT_GENERIC) // can't kill while planar bound.
-		S.status_flags -= GODMODE
+		S.status_flags &= ~GODMODE // OV Edit: this is a bitflag use bitflag ops
 		S.candodge = TRUE
 		S.binded = FALSE
 		S.move_resist = MOVE_RESIST_DEFAULT

--- a/code/modules/roguetown/roguejobs/mages/rituals/summons.dm
+++ b/code/modules/roguetown/roguejobs/mages/rituals/summons.dm
@@ -15,7 +15,7 @@
 	else
 		summoned = new mob_to_summon(loc)
 		ADD_TRAIT(summoned, TRAIT_PACIFISM, TRAIT_GENERIC)	//can't kill while planar bound.
-		summoned.status_flags += GODMODE//It's not meant to be killable until released from it's planar binding.
+		summoned.status_flags |= GODMODE//It's not meant to be killable until released from it's planar binding. // OV Edit: this is a bitflag use bitflag ops
 		summoned.candodge = FALSE
 		animate(summoned, color = "#ff0000",time = 5)
 		summoned.move_resist = MOVE_FORCE_EXTREMELY_STRONG


### PR DESCRIPTION
## About The Pull Request
So, if you double-clicked the rune by mistake and managed to triggered releasing twice, the mob's status_flags would become negative 8 and therefore give them godmode again!

This is because they were using += and -= instead of |= and &= for some reason, which isn't correct for bitflags.

## Developer's checklist
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence
I spam-clicked the rune and it didn't cause the bug

## Why It's Good For The Game
It sucks that mages occasionally have to get admin help to deal with their broken summosn

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Mage summons no longer can become stuck in godmode
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
