### PR TITLE
Item TF rune

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1751,6 +1751,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		str += "<b>[initial(S.name)]</b> and a hammer."
 	if(sewrepair)
 		str += "<b>Sewing</b> and a needle."
+	if(mob_possession)
+		str += "<br>There is something unusually <b>ALIVE</b> about this." //OV ADD
 	str = span_info(str)
 	. += str
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1751,7 +1751,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		str += "<b>[initial(S.name)]</b> and a hammer."
 	if(sewrepair)
 		str += "<b>Sewing</b> and a needle."
-	if(mob_possession)
+	if(mob_possession) // OV Add
 		str += "<br>There is something unusually <b>ALIVE</b> about this." //OV ADD
 	str = span_info(str)
 	. += str

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -277,6 +277,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	/// does this item/weapon circumvent two-stage death during dismemberment? (do not add this to anything but ultra rare shit)
 	var/vorpal = FALSE
 
+	var/mob/living/mob_possession = null //OV ADD
+
 /obj/item/Initialize()
 	. = ..()
 	if(!pixel_x && !pixel_y && !bigboy)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -155,6 +155,14 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	else if(stat == UNCONSCIOUS && !forced)
 		if(!(unconscious_allowed_modes[message_mode]))
 			return
+	
+	//OV edit
+	if(isitem(loc))
+		var/obj/item/the_item = loc
+		if(the_item.mob_possession == src)
+			the_item.say(message, message_mode = message_mode)
+			return
+	//OV edit end
 
 	// language comma detection.
 	var/datum/language/message_language = get_message_language(message)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -113,6 +113,14 @@
 	message = parsemarkdown_basic(message, limited = TRUE, barebones = TRUE)
 	if(check_subtler(message, FALSE))
 		return
+	//OV edit
+	if(isitem(loc))
+		var/obj/item/the_item = loc
+		if(the_item.mob_possession == src)
+			the_item.visible_message(span_italics("[the_item] [message]"), vision_distance = 7)
+			log_talk(message, LOG_EMOTE)
+			return
+	//OV edit end
 	usr.emote("me",1,message,TRUE, custom_me = TRUE)
 
 ///Speak as a dead person (ghost etc)
@@ -123,6 +131,15 @@
 ///Check if this message is an emote
 /mob/proc/check_emote(message, forced)
 	if(copytext_char(message, 1, 2) == "*")
+		//OV edit
+		if(isitem(loc) && (copytext_char(message, 1, 2) == "*"))
+			var/obj/item/the_item = loc
+			if(the_item.mob_possession == src)
+				message = copytext_char(message, 2)
+				the_item.visible_message("[the_item] [message]", vision_distance = 7)
+				log_talk(message, LOG_EMOTE)
+				return 1
+		//OV edit end
 		emote(copytext_char(message, 2), intentional = !forced, custom_me = TRUE)
 		return 1
 

--- a/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
+++ b/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
@@ -327,9 +327,10 @@ GLOBAL_LIST(teleport_runes)
 	desc = "subtype used for arcane rituals- you should not be seeing this."
 	magictype = "arcyne"
 	can_be_scribed = FALSE
+	var/require_mage_user = TRUE
 
 /obj/effect/decal/cleanable/roguerune/arcyne/attack_hand(mob/living/user)
-	if(!isarcyne(user))
+	if(!isarcyne(user) && require_mage_user)
 		to_chat(user, span_warning("You aren't able to understand the words of [src]."))
 		return
 	. = ..()

--- a/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
+++ b/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
@@ -327,10 +327,10 @@ GLOBAL_LIST(teleport_runes)
 	desc = "subtype used for arcane rituals- you should not be seeing this."
 	magictype = "arcyne"
 	can_be_scribed = FALSE
-	var/require_mage_user = TRUE
+	var/require_mage_user = TRUE // OV Add
 
 /obj/effect/decal/cleanable/roguerune/arcyne/attack_hand(mob/living/user)
-	if(!isarcyne(user) && require_mage_user)
+	if(!isarcyne(user) && require_mage_user) // OV Edit: require_mage_user
 		to_chat(user, span_warning("You aren't able to understand the words of [src]."))
 		return
 	. = ..()

--- a/modular/code/modules/living/say.dm
+++ b/modular/code/modules/living/say.dm
@@ -1,5 +1,12 @@
 /mob/proc/check_subtler(message, forced)
 	//OV edit
+	if(isitem(loc) && (copytext_char(message, 1, 2) == "@"))
+		var/obj/item/the_item = loc
+		if(the_item.mob_possession == src)
+			message = copytext_char(message, 2)
+			the_item.visible_message(span_italics("[the_item] [message]"), vision_distance = 1)
+			log_talk(message, LOG_EMOTE)
+			return 1
 	if(muffled && (copytext_char(message, 1, 2) == "*")) //muffled by belly but trying to emote
 		emote("subtle", message = copytext_char(message, 2), intentional = !forced, custom_me = TRUE)
 		return 1

--- a/modular_causticcove/code/modules/vore/eating/digest_act_vr.dm
+++ b/modular_causticcove/code/modules/vore/eating/digest_act_vr.dm
@@ -85,9 +85,8 @@
 		//Allow those turned into items to become the recycled item
 		//OV edit
 		if(mob_possession)
-			var/mob/dead/observer/G = mob_possession.ghostize(0)
-			if(G)
-				G.vore_death = TRUE
+			B.digestion_death(mob_possession)
+			mob_possession = null
 		//OV edit end
 		/*var/recycled = B?.recycle(src)
 		if(!recycled) //Caustic - Recycle-based Vore Code Item Handling here

--- a/modular_causticcove/code/modules/vore/eating/digest_act_vr.dm
+++ b/modular_causticcove/code/modules/vore/eating/digest_act_vr.dm
@@ -6,6 +6,12 @@
 /obj/item/proc/digest_act(atom/movable/item_storage = null, touchable_amount, splashing = 0)
 	if(!digestable)
 		return FALSE
+	
+	//OV edit
+	if(mob_possession)
+		if(!mob_possession.digestable)
+			return FALSE
+	//OV edit end
 
 	var/g_damage = 1
 	if(digest_stage == null)
@@ -77,6 +83,12 @@
 			soundfile = pick('modular_causticcove/sound/cvore/vore/shortgurgles/gurgle_s1.ogg', 'modular_causticcove/sound/cvore/vore/shortgurgles/gurgle_s2.ogg', 'modular_causticcove/sound/cvore/vore/shortgurgles/gurgle_s3.ogg')
 		playsound(src, soundfile, vol = g_sound_volume, vary = 1, falloff = VORE_SOUND_FALLOFF, frequency = noise_freq, preference = "eating_noises")
 		//Allow those turned into items to become the recycled item
+		//OV edit
+		if(mob_possession)
+			var/mob/dead/observer/G = mob_possession.ghostize(0)
+			if(G)
+				G.vore_death = TRUE
+		//OV edit end
 		/*var/recycled = B?.recycle(src)
 		if(!recycled) //Caustic - Recycle-based Vore Code Item Handling here
 			for(var/mob/living/voice/V in possessed_voice) // Delete voices.

--- a/modular_causticcove/code/modules/vore/eating/living_vr.dm
+++ b/modular_causticcove/code/modules/vore/eating/living_vr.dm
@@ -823,6 +823,13 @@
 	if(!I)
 		to_chat(src, span_notice("You are not holding anything."))
 		return
+	
+	//OV edit
+	if(I.mob_possession)
+		if(!I.mob_possession.devourable)
+			to_chat(src, span_notice("Their preferences do not allow them to be eaten."))
+			return
+	//OV edit end
 
 	//if(I.) //Caustic - Potential Whitelist can go here.
 

--- a/modular_ochrevalley/code/modules/admin/player_effects.dm
+++ b/modular_ochrevalley/code/modules/admin/player_effects.dm
@@ -199,7 +199,40 @@
 				return
 			target.overlay_fullscreen("scrolls", /atom/movable/screen/fullscreen/scrolls, 1)
 			addtimer(CALLBACK(target, TYPE_PROC_REF(/mob, clear_fullscreen), "scrolls"), 20 SECONDS)
-				
+		
+		if("item_tf")
+			var/mob/living/M = target
+
+			if(!istype(M))
+				return
+
+			if(!M.ckey)
+				return
+			
+			var/target_path = input(ui.user, "Enter typepath:", "Typepath", "/obj/structure/closet")
+			var/objholder = text2path(target_path)
+			if(!ispath(objholder))
+				objholder = pick_closest_path(target_path)
+				if(!objholder)
+					alert("No path was selected")
+					return
+				else if(!ispath(objholder, /obj/item))
+					objholder = null
+					alert("That path is not allowed.")
+					return
+
+			var/obj/item/spawning = objholder
+
+			to_chat(ui.user,span_warning("spawning is: [spawning]"))
+
+			if(!ispath(spawning, /obj/item/))
+				to_chat(ui.user,span_warning("Can only spawn items."))
+				return
+
+			var/obj/item/spawned_obj = new spawning(M.loc)
+
+			spawned_obj.mob_possession = M
+			M.forceMove(spawned_obj)
 
 
 		/*
@@ -449,27 +482,7 @@
 
 			M.tf_into(new_mob)
 
-		if("item_tf")
-			var/mob/living/M = target
-
-			if(!istype(M))
-				return
-
-			if(!M.ckey)
-				return
-
-			var/obj/item/spawning = ui.user.client.get_path_from_partial_text()
-
-			to_chat(ui.user,span_warning("spawning is: [spawning]"))
-
-			if(!ispath(spawning, /obj/item/))
-				to_chat(ui.user,span_warning("Can only spawn items."))
-				return
-
-			var/obj/item/spawned_obj = new spawning(M.loc)
-			var/obj/item/original_name = spawned_obj.name
-
-			M.tf_into(spawned_obj, TRUE, original_name)
+		
 
 		if("elder_smite")
 			if(!target.ckey)

--- a/modular_ochrevalley/code/modules/roguetown/roguejobs/mages/item_tf.dm
+++ b/modular_ochrevalley/code/modules/roguetown/roguejobs/mages/item_tf.dm
@@ -1,0 +1,107 @@
+/obj/effect/decal/cleanable/roguerune/arcyne/item_tf
+	name = "Consolidation rune"
+	desc = "arcane symbols pulse upon the ground..."
+	icon_state = "6"
+	invocation = "Materia Unita!"
+	color = "#a0d145"
+	spellbonus = 15
+	scribe_damage = 10
+	can_be_scribed = TRUE
+	rituals = list(/datum/runeritual/item_tf::name = /datum/runeritual/item_tf)
+
+/obj/effect/decal/cleanable/roguerune/arcyne/item_tf/invoke(list/invokers, datum/runeritual/runeritual)
+	if(!..())	//VERY important. Calls parent and checks if it fails. parent/invoke has all the checks for ingredients
+		return
+//	if(!buffed)
+	var/list/items_to_use = list()
+	var/list/humans_to_use = list()
+	for(var/atom/close_atom as anything in range(0, src))
+		if(!ismovable(close_atom))
+			continue
+		if(close_atom == src)
+			continue
+		if(close_atom.invisibility)
+			continue
+		if(close_atom == usr)
+			continue
+		if(isitem(close_atom))
+			var/obj/item/close_item = close_atom
+			if(close_item.item_flags & ABSTRACT) //woops sacrificed your own head
+				continue
+			items_to_use += close_atom
+		if(ishuman(close_atom))
+			humans_to_use += close_atom
+
+	/*
+	for(var/i in items_to_use)
+		message_admins("[i] in items_to_use")
+	for(var/i in humans_to_use)
+		message_admins("[i] in humans_to_use")
+	*/
+	
+	if(items_to_use.len != 1)
+		for(var/atom/invoker in invokers)
+			if(!isliving(invoker))
+				continue
+			var/mob/living/living_invoker = invoker
+			to_chat(living_invoker, "There must be a single item on the rune to consolidate!")
+		return
+	
+	var/obj/item/the_item
+	for(var/obj/item/our_item in items_to_use)
+		the_item = our_item
+	
+	if(the_item.mob_possession)
+		if(the_item.mob_possession in the_item.contents)
+			var/our_loc = get_turf(the_item)
+			the_item.mob_possession.forceMove(our_loc)
+			visible_message(src, span_warning("[the_item.mob_possession] is separated from [the_item]!"))
+		the_item.mob_possession = null
+		return
+
+	if(humans_to_use.len != 1)
+		for(var/atom/invoker in invokers)
+			if(!isliving(invoker))
+				continue
+			var/mob/living/living_invoker = invoker
+			to_chat(living_invoker, "There must be a single humen on the rune to consolidate!")
+		return
+
+	var/mob/living/the_mob
+	for(var/mob/living/our_mob in humans_to_use)
+		the_mob = our_mob
+
+	if(!the_mob.allow_spontaneous_tf || !the_mob.client) //Don't allow pref breaks or mobs without clients to avoid powergaming.
+		for(var/atom/invoker in invokers)
+			if(!isliving(invoker))
+				continue
+			var/mob/living/living_invoker = invoker
+			to_chat(living_invoker, "The rune fails to invoke as [the_mob]'s lux refuses to combine with [the_item].")
+		return
+	
+	the_item.mob_possession = the_mob
+	the_mob.forceMove(the_item)
+	visible_message(src, span_warning("[the_mob] is merged into [the_item]!"))
+
+	if(ritual_result)
+		pickritual.cleanup_atoms(selected_atoms)
+	invoke_cleanup()
+
+	for(var/atom/invoker in invokers)
+		if(!isliving(invoker))
+			continue
+		var/mob/living/living_invoker = invoker
+		if(invocation)
+			living_invoker.say(invocation, language = /datum/language/common, ignore_spam = TRUE, forced = "cult invocation")
+		if(invoke_damage)
+			living_invoker.apply_damage(invoke_damage, BRUTE)
+			to_chat(living_invoker,  span_italics("[src] saps your strength!"))
+	do_invoke_glow()
+
+/datum/runeritual/item_tf
+	name = "Merge lux with object"
+	tier = 1
+	blacklisted = FALSE
+
+/datum/runeritual/item_tf/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
+	return TRUE

--- a/modular_ochrevalley/code/modules/roguetown/roguejobs/mages/item_tf.dm
+++ b/modular_ochrevalley/code/modules/roguetown/roguejobs/mages/item_tf.dm
@@ -8,6 +8,7 @@
 	scribe_damage = 10
 	can_be_scribed = TRUE
 	rituals = list(/datum/runeritual/item_tf::name = /datum/runeritual/item_tf)
+	require_mage_user = FALSE
 
 /obj/effect/decal/cleanable/roguerune/arcyne/item_tf/get_mechanics_examine(mob/user)
 	. = ..()

--- a/modular_ochrevalley/code/modules/roguetown/roguejobs/mages/item_tf.dm
+++ b/modular_ochrevalley/code/modules/roguetown/roguejobs/mages/item_tf.dm
@@ -9,6 +9,12 @@
 	can_be_scribed = TRUE
 	rituals = list(/datum/runeritual/item_tf::name = /datum/runeritual/item_tf)
 
+/obj/effect/decal/cleanable/roguerune/arcyne/item_tf/get_mechanics_examine(mob/user)
+	. = ..()
+	. += span_info("Use the rune with ONE item and ONE humen on it to merge the humen into the item.")
+	. += span_info("This can be reversed by putting the possessed item back onto the rune and using it again.")
+	. += span_info("Be wary that destroying the item in any way (including using it in crafting) will KILL the mob inside.")
+
 /obj/effect/decal/cleanable/roguerune/arcyne/item_tf/invoke(list/invokers, datum/runeritual/runeritual)
 	if(!..())	//VERY important. Calls parent and checks if it fails. parent/invoke has all the checks for ingredients
 		return

--- a/modular_ochrevalley/code/ooc_escape.dm
+++ b/modular_ochrevalley/code/ooc_escape.dm
@@ -17,6 +17,10 @@
 	var/atom/where = loc
 	var/msg = "has OOC escaped. "
 	forceMove(get_turf(src))
+	if(isitem(where))
+		var/obj/item/the_loc = where
+		if(the_loc.mob_possession)
+			the_loc.mob_possession = null
 	if(isbelly(where))	//For vore
 		if(pulledby)
 			pulledby.stop_pulling()

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3252,6 +3252,7 @@
 #include "modular_ochrevalley\code\datums\stress\negative_events.dm"
 #include "modular_ochrevalley\code\datums\loadout\loadout_accessories.dm"
 #include "modular_ochrevalley\code\datums\loadout\loadout_miscellaneous.dm"
+#include "modular_ochrevalley\code\modules\roguetown\roguejobs\mages\item_tf.dm"
 #include "modular_ochrevalley\code\datums\loadout\loadout_hats.dm"
 #include "modular_ochrevalley\code\modules\admin\give_buff.dm"
 #include "modular_ochrevalley\code\modules\admin\player_effects.dm"

--- a/tgui/packages/tgui/interfaces/PlayerEffects/PlayerEffectsTabs/ControlSmites.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerEffects/PlayerEffectsTabs/ControlSmites.tsx
@@ -46,6 +46,9 @@ export const ControlSmites = (props) => {
       <Button fluid onClick={() => act('elder_smite')}>
         Elder Smite
       </Button>
+      <Button fluid onClick={() => act('item_tf')}>
+        Item TF
+      </Button>
     </Section>
   );
 };


### PR DESCRIPTION


## About The Pull Request

Added a new item TF rune called the consolidation rune, created by chalk and is a tier 1 arcyne rune (so anyone with a bit of arcyne can use it).

The current functionality that is all tested and working:
- It requires ONE object and ONE humen to stand on the rune when activated by another player.
- You can not activate it on yourself currently.
- The humen MUST have a client and MUST have spont TF pref enabled.
- They can be escaped via OOC Escape.
- You can separate them again by placing the possessed item onto the rune and using the rune again.
- All says, emotes and subtles now come from the item and not the person inside it (eg, it will say The Stone Knife instead the players name).
- If the item is completely destroyed, the person inside of it will die.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Currently all features listed seem to work well!

## Why It's Good For The Game

Big kink for a lot of people and works well in a high magic setting.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added a new item TF rune called the consolidation rune, created by chalk and is a tier 1 arcyne rune (so anyone with a bit of arcyne can use it).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
