### PR TITLE
Angels n' Demons, Tails n' Wings

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
@@ -67,6 +67,9 @@
 		/datum/customizer/organ/belly/human,
 		/datum/customizer/organ/butt/human,
 		//Caustic edit end
+		// OV Edit start
+		/datum/customizer/organ/tail/demihuman,
+		// OV Edit End
 		)
 	body_marking_sets = list(
 		/datum/body_marking_set/none,

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
@@ -90,6 +90,9 @@
 		/datum/customizer/organ/belly/human,
 		/datum/customizer/organ/butt/human,
 		//Caustic edit end
+		// OV Edit start
+		/datum/customizer/organ/wings/anthro,
+		// OV Edit End
 		)
 	body_marking_sets = list(
 		/datum/body_marking_set/none,


### PR DESCRIPTION
## About The Pull Request
Allows aasimar to have tails, and tieflings to have wings.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence
<img width="478" height="217" alt="image" src="https://github.com/user-attachments/assets/dc50ef58-074d-4d88-8055-f94e5d790971" />
<img width="455" height="207" alt="image" src="https://github.com/user-attachments/assets/6e64605e-466b-4432-951d-72c5663bfc3c" />


## Why It's Good For The Game
more customization

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Tieflings can now have wings
add: Aasimar can now have tails
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
