### PR TITLE
Replacing the 'View' functionality in the Character Directory with the Examine Closer Panel

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2916,8 +2916,8 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 						directory_pvp = new_choice
 				if("directory_ad")
 					var/new_dir_ad = tgui_input_text(user, "Input an ad for your style of ERP to show in the character directory:", "Directory Ad", directory_ad, multiline = TRUE,  encode = FALSE, bigmodal = TRUE)
-					if(new_dir_ad)
-						directory_ad = new_dir_ad
+					if(!isnull(new_dir_ad))
+						set_character_ad_value(ishuman(user) ? user : null, src, user?.mind, new_dir_ad)
 				
 				//OV edit end
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2916,10 +2916,10 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 						directory_pvp = new_choice
 				if("directory_ad")
 					var/new_dir_ad = tgui_input_text(user, "Input an ad for your style of ERP to show in the character directory:", "Directory Ad", directory_ad, multiline = TRUE,  encode = FALSE, bigmodal = TRUE)
-					// OV changes
+					// OV Edit Start
 					if(!isnull(new_dir_ad))
 						set_character_ad_value(ishuman(user) ? user : null, src, user?.mind, new_dir_ad)
-					// OV changes
+					// OV Edit End
 				
 				//OV edit end
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2916,8 +2916,10 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 						directory_pvp = new_choice
 				if("directory_ad")
 					var/new_dir_ad = tgui_input_text(user, "Input an ad for your style of ERP to show in the character directory:", "Directory Ad", directory_ad, multiline = TRUE,  encode = FALSE, bigmodal = TRUE)
+					// OV changes
 					if(!isnull(new_dir_ad))
 						set_character_ad_value(ishuman(user) ? user : null, src, user?.mind, new_dir_ad)
+					// OV changes
 				
 				//OV edit end
 

--- a/code/modules/mob/living/carbon/human/examine_tgui.dm
+++ b/code/modules/mob/living/carbon/human/examine_tgui.dm
@@ -7,6 +7,7 @@
 	var/datum/preferences/pref = null
 
 	var/is_playing = FALSE
+	var/open_character_ad_on_open = FALSE
 
 	var/mob/viewing
 
@@ -33,6 +34,36 @@
 	if(!ui)
 		ui = new(user, src, "ExaminePanel")
 		ui.open()
+
+/datum/examine_panel/proc/get_character_ad()
+	if(ishuman(holder))
+		var/raw_character_ad = holder.client?.prefs?.directory_ad
+		if(isnull(raw_character_ad))
+			raw_character_ad = holder.mind?.directory_ad
+		if(raw_character_ad)
+			return parsemarkdown_basic(html_encode(raw_character_ad), hyperlink = TRUE)
+	else if(pref?.directory_ad)
+		return parsemarkdown_basic(html_encode(pref.directory_ad), hyperlink = TRUE)
+
+	return ""
+
+/proc/refresh_character_ad_examine_panels(mob/living/carbon/human/holder_mob, datum/preferences/holder_prefs, datum/mind/holder_mind)
+	for(var/datum/tgui/ui as anything in SStgui.all_uis)
+		if(!istype(ui?.src_object, /datum/examine_panel))
+			continue
+
+		var/datum/examine_panel/panel = ui.src_object
+		var/panel_matches_character = FALSE
+
+		if(holder_mob && panel.holder == holder_mob)
+			panel_matches_character = TRUE
+		else if(holder_prefs && (panel.pref == holder_prefs || panel.holder?.client?.prefs == holder_prefs))
+			panel_matches_character = TRUE
+		else if(holder_mind && panel.holder?.mind == holder_mind)
+			panel_matches_character = TRUE
+
+		if(panel_matches_character)
+			ui.send_update()
 
 /datum/examine_panel/familiar/ui_static_data(mob/user) //altered and condensed version used for familiars. sorry
 
@@ -87,7 +118,9 @@
 
 /datum/examine_panel/familiar/ui_data(mob/user)
 	var/list/data = list( 
+		"character_ad" = "",
 		"is_playing" = is_playing,
+		"start_with_character_ad" = FALSE,
 	)
 	return data
 
@@ -195,7 +228,9 @@
 
 /datum/examine_panel/ui_data(mob/user)
 	var/list/data = list(
+		"character_ad" = get_character_ad(),
 		"is_playing" = is_playing,
+		"start_with_character_ad" = open_character_ad_on_open,
 	)
 	return data
 

--- a/code/modules/mob/living/carbon/human/examine_tgui.dm
+++ b/code/modules/mob/living/carbon/human/examine_tgui.dm
@@ -7,9 +7,9 @@
 	var/datum/preferences/pref = null
 
 	var/is_playing = FALSE
-	// OV changes
+	// OV Edit Start
 	var/open_character_ad_on_open = FALSE
-	// OV changes
+	// OV Edit End
 
 	var/mob/viewing
 
@@ -37,7 +37,7 @@
 		ui = new(user, src, "ExaminePanel")
 		ui.open()
 
-// OV changes
+// OV Edit Start
 /datum/examine_panel/proc/get_character_ad()
 	if(ishuman(holder))
 		var/raw_character_ad = holder.client?.prefs?.directory_ad
@@ -67,7 +67,7 @@
 
 		if(panel_matches_character)
 			ui.send_update()
-// OV changes
+// OV Edit End
 
 /datum/examine_panel/familiar/ui_static_data(mob/user) //altered and condensed version used for familiars. sorry
 
@@ -122,11 +122,11 @@
 
 /datum/examine_panel/familiar/ui_data(mob/user)
 	var/list/data = list( 
-		// OV changes
+		// OV Edit Start
 		"character_ad" = "",
 		"is_playing" = is_playing,
 		"start_with_character_ad" = FALSE,
-		// OV changes
+		// OV Edit End
 	)
 	return data
 
@@ -234,11 +234,11 @@
 
 /datum/examine_panel/ui_data(mob/user)
 	var/list/data = list(
-		// OV changes
+		// OV Edit Start
 		"character_ad" = get_character_ad(),
 		"is_playing" = is_playing,
 		"start_with_character_ad" = open_character_ad_on_open,
-		// OV changes
+		// OV Edit End
 	)
 	return data
 

--- a/code/modules/mob/living/carbon/human/examine_tgui.dm
+++ b/code/modules/mob/living/carbon/human/examine_tgui.dm
@@ -7,7 +7,9 @@
 	var/datum/preferences/pref = null
 
 	var/is_playing = FALSE
+	// OV changes
 	var/open_character_ad_on_open = FALSE
+	// OV changes
 
 	var/mob/viewing
 
@@ -35,6 +37,7 @@
 		ui = new(user, src, "ExaminePanel")
 		ui.open()
 
+// OV changes
 /datum/examine_panel/proc/get_character_ad()
 	if(ishuman(holder))
 		var/raw_character_ad = holder.client?.prefs?.directory_ad
@@ -64,6 +67,7 @@
 
 		if(panel_matches_character)
 			ui.send_update()
+// OV changes
 
 /datum/examine_panel/familiar/ui_static_data(mob/user) //altered and condensed version used for familiars. sorry
 
@@ -118,9 +122,11 @@
 
 /datum/examine_panel/familiar/ui_data(mob/user)
 	var/list/data = list( 
+		// OV changes
 		"character_ad" = "",
 		"is_playing" = is_playing,
 		"start_with_character_ad" = FALSE,
+		// OV changes
 	)
 	return data
 
@@ -228,9 +234,11 @@
 
 /datum/examine_panel/ui_data(mob/user)
 	var/list/data = list(
+		// OV changes
 		"character_ad" = get_character_ad(),
 		"is_playing" = is_playing,
 		"start_with_character_ad" = open_character_ad_on_open,
+		// OV changes
 	)
 	return data
 

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -228,6 +228,7 @@ Hotkey-Mode: (hotkey-mode must be on)
 		if(!ishuman(mob))
 			return
 		var/mob/living/carbon/human/C = mob
+		// OV changes
 		var/current_ad = get_character_ad_value(C, C.client?.prefs, C.mind)
 		if(current_ad)
 			to_chat(C, span_info(current_ad))
@@ -235,11 +236,14 @@ Hotkey-Mode: (hotkey-mode must be on)
 		if(isnull(msg))
 			return
 		set_character_ad_value(C, C.client?.prefs, C.mind, msg, TRUE)
+		// OV changes
 		if(msg)
 			to_chat(C, span_info("Roleplay ad set."))
 			log_game("[C] has set their Roleplay Ad to '[msg]'.")
+		// OV changes
 		else
 			to_chat(C, span_info("Roleplay ad removed."))
+		// OV changes
 
 /client/verb/changefps()
 	set category = "Options"

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -228,21 +228,17 @@ Hotkey-Mode: (hotkey-mode must be on)
 		if(!ishuman(mob))
 			return
 		var/mob/living/carbon/human/C = mob
-		var/has_old_ad = FALSE
-		if(LAZYACCESS(GLOB.roleplay_ads,C.mobid))
-			to_chat(C, span_info(LAZYACCESS(GLOB.roleplay_ads,C.mobid)))
-			has_old_ad = TRUE
-		var/msg = input("Set an advertisement for what kind of roleplay you are looking to engage in. Others will be able to see it with the Roleplay Ad (View) command. Do not abuse this. Leave empty and press OK to remove your roleplay ad.", "I LOVE TO ROLEPLAY") as message|null
+		var/current_ad = get_character_ad_value(C, C.client?.prefs, C.mind)
+		if(current_ad)
+			to_chat(C, span_info(current_ad))
+		var/msg = input("Set an advertisement for what kind of roleplay you are looking to engage in. Others will be able to see it with the Roleplay Ad (View) command. Do not abuse this. Leave empty and press OK to remove your roleplay ad.", "I LOVE TO ROLEPLAY", current_ad) as message|null
+		if(isnull(msg))
+			return
+		set_character_ad_value(C, C.client?.prefs, C.mind, msg, TRUE)
 		if(msg)
-			LAZYSET(GLOB.roleplay_ads,C.mobid,"<b>[C.real_name]</b> - [msg]<BR>")
 			to_chat(C, span_info("Roleplay ad set."))
 			log_game("[C] has set their Roleplay Ad to '[msg]'.")
-			for(var/client/advertisee in (GLOB.clients - src))
-				if(!(advertisee.prefs.toggles & ROLEPLAY_ADS))
-					continue
-				to_chat(advertisee, span_info("[C.real_name] has set a roleplay ad."))
-		else if(has_old_ad)
-			LAZYREMOVE(GLOB.roleplay_ads,C.mobid)
+		else
 			to_chat(C, span_info("Roleplay ad removed."))
 
 /client/verb/changefps()

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -228,7 +228,7 @@ Hotkey-Mode: (hotkey-mode must be on)
 		if(!ishuman(mob))
 			return
 		var/mob/living/carbon/human/C = mob
-		// OV changes
+		// OV Edit Start
 		var/current_ad = get_character_ad_value(C, C.client?.prefs, C.mind)
 		if(current_ad)
 			to_chat(C, span_info(current_ad))
@@ -236,14 +236,12 @@ Hotkey-Mode: (hotkey-mode must be on)
 		if(isnull(msg))
 			return
 		set_character_ad_value(C, C.client?.prefs, C.mind, msg, TRUE)
-		// OV changes
 		if(msg)
 			to_chat(C, span_info("Roleplay ad set."))
 			log_game("[C] has set their Roleplay Ad to '[msg]'.")
-		// OV changes
 		else
 			to_chat(C, span_info("Roleplay ad removed."))
-		// OV changes
+		// OV Edit End
 
 /client/verb/changefps()
 	set category = "Options"

--- a/modular_ochrevalley/code/datums/loadout/mind_ov.dm
+++ b/modular_ochrevalley/code/datums/loadout/mind_ov.dm
@@ -19,7 +19,5 @@
 		mind.directory_gendertag = client.prefs.directory_gendertag
 		mind.directory_sexualitytag = client.prefs.directory_sexualitytag
 		mind.directory_pvp = client.prefs.directory_pvp
-		// OV changes
 		if(ishuman(src))
 			set_character_ad_value(src, client.prefs, mind, client.prefs.directory_ad)
-		// OV changes

--- a/modular_ochrevalley/code/datums/loadout/mind_ov.dm
+++ b/modular_ochrevalley/code/datums/loadout/mind_ov.dm
@@ -19,3 +19,5 @@
 		mind.directory_gendertag = client.prefs.directory_gendertag
 		mind.directory_sexualitytag = client.prefs.directory_sexualitytag
 		mind.directory_pvp = client.prefs.directory_pvp
+		if(ishuman(src))
+			set_character_ad_value(src, client.prefs, mind, client.prefs.directory_ad)

--- a/modular_ochrevalley/code/datums/loadout/mind_ov.dm
+++ b/modular_ochrevalley/code/datums/loadout/mind_ov.dm
@@ -19,5 +19,7 @@
 		mind.directory_gendertag = client.prefs.directory_gendertag
 		mind.directory_sexualitytag = client.prefs.directory_sexualitytag
 		mind.directory_pvp = client.prefs.directory_pvp
+		// OV changes
 		if(ishuman(src))
 			set_character_ad_value(src, client.prefs, mind, client.prefs.directory_ad)
+		// OV changes

--- a/modular_ochrevalley/code/modules/client/verbs/character_directory.dm
+++ b/modular_ochrevalley/code/modules/client/verbs/character_directory.dm
@@ -5,7 +5,6 @@ GLOBAL_LIST_INIT(char_directory_sexualitytags, list("Straight", "Bisexual", "Pan
 GLOBAL_LIST_INIT(char_directory_gendertags, list("Male", "Female", "Feminine", "Masculine", "Nonbinary", "Trans Man", "Trans Woman", "Other", "Flexible", "Ungendered", "Unset"))
 GLOBAL_LIST_INIT(char_directory_pvp, list("No PvP", "Ask First", "Open to PvP"))
 
-// OV changes
 /proc/get_character_ad_value(mob/living/carbon/human/character, datum/preferences/prefs, datum/mind/mind)
 	var/current_ad = prefs?.directory_ad
 	if(isnull(current_ad))
@@ -36,7 +35,6 @@ GLOBAL_LIST_INIT(char_directory_pvp, list("No PvP", "Ask First", "Open to PvP"))
 			LAZYREMOVE(GLOB.roleplay_ads, character.mobid)
 
 	refresh_character_ad_examine_panels(character, prefs || character?.client?.prefs, mind || character?.mind)
-// OV changes
 
 /client/verb/show_character_directory()
 	set name = "Character Directory"
@@ -133,18 +131,14 @@ GLOBAL_LIST_EMPTY(chardirectory_photos)
 		if (C.mob?.mind) //could use ternary for all three but this is more efficient
 			tag = C.mob.mind.directory_tag || "Unset"
 			erptag = C.mob.mind.directory_erptag || "Unset"
-			// OV changes
 			character_ad = get_character_ad_value(C.mob, C.prefs, C.mob.mind)
-			// OV changes
 			gendertag = C.mob.mind.directory_gendertag || "Unset"
 			sexualitytag = C.mob.mind.directory_sexualitytag || "Unset"
 			pvp = C.mob.mind.directory_pvp || "No PvP"
 		else
 			tag = C.prefs.directory_tag || "Unset"
 			erptag = C.prefs.directory_erptag || "Unset"
-			// OV changes
 			character_ad = get_character_ad_value(null, C.prefs, null)
-			// OV changes
 			gendertag = C.prefs.directory_gendertag || "Unset"
 			sexualitytag = C.prefs.directory_sexualitytag || "Unset"
 			pvp = C.prefs.directory_pvp || "No PvP"
@@ -195,15 +189,11 @@ GLOBAL_LIST_EMPTY(chardirectory_photos)
 		// But if we can't find the name, they must be using a non-compatible mob type currently.
 		if(!name)
 			continue
-		// OV changes
 		if(character_ad)
 			character_ad = parsemarkdown_basic(html_encode(character_ad), hyperlink = TRUE)
-		// OV changes
 
 		directory_mobs.Add(list(list(
-			// OV changes
 			"ckey" = C.ckey,
-			// OV changes
 			"name" = name,
 			"species" = species,
 			"ooc_notes_favs" = ooc_notes_favs,
@@ -245,14 +235,11 @@ GLOBAL_LIST_EMPTY(chardirectory_photos)
 		*/
 		update_ui_static_data(ui.user, ui)
 		return TRUE
-	// OV changes
 	else if(action == "openExamine")
 		return open_character_examine(ui.user, params["ckey"], params["open_ad"])
-	// OV changes
 	else
 		return check_for_mind_or_prefs(ui.user, action, params["overwrite_prefs"])
 
-// OV changes
 /datum/character_directory/proc/open_character_examine(mob/user, target_ckey, open_ad = FALSE)
 	if(!user || !target_ckey)
 		return FALSE
@@ -277,7 +264,6 @@ GLOBAL_LIST_EMPTY(chardirectory_photos)
 	character_examine_panel.viewing = user
 	character_examine_panel.ui_interact(user)
 	return TRUE
-// OV changes
 
 /datum/character_directory/proc/check_for_mind_or_prefs(mob/user, action, overwrite_prefs)
 	if (!user.client)
@@ -313,9 +299,7 @@ GLOBAL_LIST_EMPTY(chardirectory_photos)
 			to_chat(user, span_notice("You are now [!visible ? "shown" : "not shown"] in the directory."))
 			return set_for_mind_or_prefs(user, action, !visible, can_set_prefs, can_set_mind)
 		if ("editAd")
-			// OV changes
 			var/current_ad = get_character_ad_value(user, can_set_prefs ? user.client.prefs : null, can_set_mind ? user.mind : null)
-			// OV changes
 			var/new_ad = tgui_input_text(user, "Change your character ad", "Character Ad", current_ad, MAX_MESSAGE_LEN, TRUE, prevent_enter = TRUE)
 			if(isnull(new_ad))
 				return
@@ -357,9 +341,7 @@ GLOBAL_LIST_EMPTY(chardirectory_photos)
 				user.mind.show_in_directory = new_value
 			return TRUE
 		if ("editAd")
-			// OV changes
 			set_character_ad_value(user, can_set_prefs ? user.client.prefs : null, can_set_mind ? user.mind : null, new_value)
-			// OV changes
 			return TRUE
 		if ("setGenderTag")
 			if (can_set_prefs)

--- a/modular_ochrevalley/code/modules/client/verbs/character_directory.dm
+++ b/modular_ochrevalley/code/modules/client/verbs/character_directory.dm
@@ -5,6 +5,37 @@ GLOBAL_LIST_INIT(char_directory_sexualitytags, list("Straight", "Bisexual", "Pan
 GLOBAL_LIST_INIT(char_directory_gendertags, list("Male", "Female", "Feminine", "Masculine", "Nonbinary", "Trans Man", "Trans Woman", "Other", "Flexible", "Ungendered", "Unset"))
 GLOBAL_LIST_INIT(char_directory_pvp, list("No PvP", "Ask First", "Open to PvP"))
 
+/proc/get_character_ad_value(mob/living/carbon/human/character, datum/preferences/prefs, datum/mind/mind)
+	var/current_ad = prefs?.directory_ad
+	if(isnull(current_ad))
+		current_ad = mind?.directory_ad
+	if(isnull(current_ad))
+		current_ad = character?.client?.prefs?.directory_ad
+	if(isnull(current_ad))
+		current_ad = character?.mind?.directory_ad
+	return current_ad
+
+/proc/set_character_ad_value(mob/living/carbon/human/character, datum/preferences/prefs, datum/mind/mind, new_value, notify_roleplay_viewers = FALSE)
+	if(prefs)
+		prefs.directory_ad = new_value
+	if(mind)
+		mind.directory_ad = new_value
+
+	if(character)
+		if(new_value)
+			var/formatted_ad = parsemarkdown_basic(html_encode(new_value), hyperlink = TRUE)
+			LAZYSET(GLOB.roleplay_ads, character.mobid, "<b>[html_encode(character.real_name)]</b> - [formatted_ad]<BR>")
+
+			if(notify_roleplay_viewers)
+				for(var/client/advertisee in (GLOB.clients - character.client))
+					if(!(advertisee.prefs.toggles & ROLEPLAY_ADS))
+						continue
+					to_chat(advertisee, span_info("[character.real_name] has set a roleplay ad."))
+		else
+			LAZYREMOVE(GLOB.roleplay_ads, character.mobid)
+
+	refresh_character_ad_examine_panels(character, prefs || character?.client?.prefs, mind || character?.mind)
+
 /client/verb/show_character_directory()
 	set name = "Character Directory"
 	set category = "OOC"
@@ -100,14 +131,14 @@ GLOBAL_LIST_EMPTY(chardirectory_photos)
 		if (C.mob?.mind) //could use ternary for all three but this is more efficient
 			tag = C.mob.mind.directory_tag || "Unset"
 			erptag = C.mob.mind.directory_erptag || "Unset"
-			character_ad = C.mob.mind.directory_ad
+			character_ad = get_character_ad_value(C.mob, C.prefs, C.mob.mind)
 			gendertag = C.mob.mind.directory_gendertag || "Unset"
 			sexualitytag = C.mob.mind.directory_sexualitytag || "Unset"
 			pvp = C.mob.mind.directory_pvp || "No PvP"
 		else
 			tag = C.prefs.directory_tag || "Unset"
 			erptag = C.prefs.directory_erptag || "Unset"
-			character_ad = C.prefs.directory_ad
+			character_ad = get_character_ad_value(null, C.prefs, null)
 			gendertag = C.prefs.directory_gendertag || "Unset"
 			sexualitytag = C.prefs.directory_sexualitytag || "Unset"
 			pvp = C.prefs.directory_pvp || "No PvP"
@@ -158,6 +189,8 @@ GLOBAL_LIST_EMPTY(chardirectory_photos)
 		// But if we can't find the name, they must be using a non-compatible mob type currently.
 		if(!name)
 			continue
+		if(character_ad)
+			character_ad = parsemarkdown_basic(html_encode(character_ad), hyperlink = TRUE)
 
 		directory_mobs.Add(list(list(
 			"ckey" = C.ckey,
@@ -203,11 +236,11 @@ GLOBAL_LIST_EMPTY(chardirectory_photos)
 		update_ui_static_data(ui.user, ui)
 		return TRUE
 	else if(action == "openExamine")
-		return open_character_examine(ui.user, params["ckey"])
+		return open_character_examine(ui.user, params["ckey"], params["open_ad"])
 	else
 		return check_for_mind_or_prefs(ui.user, action, params["overwrite_prefs"])
 
-/datum/character_directory/proc/open_character_examine(mob/user, target_ckey)
+/datum/character_directory/proc/open_character_examine(mob/user, target_ckey, open_ad = FALSE)
 	if(!user || !target_ckey)
 		return FALSE
 
@@ -227,6 +260,7 @@ GLOBAL_LIST_EMPTY(chardirectory_photos)
 		to_chat(user, span_warning("That character does not currently have profile data available."))
 		return FALSE
 
+	character_examine_panel.open_character_ad_on_open = !!open_ad
 	character_examine_panel.viewing = user
 	character_examine_panel.ui_interact(user)
 	return TRUE
@@ -265,7 +299,7 @@ GLOBAL_LIST_EMPTY(chardirectory_photos)
 			to_chat(user, span_notice("You are now [!visible ? "shown" : "not shown"] in the directory."))
 			return set_for_mind_or_prefs(user, action, !visible, can_set_prefs, can_set_mind)
 		if ("editAd")
-			var/current_ad = (can_set_mind ? user.mind.directory_ad : null) || (can_set_prefs ? user.client.prefs.directory_ad : null)
+			var/current_ad = get_character_ad_value(user, can_set_prefs ? user.client.prefs : null, can_set_mind ? user.mind : null)
 			var/new_ad = tgui_input_text(user, "Change your character ad", "Character Ad", current_ad, MAX_MESSAGE_LEN, TRUE, prevent_enter = TRUE)
 			if(isnull(new_ad))
 				return
@@ -307,10 +341,7 @@ GLOBAL_LIST_EMPTY(chardirectory_photos)
 				user.mind.show_in_directory = new_value
 			return TRUE
 		if ("editAd")
-			if (can_set_prefs)
-				user.client.prefs.directory_ad = new_value
-			if (can_set_mind)
-				user.mind.directory_ad = new_value
+			set_character_ad_value(user, can_set_prefs ? user.client.prefs : null, can_set_mind ? user.mind : null, new_value)
 			return TRUE
 		if ("setGenderTag")
 			if (can_set_prefs)

--- a/modular_ochrevalley/code/modules/client/verbs/character_directory.dm
+++ b/modular_ochrevalley/code/modules/client/verbs/character_directory.dm
@@ -160,6 +160,7 @@ GLOBAL_LIST_EMPTY(chardirectory_photos)
 			continue
 
 		directory_mobs.Add(list(list(
+			"ckey" = C.ckey,
 			"name" = name,
 			"species" = species,
 			"ooc_notes_favs" = ooc_notes_favs,
@@ -201,8 +202,34 @@ GLOBAL_LIST_EMPTY(chardirectory_photos)
 		*/
 		update_ui_static_data(ui.user, ui)
 		return TRUE
+	else if(action == "openExamine")
+		return open_character_examine(ui.user, params["ckey"])
 	else
 		return check_for_mind_or_prefs(ui.user, action, params["overwrite_prefs"])
+
+/datum/character_directory/proc/open_character_examine(mob/user, target_ckey)
+	if(!user || !target_ckey)
+		return FALSE
+
+	var/client/target_client = GLOB.directory[target_ckey]
+	if(!target_client)
+		to_chat(user, span_warning("That character is no longer available. Try refreshing the directory."))
+		return FALSE
+
+	var/datum/examine_panel/character_examine_panel
+	if(ishuman(target_client.mob))
+		character_examine_panel = new(target_client.mob)
+		character_examine_panel.holder = target_client.mob
+	else if(target_client.prefs)
+		character_examine_panel = new
+		character_examine_panel.pref = target_client.prefs
+	else
+		to_chat(user, span_warning("That character does not currently have profile data available."))
+		return FALSE
+
+	character_examine_panel.viewing = user
+	character_examine_panel.ui_interact(user)
+	return TRUE
 
 /datum/character_directory/proc/check_for_mind_or_prefs(mob/user, action, overwrite_prefs)
 	if (!user.client)

--- a/modular_ochrevalley/code/modules/client/verbs/character_directory.dm
+++ b/modular_ochrevalley/code/modules/client/verbs/character_directory.dm
@@ -5,6 +5,7 @@ GLOBAL_LIST_INIT(char_directory_sexualitytags, list("Straight", "Bisexual", "Pan
 GLOBAL_LIST_INIT(char_directory_gendertags, list("Male", "Female", "Feminine", "Masculine", "Nonbinary", "Trans Man", "Trans Woman", "Other", "Flexible", "Ungendered", "Unset"))
 GLOBAL_LIST_INIT(char_directory_pvp, list("No PvP", "Ask First", "Open to PvP"))
 
+// OV changes
 /proc/get_character_ad_value(mob/living/carbon/human/character, datum/preferences/prefs, datum/mind/mind)
 	var/current_ad = prefs?.directory_ad
 	if(isnull(current_ad))
@@ -35,6 +36,7 @@ GLOBAL_LIST_INIT(char_directory_pvp, list("No PvP", "Ask First", "Open to PvP"))
 			LAZYREMOVE(GLOB.roleplay_ads, character.mobid)
 
 	refresh_character_ad_examine_panels(character, prefs || character?.client?.prefs, mind || character?.mind)
+// OV changes
 
 /client/verb/show_character_directory()
 	set name = "Character Directory"
@@ -131,14 +133,18 @@ GLOBAL_LIST_EMPTY(chardirectory_photos)
 		if (C.mob?.mind) //could use ternary for all three but this is more efficient
 			tag = C.mob.mind.directory_tag || "Unset"
 			erptag = C.mob.mind.directory_erptag || "Unset"
+			// OV changes
 			character_ad = get_character_ad_value(C.mob, C.prefs, C.mob.mind)
+			// OV changes
 			gendertag = C.mob.mind.directory_gendertag || "Unset"
 			sexualitytag = C.mob.mind.directory_sexualitytag || "Unset"
 			pvp = C.mob.mind.directory_pvp || "No PvP"
 		else
 			tag = C.prefs.directory_tag || "Unset"
 			erptag = C.prefs.directory_erptag || "Unset"
+			// OV changes
 			character_ad = get_character_ad_value(null, C.prefs, null)
+			// OV changes
 			gendertag = C.prefs.directory_gendertag || "Unset"
 			sexualitytag = C.prefs.directory_sexualitytag || "Unset"
 			pvp = C.prefs.directory_pvp || "No PvP"
@@ -189,11 +195,15 @@ GLOBAL_LIST_EMPTY(chardirectory_photos)
 		// But if we can't find the name, they must be using a non-compatible mob type currently.
 		if(!name)
 			continue
+		// OV changes
 		if(character_ad)
 			character_ad = parsemarkdown_basic(html_encode(character_ad), hyperlink = TRUE)
+		// OV changes
 
 		directory_mobs.Add(list(list(
+			// OV changes
 			"ckey" = C.ckey,
+			// OV changes
 			"name" = name,
 			"species" = species,
 			"ooc_notes_favs" = ooc_notes_favs,
@@ -235,11 +245,14 @@ GLOBAL_LIST_EMPTY(chardirectory_photos)
 		*/
 		update_ui_static_data(ui.user, ui)
 		return TRUE
+	// OV changes
 	else if(action == "openExamine")
 		return open_character_examine(ui.user, params["ckey"], params["open_ad"])
+	// OV changes
 	else
 		return check_for_mind_or_prefs(ui.user, action, params["overwrite_prefs"])
 
+// OV changes
 /datum/character_directory/proc/open_character_examine(mob/user, target_ckey, open_ad = FALSE)
 	if(!user || !target_ckey)
 		return FALSE
@@ -264,6 +277,7 @@ GLOBAL_LIST_EMPTY(chardirectory_photos)
 	character_examine_panel.viewing = user
 	character_examine_panel.ui_interact(user)
 	return TRUE
+// OV changes
 
 /datum/character_directory/proc/check_for_mind_or_prefs(mob/user, action, overwrite_prefs)
 	if (!user.client)
@@ -299,7 +313,9 @@ GLOBAL_LIST_EMPTY(chardirectory_photos)
 			to_chat(user, span_notice("You are now [!visible ? "shown" : "not shown"] in the directory."))
 			return set_for_mind_or_prefs(user, action, !visible, can_set_prefs, can_set_mind)
 		if ("editAd")
+			// OV changes
 			var/current_ad = get_character_ad_value(user, can_set_prefs ? user.client.prefs : null, can_set_mind ? user.mind : null)
+			// OV changes
 			var/new_ad = tgui_input_text(user, "Change your character ad", "Character Ad", current_ad, MAX_MESSAGE_LEN, TRUE, prevent_enter = TRUE)
 			if(isnull(new_ad))
 				return
@@ -341,7 +357,9 @@ GLOBAL_LIST_EMPTY(chardirectory_photos)
 				user.mind.show_in_directory = new_value
 			return TRUE
 		if ("editAd")
+			// OV changes
 			set_character_ad_value(user, can_set_prefs ? user.client.prefs : null, can_set_mind ? user.mind : null, new_value)
+			// OV changes
 			return TRUE
 		if ("setGenderTag")
 			if (can_set_prefs)

--- a/tgui/packages/tgui/interfaces/CharacterDirectory/CharacterDirectoryList.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterDirectory/CharacterDirectoryList.tsx
@@ -9,13 +9,15 @@ import type { mobEntry } from './types';
 
 export const CharacterDirectoryList = (props: {
   directory: mobEntry[];
+  onOpenAd: (name: string, ad: string) => void;
 }) => {
   const { act } = useBackend();
 
-  const { directory } = props;
+  const { directory, onOpenAd } = props;
 
   const [sortId, setSortId] = useState<string>('name');
   const [sortOrder, setSortOrder] = useState<boolean>(true);
+  const [hoveredAction, setHoveredAction] = useState<string | null>(null);
 
   return (
     <Section
@@ -28,7 +30,9 @@ export const CharacterDirectoryList = (props: {
     >
       <Table>
         <Table.Row bold>
-          <Table.Cell collapsing>Photo</Table.Cell>
+          <Table.Cell collapsing textAlign="center">
+            Photo
+          </Table.Cell>
           <SortButton
             ourId="name"
             sortId={sortId}
@@ -92,7 +96,10 @@ export const CharacterDirectoryList = (props: {
           >
             PvP Opt-In
           </SortButton>
-          <Table.Cell collapsing textAlign="right">
+          <Table.Cell collapsing textAlign="center">
+            Ad
+          </Table.Cell>
+          <Table.Cell collapsing textAlign="center">
             View
           </Table.Cell>
         </Table.Row>
@@ -101,59 +108,97 @@ export const CharacterDirectoryList = (props: {
             const i = sortOrder ? 1 : -1;
             return a[sortId].localeCompare(b[sortId]) * i;
           })
-          .map((character, i) => (
-            <Table.Row key={i} backgroundColor={getTagColor(character.tag)} textColor={"black"}>
-              <Table.Cell verticalAlign="middle">
-                {character.photo ? (
-                  <Stack
-                    align="center"
-                    justify="center"
-                    backgroundColor="black"
-                    overflow="hidden"
-                  >
-                    <Stack.Item>
-                      <Image
-                        fixErrors
-                        src={character.photo.substring(
-                          1,
-                          character.photo.length - 1,
-                        )}
-                        height="64px"
-                      />
-                    </Stack.Item>
-                  </Stack>
-                ) : null}
-              </Table.Cell>
-              <Table.Cell p={1} verticalAlign="middle">
-                {character.name}
-              </Table.Cell>
-              <Table.Cell verticalAlign="middle">
-                {character.species}
-              </Table.Cell>
-              <Table.Cell verticalAlign="middle">{character.tag}</Table.Cell>
-              <Table.Cell verticalAlign="middle">
-                {character.gendertag}
-              </Table.Cell>
-              <Table.Cell verticalAlign="middle">
-                {character.sexualitytag}
-              </Table.Cell>
-              <Table.Cell verticalAlign="middle">{character.erptag}</Table.Cell>
-              <Table.Cell verticalAlign="middle">
-                {character.pvptag}
-              </Table.Cell>
-              <Table.Cell verticalAlign="middle" collapsing textAlign="right">
-                <Button
-                  onClick={() => act('openExamine', { ckey: character.ckey })}
-                  color="transparent"
-                  textColor="black"
-                  icon="sticky-note"
-                  mr={1}
-                >
-                  View
-                </Button>
-              </Table.Cell>
-            </Table.Row>
-          ))}
+          .map((character, i) => {
+            const hasCharacterAd = !!character.character_ad?.trim();
+            const adActionId = `${character.ckey}-ad`;
+            const viewActionId = `${character.ckey}-view`;
+
+            return (
+              <Table.Row key={i} backgroundColor={getTagColor(character.tag)} textColor="black">
+                <Table.Cell verticalAlign="middle" textAlign="center">
+                  {character.photo ? (
+                    <Stack
+                      align="center"
+                      justify="center"
+                      backgroundColor="black"
+                      overflow="hidden"
+                    >
+                      <Stack.Item>
+                        <Image
+                          fixErrors
+                          src={character.photo.substring(
+                            1,
+                            character.photo.length - 1,
+                          )}
+                          height="64px"
+                        />
+                      </Stack.Item>
+                    </Stack>
+                  ) : null}
+                </Table.Cell>
+                <Table.Cell p={1} verticalAlign="middle">
+                  {character.name}
+                </Table.Cell>
+                <Table.Cell verticalAlign="middle">
+                  {character.species}
+                </Table.Cell>
+                <Table.Cell verticalAlign="middle" textAlign="center">
+                  {character.tag}
+                </Table.Cell>
+                <Table.Cell verticalAlign="middle" textAlign="center">
+                  {character.gendertag}
+                </Table.Cell>
+                <Table.Cell verticalAlign="middle" textAlign="center">
+                  {character.sexualitytag}
+                </Table.Cell>
+                <Table.Cell verticalAlign="middle" textAlign="center">
+                  {character.erptag}
+                </Table.Cell>
+                <Table.Cell verticalAlign="middle" textAlign="center">
+                  {character.pvptag}
+                </Table.Cell>
+                <Table.Cell verticalAlign="middle" collapsing textAlign="center">
+                  <Button
+                    onClick={() => onOpenAd(character.name, character.character_ad)}
+                    onMouseEnter={() => setHoveredAction(adActionId)}
+                    onMouseLeave={() => setHoveredAction((current) => current === adActionId ? null : current)}
+                    color="transparent"
+                    textColor="black"
+                    icon="scroll"
+                    tooltip={hasCharacterAd ? 'View advertisement' : 'No advertisement set'}
+                    disabled={!hasCharacterAd}
+                    style={{
+                      backgroundColor: hoveredAction === adActionId
+                        ? 'rgba(255, 255, 255, 0.16)'
+                        : 'transparent',
+                      borderRadius: '3px',
+                      ...(!hasCharacterAd ? {
+                        opacity: 0.55,
+                        filter: 'brightness(1.15)',
+                      } : undefined),
+                    }}
+                  />
+                </Table.Cell>
+                <Table.Cell verticalAlign="middle" collapsing textAlign="center">
+                  <Button
+                    onClick={() => act('openExamine', { ckey: character.ckey })}
+                    onMouseEnter={() => setHoveredAction(viewActionId)}
+                    onMouseLeave={() => setHoveredAction((current) => current === viewActionId ? null : current)}
+                    color="transparent"
+                    textColor="black"
+                    icon="eye"
+                    tooltip="View character profile"
+                    style={{
+                      backgroundColor: hoveredAction === viewActionId
+                        ? 'rgba(255, 255, 255, 0.16)'
+                        : 'transparent',
+                      borderRadius: '3px',
+                    }}
+                  />
+                </Table.Cell>
+              </Table.Row>
+            );
+          })}
       </Table>
     </Section>
   );

--- a/tgui/packages/tgui/interfaces/CharacterDirectory/CharacterDirectoryList.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterDirectory/CharacterDirectoryList.tsx
@@ -9,21 +9,15 @@ import type { mobEntry } from './types';
 
 export const CharacterDirectoryList = (props: {
   directory: mobEntry[];
-  // OV changes
   onOpenAd: (name: string, ad: string) => void;
-  // OV changes
 }) => {
   const { act } = useBackend();
 
-  // OV changes
   const { directory, onOpenAd } = props;
-  // OV changes
 
   const [sortId, setSortId] = useState<string>('name');
   const [sortOrder, setSortOrder] = useState<boolean>(true);
-  // OV changes
   const [hoveredAction, setHoveredAction] = useState<string | null>(null);
-  // OV changes
 
   return (
     <Section
@@ -36,11 +30,9 @@ export const CharacterDirectoryList = (props: {
     >
       <Table>
         <Table.Row bold>
-          {/* // OV changes */}
           <Table.Cell collapsing textAlign="center">
             Photo
           </Table.Cell>
-          {/* // OV changes */}
           <SortButton
             ourId="name"
             sortId={sortId}
@@ -104,21 +96,18 @@ export const CharacterDirectoryList = (props: {
           >
             PvP Opt-In
           </SortButton>
-          {/* // OV changes */}
           <Table.Cell collapsing textAlign="center">
             Ad
           </Table.Cell>
           <Table.Cell collapsing textAlign="center">
             View
           </Table.Cell>
-          {/* // OV changes */}
         </Table.Row>
         {directory
           .sort((a, b) => {
             const i = sortOrder ? 1 : -1;
             return a[sortId].localeCompare(b[sortId]) * i;
           })
-          /* // OV changes */
           .map((character, i) => {
             const hasCharacterAd = !!character.character_ad?.trim();
             const adActionId = `${character.ckey}-ad`;
@@ -210,7 +199,7 @@ export const CharacterDirectoryList = (props: {
               </Table.Row>
             );
           })
-          /* // OV changes */}
+        }
       </Table>
     </Section>
   );

--- a/tgui/packages/tgui/interfaces/CharacterDirectory/CharacterDirectoryList.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterDirectory/CharacterDirectoryList.tsx
@@ -9,11 +9,10 @@ import type { mobEntry } from './types';
 
 export const CharacterDirectoryList = (props: {
   directory: mobEntry[];
-  onOverlay: React.Dispatch<React.SetStateAction<mobEntry | null>>;
 }) => {
   const { act } = useBackend();
 
-  const { onOverlay, directory } = props;
+  const { directory } = props;
 
   const [sortId, setSortId] = useState<string>('name');
   const [sortOrder, setSortOrder] = useState<boolean>(true);
@@ -144,7 +143,7 @@ export const CharacterDirectoryList = (props: {
               </Table.Cell>
               <Table.Cell verticalAlign="middle" collapsing textAlign="right">
                 <Button
-                  onClick={() => onOverlay(character)}
+                  onClick={() => act('openExamine', { ckey: character.ckey })}
                   color="transparent"
                   textColor="black"
                   icon="sticky-note"

--- a/tgui/packages/tgui/interfaces/CharacterDirectory/CharacterDirectoryList.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterDirectory/CharacterDirectoryList.tsx
@@ -9,15 +9,21 @@ import type { mobEntry } from './types';
 
 export const CharacterDirectoryList = (props: {
   directory: mobEntry[];
+  // OV changes
   onOpenAd: (name: string, ad: string) => void;
+  // OV changes
 }) => {
   const { act } = useBackend();
 
+  // OV changes
   const { directory, onOpenAd } = props;
+  // OV changes
 
   const [sortId, setSortId] = useState<string>('name');
   const [sortOrder, setSortOrder] = useState<boolean>(true);
+  // OV changes
   const [hoveredAction, setHoveredAction] = useState<string | null>(null);
+  // OV changes
 
   return (
     <Section
@@ -30,9 +36,11 @@ export const CharacterDirectoryList = (props: {
     >
       <Table>
         <Table.Row bold>
+          {/* // OV changes */}
           <Table.Cell collapsing textAlign="center">
             Photo
           </Table.Cell>
+          {/* // OV changes */}
           <SortButton
             ourId="name"
             sortId={sortId}
@@ -96,18 +104,21 @@ export const CharacterDirectoryList = (props: {
           >
             PvP Opt-In
           </SortButton>
+          {/* // OV changes */}
           <Table.Cell collapsing textAlign="center">
             Ad
           </Table.Cell>
           <Table.Cell collapsing textAlign="center">
             View
           </Table.Cell>
+          {/* // OV changes */}
         </Table.Row>
         {directory
           .sort((a, b) => {
             const i = sortOrder ? 1 : -1;
             return a[sortId].localeCompare(b[sortId]) * i;
           })
+          /* // OV changes */
           .map((character, i) => {
             const hasCharacterAd = !!character.character_ad?.trim();
             const adActionId = `${character.ckey}-ad`;
@@ -198,7 +209,8 @@ export const CharacterDirectoryList = (props: {
                 </Table.Cell>
               </Table.Row>
             );
-          })}
+          })
+          /* // OV changes */}
       </Table>
     </Section>
   );

--- a/tgui/packages/tgui/interfaces/CharacterDirectory/CharacterDirectoryViewCharacter.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterDirectory/CharacterDirectoryViewCharacter.tsx
@@ -1,7 +1,5 @@
 // OV FILE
-// OV changes
 // Old/redundant in-directory description renderer retained for reference.
-// OV changes
 import { Box, Button, Section, Table } from 'tgui-core/components';
 
 import { getTagColor } from './constants';

--- a/tgui/packages/tgui/interfaces/CharacterDirectory/CharacterDirectoryViewCharacter.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterDirectory/CharacterDirectoryViewCharacter.tsx
@@ -1,5 +1,7 @@
 // OV FILE
+// OV changes
 // Old/redundant in-directory description renderer retained for reference.
+// OV changes
 import { Box, Button, Section, Table } from 'tgui-core/components';
 
 import { getTagColor } from './constants';

--- a/tgui/packages/tgui/interfaces/CharacterDirectory/CharacterDirectoryViewCharacter.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterDirectory/CharacterDirectoryViewCharacter.tsx
@@ -1,4 +1,5 @@
 // OV FILE
+// Old/redundant in-directory description renderer retained for reference.
 import { Box, Button, Section, Table } from 'tgui-core/components';
 
 import { getTagColor } from './constants';

--- a/tgui/packages/tgui/interfaces/CharacterDirectory/index.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterDirectory/index.tsx
@@ -27,6 +27,10 @@ export const CharacterDirectory = (props) => {
   const directoryAdHTML = useMemo(() => ({
     __html: directoryAd || '',
   }), [directoryAd]);
+  const closeDirectoryAd = () => {
+    setDirectoryAd(null);
+    setDirectoryAdName('');
+  };
 
   return (
     <Window width={816} height={722}>
@@ -40,7 +44,7 @@ export const CharacterDirectory = (props) => {
           <ViewCharacter overlay={overlay} onOverlay={setOverlay} />
         )) || (
         */}
-        <Box position="relative">
+        <Box>
           <Section
             title="Settings and Preferences"
             buttons={
@@ -144,65 +148,63 @@ export const CharacterDirectory = (props) => {
               setDirectoryAd(ad);
             }}
           />
-          {!!directoryAd?.trim() && (
-            <Box
-              style={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                right: 0,
-                bottom: 0,
-                backgroundColor: 'rgba(0, 0, 0, 0.78)',
-                zIndex: 3,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                padding: '1.5rem',
-              }}
-            >
-              <Section
-                title={`${directoryAdName} Advertisement`}
-                fill
-                scrollable
-                style={{
-                  width: '70%',
-                  height: '65%',
-                }}
-                buttons={
-                  <Button
-                    icon="times"
-                    color="red"
-                    onClick={() => {
-                      setDirectoryAd(null);
-                      setDirectoryAdName('');
-                    }}
-                  >
-                    Close
-                  </Button>
-                }
-              >
-                <Box
-                  backgroundColor="black"
-                  p={2}
-                  style={{
-                    border: '1px solid rgba(138, 92, 92, 0.85)',
-                    borderRadius: '0.2rem',
-                    minHeight: '100%',
-                  }}
-                >
-                  <Box
-                    preserveWhitespace
-                    dangerouslySetInnerHTML={directoryAdHTML}
-                  />
-                </Box>
-              </Section>
-            </Box>
-          )}
         </Box>
         {/*
         )}
         */}
       </Window.Content>
+      {!!directoryAd?.trim() && (
+        <Box
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.78)',
+            zIndex: 3,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '1.5rem',
+          }}
+        >
+          <Section
+            title={`${directoryAdName} Advertisement`}
+            scrollable
+            style={{
+              width: '70%',
+              height: '65%',
+              maxWidth: '48rem',
+              maxHeight: '36rem',
+            }}
+            buttons={
+              <Button
+                icon="times"
+                color="red"
+                onClick={closeDirectoryAd}
+              >
+                Close
+              </Button>
+            }
+          >
+            <Box
+              backgroundColor="black"
+              p={2}
+              style={{
+                border: '1px solid rgba(138, 92, 92, 0.85)',
+                borderRadius: '0.2rem',
+                minHeight: '100%',
+              }}
+            >
+              <Box
+                preserveWhitespace
+                dangerouslySetInnerHTML={directoryAdHTML}
+              />
+            </Box>
+          </Section>
+        </Box>
+      )}
     </Window>
   );
 };

--- a/tgui/packages/tgui/interfaces/CharacterDirectory/index.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterDirectory/index.tsx
@@ -1,5 +1,5 @@
 // OV FILE
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useBackend } from 'tgui/backend';
 import { Window } from 'tgui/layouts';
 import { Box, Button, LabeledList, Section, Stack } from 'tgui-core/components';
@@ -22,6 +22,11 @@ export const CharacterDirectory = (props) => {
   } = data;
 
   const [overwritePrefs, setOverwritePrefs] = useState<boolean>(false);
+  const [directoryAd, setDirectoryAd] = useState<string | null>(null);
+  const [directoryAdName, setDirectoryAdName] = useState<string>('');
+  const directoryAdHTML = useMemo(() => ({
+    __html: directoryAd || '',
+  }), [directoryAd]);
 
   return (
     <Window width={816} height={722}>
@@ -35,7 +40,7 @@ export const CharacterDirectory = (props) => {
           <ViewCharacter overlay={overlay} onOverlay={setOverlay} />
         )) || (
         */}
-        <>
+        <Box position="relative">
           <Section
             title="Settings and Preferences"
             buttons={
@@ -132,8 +137,68 @@ export const CharacterDirectory = (props) => {
               </LabeledList.Item>
             </LabeledList>
           </Section>
-          <CharacterDirectoryList directory={directory} />
-        </>
+          <CharacterDirectoryList
+            directory={directory}
+            onOpenAd={(name, ad) => {
+              setDirectoryAdName(name);
+              setDirectoryAd(ad);
+            }}
+          />
+          {!!directoryAd?.trim() && (
+            <Box
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                backgroundColor: 'rgba(0, 0, 0, 0.78)',
+                zIndex: 3,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '1.5rem',
+              }}
+            >
+              <Section
+                title={`${directoryAdName} Advertisement`}
+                fill
+                scrollable
+                style={{
+                  width: '70%',
+                  height: '65%',
+                }}
+                buttons={
+                  <Button
+                    icon="times"
+                    color="red"
+                    onClick={() => {
+                      setDirectoryAd(null);
+                      setDirectoryAdName('');
+                    }}
+                  >
+                    Close
+                  </Button>
+                }
+              >
+                <Box
+                  backgroundColor="black"
+                  p={2}
+                  style={{
+                    border: '1px solid rgba(138, 92, 92, 0.85)',
+                    borderRadius: '0.2rem',
+                    minHeight: '100%',
+                  }}
+                >
+                  <Box
+                    preserveWhitespace
+                    dangerouslySetInnerHTML={directoryAdHTML}
+                  />
+                </Box>
+              </Section>
+            </Box>
+          )}
+        </Box>
         {/*
         )}
         */}

--- a/tgui/packages/tgui/interfaces/CharacterDirectory/index.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterDirectory/index.tsx
@@ -1,15 +1,11 @@
 // OV FILE
-// OV changes
 import { useMemo, useState } from 'react';
-// OV changes
 import { useBackend } from 'tgui/backend';
 import { Window } from 'tgui/layouts';
 import { Box, Button, LabeledList, Section, Stack } from 'tgui-core/components';
 
 import { CharacterDirectoryList } from './CharacterDirectoryList';
-// OV changes
 import type { Data } from './types';
-// OV changes
 
 export const CharacterDirectory = (props) => {
   const { act, data } = useBackend<Data>();
@@ -26,18 +22,15 @@ export const CharacterDirectory = (props) => {
   } = data;
 
   const [overwritePrefs, setOverwritePrefs] = useState<boolean>(false);
-  // OV changes
   const [directoryAd, setDirectoryAd] = useState<string | null>(null);
   const [directoryAdName, setDirectoryAdName] = useState<string>('');
   const directoryAdHTML = useMemo(() => ({
     __html: directoryAd || '',
   }), [directoryAd]);
-  // OV changes
 
   return (
     <Window width={816} height={722}>
       <Window.Content scrollable>
-        {/* // OV changes */}
         {/*
           Old/redundant in-directory description overlay retained for reference.
           We now open the shared Examine Panel instead so directory views match
@@ -209,7 +202,6 @@ export const CharacterDirectory = (props) => {
         {/*
         )}
         */}
-        {/* // OV changes */}
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/CharacterDirectory/index.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterDirectory/index.tsx
@@ -7,6 +7,9 @@ import { Box, Button, LabeledList, Section, Stack } from 'tgui-core/components';
 import { CharacterDirectoryList } from './CharacterDirectoryList';
 import type { Data } from './types';
 
+const CHARACTER_DIRECTORY_WINDOW_WIDTH = Math.round(816 * 1.15);
+const CHARACTER_DIRECTORY_WINDOW_HEIGHT = Math.round(722 * 1.15);
+
 export const CharacterDirectory = (props) => {
   const { act, data } = useBackend<Data>();
 
@@ -33,7 +36,10 @@ export const CharacterDirectory = (props) => {
   };
 
   return (
-    <Window width={816} height={722}>
+    <Window
+      width={CHARACTER_DIRECTORY_WINDOW_WIDTH}
+      height={CHARACTER_DIRECTORY_WINDOW_HEIGHT}
+    >
       <Window.Content scrollable>
         {/*
           Old/redundant in-directory description overlay retained for reference.
@@ -171,6 +177,8 @@ export const CharacterDirectory = (props) => {
         >
           <Section
             title={`${directoryAdName} Advertisement`}
+            fill
+            fitted
             scrollable
             style={{
               width: '70%',
@@ -195,6 +203,7 @@ export const CharacterDirectory = (props) => {
                 border: '1px solid rgba(138, 92, 92, 0.85)',
                 borderRadius: '0.2rem',
                 minHeight: '100%',
+                overflowWrap: 'break-word',
               }}
             >
               <Box

--- a/tgui/packages/tgui/interfaces/CharacterDirectory/index.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterDirectory/index.tsx
@@ -1,11 +1,15 @@
 // OV FILE
+// OV changes
 import { useMemo, useState } from 'react';
+// OV changes
 import { useBackend } from 'tgui/backend';
 import { Window } from 'tgui/layouts';
 import { Box, Button, LabeledList, Section, Stack } from 'tgui-core/components';
 
 import { CharacterDirectoryList } from './CharacterDirectoryList';
+// OV changes
 import type { Data } from './types';
+// OV changes
 
 export const CharacterDirectory = (props) => {
   const { act, data } = useBackend<Data>();
@@ -22,15 +26,18 @@ export const CharacterDirectory = (props) => {
   } = data;
 
   const [overwritePrefs, setOverwritePrefs] = useState<boolean>(false);
+  // OV changes
   const [directoryAd, setDirectoryAd] = useState<string | null>(null);
   const [directoryAdName, setDirectoryAdName] = useState<string>('');
   const directoryAdHTML = useMemo(() => ({
     __html: directoryAd || '',
   }), [directoryAd]);
+  // OV changes
 
   return (
     <Window width={816} height={722}>
       <Window.Content scrollable>
+        {/* // OV changes */}
         {/*
           Old/redundant in-directory description overlay retained for reference.
           We now open the shared Examine Panel instead so directory views match
@@ -202,6 +209,7 @@ export const CharacterDirectory = (props) => {
         {/*
         )}
         */}
+        {/* // OV changes */}
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/CharacterDirectory/index.tsx
+++ b/tgui/packages/tgui/interfaces/CharacterDirectory/index.tsx
@@ -5,8 +5,7 @@ import { Window } from 'tgui/layouts';
 import { Box, Button, LabeledList, Section, Stack } from 'tgui-core/components';
 
 import { CharacterDirectoryList } from './CharacterDirectoryList';
-import { ViewCharacter } from './CharacterDirectoryViewCharacter';
-import type { Data, mobEntry } from './types';
+import type { Data } from './types';
 
 export const CharacterDirectory = (props) => {
   const { act, data } = useBackend<Data>();
@@ -22,118 +21,122 @@ export const CharacterDirectory = (props) => {
     directory,
   } = data;
 
-  const [overlay, setOverlay] = useState<mobEntry | null>(null);
   const [overwritePrefs, setOverwritePrefs] = useState<boolean>(false);
 
   return (
     <Window width={816} height={722}>
       <Window.Content scrollable>
+        {/*
+          Old/redundant in-directory description overlay retained for reference.
+          We now open the shared Examine Panel instead so directory views match
+          in-person "Examine closer" rendering.
+
         {(overlay && (
           <ViewCharacter overlay={overlay} onOverlay={setOverlay} />
         )) || (
-          <>
-            <Section
-              title="Settings and Preferences"
-              buttons={
-                <Stack>
-                  <Stack.Item>
-                    <Box color="label" inline>
-                      Save to current preferences slot:&nbsp;
-                    </Box>
-                  </Stack.Item>
-                  <Stack.Item>
-                    <Button
-                      icon={overwritePrefs ? 'toggle-on' : 'toggle-off'}
-                      selected={overwritePrefs}
-                      onClick={() => setOverwritePrefs(!overwritePrefs)}
-                    >
-                      {overwritePrefs ? 'On' : 'Off'}
-                    </Button>
-                  </Stack.Item>
-                </Stack>
-              }
-            >
-              <LabeledList>
-                <LabeledList.Item label="Visibility">
+        */}
+        <>
+          <Section
+            title="Settings and Preferences"
+            buttons={
+              <Stack>
+                <Stack.Item>
+                  <Box color="label" inline>
+                    Save to current preferences slot:&nbsp;
+                  </Box>
+                </Stack.Item>
+                <Stack.Item>
                   <Button
-                    fluid
-                    onClick={() =>
-                      act('setVisible', { overwrite_prefs: overwritePrefs })
-                    }
+                    icon={overwritePrefs ? 'toggle-on' : 'toggle-off'}
+                    selected={overwritePrefs}
+                    onClick={() => setOverwritePrefs(!overwritePrefs)}
                   >
-                    {personalVisibility ? 'Shown' : 'Not Shown'}
+                    {overwritePrefs ? 'On' : 'Off'}
                   </Button>
-                </LabeledList.Item>
-                <LabeledList.Item label="Vore Tag">
-                  <Button
-                    fluid
-                    onClick={() =>
-                      act('setTag', { overwrite_prefs: overwritePrefs })
-                    }
-                  >
-                    {personalTag}
-                  </Button>
-                </LabeledList.Item>
-                <LabeledList.Item label="Gender">
-                  <Button
-                    fluid
-                    onClick={() =>
-                      act('setGenderTag', { overwrite_prefs: overwritePrefs })
-                    }
-                  >
-                    {personalGenderTag}
-                  </Button>
-                </LabeledList.Item>
-                <LabeledList.Item label="Sexuality">
-                  <Button
-                    fluid
-                    onClick={() =>
-                      act('setSexualityTag', {
-                        overwrite_prefs: overwritePrefs,
-                      })
-                    }
-                  >
-                    {personalSexualityTag}
-                  </Button>
-                </LabeledList.Item>
-                <LabeledList.Item label="ERP Tag">
-                  <Button
-                    fluid
-                    onClick={() =>
-                      act('setErpTag', { overwrite_prefs: overwritePrefs })
-                    }
-                  >
-                    {personalErpTag}
-                  </Button>
-                </LabeledList.Item>
-                <LabeledList.Item label="PvP Opt-in">
-                  <Button
-                    fluid
-                    onClick={() =>
-                      act('setPvPTag', { overwrite_prefs: overwritePrefs })
-                    }
-                  >
-                    {personalPvPTag}
-                  </Button>
-                </LabeledList.Item>
-                <LabeledList.Item label="Advertisement">
-                  <Button
-                    fluid
-                    onClick={() =>
-                      act('editAd', { overwrite_prefs: overwritePrefs })
-                    }
-                  >
-                    Edit Ad
-                  </Button>
-                </LabeledList.Item>
-              </LabeledList>
-            </Section>
-            <CharacterDirectoryList
-              directory={directory}
-              onOverlay={setOverlay}
-            />
-          </>
+                </Stack.Item>
+              </Stack>
+            }
+          >
+            <LabeledList>
+              <LabeledList.Item label="Visibility">
+                <Button
+                  fluid
+                  onClick={() =>
+                    act('setVisible', { overwrite_prefs: overwritePrefs })
+                  }
+                >
+                  {personalVisibility ? 'Shown' : 'Not Shown'}
+                </Button>
+              </LabeledList.Item>
+              <LabeledList.Item label="Vore Tag">
+                <Button
+                  fluid
+                  onClick={() =>
+                    act('setTag', { overwrite_prefs: overwritePrefs })
+                  }
+                >
+                  {personalTag}
+                </Button>
+              </LabeledList.Item>
+              <LabeledList.Item label="Gender">
+                <Button
+                  fluid
+                  onClick={() =>
+                    act('setGenderTag', { overwrite_prefs: overwritePrefs })
+                  }
+                >
+                  {personalGenderTag}
+                </Button>
+              </LabeledList.Item>
+              <LabeledList.Item label="Sexuality">
+                <Button
+                  fluid
+                  onClick={() =>
+                    act('setSexualityTag', {
+                      overwrite_prefs: overwritePrefs,
+                    })
+                  }
+                >
+                  {personalSexualityTag}
+                </Button>
+              </LabeledList.Item>
+              <LabeledList.Item label="ERP Tag">
+                <Button
+                  fluid
+                  onClick={() =>
+                    act('setErpTag', { overwrite_prefs: overwritePrefs })
+                  }
+                >
+                  {personalErpTag}
+                </Button>
+              </LabeledList.Item>
+              <LabeledList.Item label="PvP Opt-in">
+                <Button
+                  fluid
+                  onClick={() =>
+                    act('setPvPTag', { overwrite_prefs: overwritePrefs })
+                  }
+                >
+                  {personalPvPTag}
+                </Button>
+              </LabeledList.Item>
+              <LabeledList.Item label="Advertisement">
+                <Button
+                  fluid
+                  onClick={() =>
+                    act('editAd', { overwrite_prefs: overwritePrefs })
+                  }
+                >
+                  Edit Ad
+                </Button>
+              </LabeledList.Item>
+            </LabeledList>
+          </Section>
+          <CharacterDirectoryList directory={directory} />
+        </>
+        {/*
         )}
+        */}
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/CharacterDirectory/types.ts
+++ b/tgui/packages/tgui/interfaces/CharacterDirectory/types.ts
@@ -13,9 +13,7 @@ export type Data = {
 };
 
 export type mobEntry = {
-  // OV changes
   ckey: string;
-  // OV changes
   name: string;
   species: string;
   ooc_notes_favs: string;

--- a/tgui/packages/tgui/interfaces/CharacterDirectory/types.ts
+++ b/tgui/packages/tgui/interfaces/CharacterDirectory/types.ts
@@ -13,6 +13,7 @@ export type Data = {
 };
 
 export type mobEntry = {
+  ckey: string;
   name: string;
   species: string;
   ooc_notes_favs: string;

--- a/tgui/packages/tgui/interfaces/CharacterDirectory/types.ts
+++ b/tgui/packages/tgui/interfaces/CharacterDirectory/types.ts
@@ -13,7 +13,9 @@ export type Data = {
 };
 
 export type mobEntry = {
+  // OV changes
   ckey: string;
+  // OV changes
   name: string;
   species: string;
   ooc_notes_favs: string;

--- a/tgui/packages/tgui/interfaces/ExaminePanel.tsx
+++ b/tgui/packages/tgui/interfaces/ExaminePanel.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { Button, Stack } from 'tgui-core/components';
+import { useEffect, useMemo, useState } from 'react';
+import { Box, Button, Section, Stack } from 'tgui-core/components';
 
 import { useBackend } from '../backend';
 import { PageButton } from '../components/PageButton';
@@ -14,9 +14,26 @@ enum Page {
 
 export const ExaminePanel = (props) => {
   const { act, data } = useBackend<ExaminePanelData>();
-  const { is_vet, character_name, is_playing, has_song, img_gallery, nsfw_img_gallery, examine_theme } = data;
+  const { is_vet, character_name, is_playing, has_song, img_gallery, nsfw_img_gallery, examine_theme, character_ad, start_with_character_ad } = data;
   const [currentPage, setCurrentPage] = useState(Page.FlavorText);
+  const [showCharacterAd, setShowCharacterAd] = useState(false);
   const hasAnyGalleryImages = img_gallery.length > 0 || nsfw_img_gallery.length > 0;
+  const hasCharacterAd = !!character_ad?.trim();
+  const characterAdHTML = useMemo(() => ({
+    __html: `<span className='Chat'>${character_ad || ''}</span>`,
+  }), [character_ad]);
+
+  useEffect(() => {
+    if (showCharacterAd && !hasCharacterAd) {
+      setShowCharacterAd(false);
+    }
+  }, [showCharacterAd, hasCharacterAd]);
+
+  useEffect(() => {
+    if (start_with_character_ad && hasCharacterAd) {
+      setShowCharacterAd(true);
+    }
+  }, [start_with_character_ad, hasCharacterAd]);
 
   let pageContents;
 
@@ -42,6 +59,18 @@ export const ExaminePanel = (props) => {
         />
       )}
       <Button
+      icon="scroll"
+      tooltip={hasCharacterAd ? "View character advertisement" : "No character advertisement set"}
+      tooltipPosition="bottom-start"
+      onClick={() => setShowCharacterAd(true)}
+      disabled={!hasCharacterAd}
+      style={hasCharacterAd ? {
+        boxShadow: '0 0 10px rgba(214, 170, 92, 0.65)',
+        borderColor: 'rgba(214, 170, 92, 0.8)',
+        backgroundColor: 'rgba(87, 45, 22, 0.85)',
+      } : undefined}
+      />
+      <Button
       color="green"
       icon="music"
       tooltip="Music player"
@@ -52,34 +81,73 @@ export const ExaminePanel = (props) => {
       />
       </>}>
       <Window.Content>
-        <Stack vertical fill>
-          {hasAnyGalleryImages && (
-          <Stack style={{ marginBottom: '4px' }}>
-            <Stack.Item grow>
-              <PageButton
-              currentPage={currentPage}
-              page={Page.FlavorText}
-              setPage={setCurrentPage}
-              >
-                Flavor Text
-              </PageButton>
-            </Stack.Item>
-            <Stack.Item grow>
-              <PageButton
-              currentPage={currentPage}
-              page={Page.ImageGallery}
-              setPage={setCurrentPage}
-              >
-                Image Gallery
-              </PageButton>
+        <Box position="relative" height="100%">
+          <Stack vertical fill>
+            {hasAnyGalleryImages && (
+            <Stack style={{ marginBottom: '4px' }}>
+              <Stack.Item grow>
+                <PageButton
+                currentPage={currentPage}
+                page={Page.FlavorText}
+                setPage={setCurrentPage}
+                >
+                  Flavor Text
+                </PageButton>
+              </Stack.Item>
+              <Stack.Item grow>
+                <PageButton
+                currentPage={currentPage}
+                page={Page.ImageGallery}
+                setPage={setCurrentPage}
+                >
+                  Image Gallery
+                </PageButton>
+              </Stack.Item>
+            </Stack>
+            )}
+            {hasAnyGalleryImages && (<Stack.Divider />)}
+            <Stack.Item grow position="relative" overflowX="hidden" overflowY="auto">
+              {pageContents}
             </Stack.Item>
           </Stack>
+          {showCharacterAd && hasCharacterAd && (
+            <Box
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                backgroundColor: 'rgba(0, 0, 0, 0.78)',
+                zIndex: 3,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '1.5rem',
+              }}
+            >
+              <Section
+                title="Character Advertisement"
+                fill
+                scrollable
+                style={{
+                  width: '70%',
+                  height: '65%',
+                }}
+                buttons={
+                  <Button icon="times" color="red" onClick={() => setShowCharacterAd(false)}>
+                    Close
+                  </Button>
+                }
+              >
+                <Box
+                  preserveWhitespace
+                  dangerouslySetInnerHTML={characterAdHTML}
+                />
+              </Section>
+            </Box>
           )}
-          {hasAnyGalleryImages && (<Stack.Divider />)}
-          <Stack.Item grow position="relative" overflowX="hidden" overflowY="auto">
-            {pageContents}
-          </Stack.Item>
-        </Stack>
+        </Box>
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/ExaminePanel.tsx
+++ b/tgui/packages/tgui/interfaces/ExaminePanel.tsx
@@ -136,10 +136,13 @@ export const ExaminePanel = (props) => {
               <Section
                 title="Character Advertisement"
                 fill
+                fitted
                 scrollable
                 style={{
                   width: '70%',
                   height: '65%',
+                  maxWidth: '48rem',
+                  maxHeight: '36rem',
                 }}
                 buttons={
                   <Button icon="times" color="red" onClick={() => setShowCharacterAd(false)}>
@@ -148,6 +151,14 @@ export const ExaminePanel = (props) => {
                 }
               >
                 <Box
+                  backgroundColor="black"
+                  p={2}
+                  style={{
+                    border: '1px solid rgba(138, 92, 92, 0.85)',
+                    borderRadius: '0.2rem',
+                    minHeight: '100%',
+                    overflowWrap: 'break-word',
+                  }}
                   preserveWhitespace
                   dangerouslySetInnerHTML={characterAdHTML}
                 />

--- a/tgui/packages/tgui/interfaces/ExaminePanel.tsx
+++ b/tgui/packages/tgui/interfaces/ExaminePanel.tsx
@@ -1,7 +1,7 @@
-// OV changes
+// OV Edit Start
 import { useEffect, useMemo, useState } from 'react';
 import { Box, Button, Section, Stack } from 'tgui-core/components';
-// OV changes
+// OV Edit End
 
 import { useBackend } from '../backend';
 import { PageButton } from '../components/PageButton';
@@ -16,7 +16,7 @@ enum Page {
 
 export const ExaminePanel = (props) => {
   const { act, data } = useBackend<ExaminePanelData>();
-  // OV changes
+  // OV Edit Start
   const { is_vet, character_name, is_playing, has_song, img_gallery, nsfw_img_gallery, examine_theme, character_ad, start_with_character_ad } = data;
   const [currentPage, setCurrentPage] = useState(Page.FlavorText);
   const [showCharacterAd, setShowCharacterAd] = useState(false);
@@ -37,7 +37,7 @@ export const ExaminePanel = (props) => {
       setShowCharacterAd(true);
     }
   }, [start_with_character_ad, hasCharacterAd]);
-  // OV changes
+  // OV Edit End
 
   let pageContents;
 
@@ -62,7 +62,7 @@ export const ExaminePanel = (props) => {
           onClick={() => act('vet_chat')}
         />
       )}
-      {/* // OV changes */}
+      {/* // OV Edit Start */}
       <Button
       icon="scroll"
       tooltip={hasCharacterAd ? "View character advertisement" : "No character advertisement set"}
@@ -75,7 +75,7 @@ export const ExaminePanel = (props) => {
         backgroundColor: 'rgba(87, 45, 22, 0.85)',
       } : undefined}
       />
-      {/* // OV changes */}
+      {/* // OV Edit End */}
       <Button
       color="green"
       icon="music"
@@ -87,7 +87,7 @@ export const ExaminePanel = (props) => {
       />
       </>}>
       <Window.Content>
-        {/* // OV changes */}
+        {/* // OV Edit Start */}
         <Box position="relative" height="100%">
           <Stack vertical fill>
             {hasAnyGalleryImages && (
@@ -155,7 +155,7 @@ export const ExaminePanel = (props) => {
             </Box>
           )}
         </Box>
-        {/* // OV changes */}
+        {/* // OV Edit End */}
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/ExaminePanel.tsx
+++ b/tgui/packages/tgui/interfaces/ExaminePanel.tsx
@@ -1,5 +1,7 @@
+// OV changes
 import { useEffect, useMemo, useState } from 'react';
 import { Box, Button, Section, Stack } from 'tgui-core/components';
+// OV changes
 
 import { useBackend } from '../backend';
 import { PageButton } from '../components/PageButton';
@@ -14,6 +16,7 @@ enum Page {
 
 export const ExaminePanel = (props) => {
   const { act, data } = useBackend<ExaminePanelData>();
+  // OV changes
   const { is_vet, character_name, is_playing, has_song, img_gallery, nsfw_img_gallery, examine_theme, character_ad, start_with_character_ad } = data;
   const [currentPage, setCurrentPage] = useState(Page.FlavorText);
   const [showCharacterAd, setShowCharacterAd] = useState(false);
@@ -34,6 +37,7 @@ export const ExaminePanel = (props) => {
       setShowCharacterAd(true);
     }
   }, [start_with_character_ad, hasCharacterAd]);
+  // OV changes
 
   let pageContents;
 
@@ -58,6 +62,7 @@ export const ExaminePanel = (props) => {
           onClick={() => act('vet_chat')}
         />
       )}
+      {/* // OV changes */}
       <Button
       icon="scroll"
       tooltip={hasCharacterAd ? "View character advertisement" : "No character advertisement set"}
@@ -70,6 +75,7 @@ export const ExaminePanel = (props) => {
         backgroundColor: 'rgba(87, 45, 22, 0.85)',
       } : undefined}
       />
+      {/* // OV changes */}
       <Button
       color="green"
       icon="music"
@@ -81,6 +87,7 @@ export const ExaminePanel = (props) => {
       />
       </>}>
       <Window.Content>
+        {/* // OV changes */}
         <Box position="relative" height="100%">
           <Stack vertical fill>
             {hasAnyGalleryImages && (
@@ -148,6 +155,7 @@ export const ExaminePanel = (props) => {
             </Box>
           )}
         </Box>
+        {/* // OV changes */}
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/ExaminePanelData.ts
+++ b/tgui/packages/tgui/interfaces/ExaminePanelData.ts
@@ -4,6 +4,7 @@ export type ExaminePanelData = {
   headshot: string;
   obscured: boolean;
   // Descriptions
+  character_ad: string;
   flavor_text: string;
   ooc_notes: string;
   // Descriptions, but requiring manual input to see
@@ -12,6 +13,7 @@ export type ExaminePanelData = {
   img_gallery: string[];
   nsfw_img_gallery: string[];
   is_playing: boolean;
+  start_with_character_ad: boolean;
   has_song: boolean;
   is_vet: boolean;
   // is_naked: boolean; // Caustic Edit: Removes naked requirement to view NSFW flavortext

--- a/tgui/packages/tgui/interfaces/ExaminePanelData.ts
+++ b/tgui/packages/tgui/interfaces/ExaminePanelData.ts
@@ -4,7 +4,9 @@ export type ExaminePanelData = {
   headshot: string;
   obscured: boolean;
   // Descriptions
+  // OV changes
   character_ad: string;
+  // OV changes
   flavor_text: string;
   ooc_notes: string;
   // Descriptions, but requiring manual input to see
@@ -13,7 +15,9 @@ export type ExaminePanelData = {
   img_gallery: string[];
   nsfw_img_gallery: string[];
   is_playing: boolean;
+  // OV changes
   start_with_character_ad: boolean;
+  // OV changes
   has_song: boolean;
   is_vet: boolean;
   // is_naked: boolean; // Caustic Edit: Removes naked requirement to view NSFW flavortext

--- a/tgui/packages/tgui/interfaces/ExaminePanelData.ts
+++ b/tgui/packages/tgui/interfaces/ExaminePanelData.ts
@@ -4,9 +4,6 @@ export type ExaminePanelData = {
   headshot: string;
   obscured: boolean;
   // Descriptions
-  // OV changes
-  character_ad: string;
-  // OV changes
   flavor_text: string;
   ooc_notes: string;
   // Descriptions, but requiring manual input to see
@@ -15,11 +12,12 @@ export type ExaminePanelData = {
   img_gallery: string[];
   nsfw_img_gallery: string[];
   is_playing: boolean;
-  // OV changes
-  start_with_character_ad: boolean;
-  // OV changes
   has_song: boolean;
   is_vet: boolean;
   // is_naked: boolean; // Caustic Edit: Removes naked requirement to view NSFW flavortext
   examine_theme: string | null;
+  // OV Edit Start
+  character_ad: string;
+  start_with_character_ad: boolean;
+  // OV Edit End
 };


### PR DESCRIPTION
## About The Pull Request

This PR reworks how the character directory displays player profile information and advertisements.

The main change is that character directory profile viewing now reuses the same examine panel used in-world, instead of the currently broken directory renderer. This fixes a long-standing issue where profile descriptions in the directory displayed raw formatting code, making profiles with particularly large formatting blocks (e.g gradients) almost totally incomprehensible. 

<img width="888" height="720" alt="image" src="https://github.com/user-attachments/assets/a0889778-e763-409f-899c-07a48f741043" />

This PR also integrates and improves advertisement access from the directory:
- Adds a dedicated `Ad` button to the directory table, represented by a scroll symbol. This scroll is grayed out and cannot be clicked if the character does not have an advertisement actually set. Ads open a modal. 
- The View button has been simplified to an eye icon and opens the examine panel.
- Fixed some spaghetti with advertisement data so that it all comes from a single source of truth. You can now successfully set advertisements in the lobby and character creation and have them actually take effect immediately upon joining a round.
- When examining someone, you can see an advertisement button in the top right corner that will be highlighted if they have an advertisement active and will show the ad pop-up. 

The older directory-specific description implementation has not been deleted. It was retained and marked as old/redundant in case it needs to be revisited later.

## Developer's checklist
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Tested locally and confirmed to be working. The feature itself is _fairly_ straightforward and should not be too high risk to implement.

## Why It's Good For The Game

The 'view' function in the character directory was strictly inferior to the examine panel in every way, except for the presence of RP ads. By replacing the broken directory view with the examine panel and integrating ads into it, both of these problems are solved! 

## Changelog

:cl: EeviKat
qol: Character Directory profile viewing now uses the Examine Closer panel.
qol: You can now view advertisements from the Examine Closer panel by clicking the scroll symbol in the top right. It will be highlighted with a soft golden glow if the character has an advertisement active.
qol: Improved the layout of the Character Directory table. 
fix: Advertisements set in character creation or the lobby should now become active immediately when joining a round.
/:cl:
