### PR TITLE
Object muffling warning

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1391,7 +1391,7 @@
 	if(!.)
 		return
 	if(mouth?.muteinmouth)
-		to_chat(src, span_warning("You can't speak with an object in your mouth!"))
+		to_chat(src, span_warning("You can't speak with an object in your mouth!")) //OV ADD
 		return FALSE
 	for(var/obj/item/grabbing/grab in grabbedby)
 		if((grab.sublimb_grabbed == BODY_ZONE_PRECISE_MOUTH) && (get_location_accessible(src, BODY_ZONE_PRECISE_MOUTH)))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1391,6 +1391,7 @@
 	if(!.)
 		return
 	if(mouth?.muteinmouth)
+		to_chat(src, span_warning("You can't speak with an object in your mouth!"))
 		return FALSE
 	for(var/obj/item/grabbing/grab in grabbedby)
 		if((grab.sublimb_grabbed == BODY_ZONE_PRECISE_MOUTH) && (get_location_accessible(src, BODY_ZONE_PRECISE_MOUTH)))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1391,7 +1391,7 @@
 	if(!.)
 		return
 	if(mouth?.muteinmouth)
-		to_chat(src, span_warning("You can't speak with an object in your mouth!")) //OV ADD
+		to_chat(src, span_warning("I can't speak with an object in my mouth!")) //OV ADD
 		return FALSE
 	for(var/obj/item/grabbing/grab in grabbedby)
 		if((grab.sublimb_grabbed == BODY_ZONE_PRECISE_MOUTH) && (get_location_accessible(src, BODY_ZONE_PRECISE_MOUTH)))


### PR DESCRIPTION


## About The Pull Request

Added a warning for when an item is in your mouth and you attempt to speak, saving us about half of our ahelps :D

Fixes #220

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Tested and works fine.

## Why It's Good For The Game

It's a common thing that confuses people.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added a warning for when an item is in your mouth and you attempt to speak.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
