### PR TITLE
Fix and Implement Unreachable Silver Embedding Behavior

### DIFF
--- a/code/modules/mob/living/carbon/human/human_topic.dm
+++ b/code/modules/mob/living/carbon/human/human_topic.dm
@@ -60,13 +60,14 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 			usr.visible_message("<span class='warning'>[usr] attempts to remove [I] from [usr.p_their()] [L.name][with_what].</span>","<span class='warning'>I attempt to remove [I] from my [L.name][with_what]...</span>")
 		else
 			usr.visible_message("<span class='warning'>[usr] attempts to remove [I] from [src]'s [L.name][with_what].</span>","<span class='warning'>I attempt to remove [I] from [src]'s [L.name][with_what]...</span>")
+		// OV Edit End
 		if(do_after(usr, time_taken, needhand = TRUE, target = src))
 			if(QDELETED(I) || QDELETED(L) || !L.remove_embedded_object(I))
 				return
 			var/hort = FALSE
+			// OV Edit Start: Digging embedded objects out with a knife.
 			if(foundstab)
 				hort = L.receive_damage(ceil(I.embedding.embedded_unsafe_removal_pain_multiplier*I.w_class/2)) // Hurts less. Surgery is still better though.
-				L.remove_embedded_object(I) // This drops the embedded item without touching it: good for vampyres and silver.
 			else
 				hort = L.receive_damage(I.embedding.embedded_unsafe_removal_pain_multiplier*I.w_class)//It hurts to rip it out, get surgery you dingus.
 				usr.put_in_hands(I)

--- a/code/modules/mob/living/carbon/human/human_topic.dm
+++ b/code/modules/mob/living/carbon/human/human_topic.dm
@@ -55,7 +55,6 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 		if (foundstab)
 			time_taken = ceil(time_taken/2) // It's faster to dig it out with a tool instead of your fingers.
 			with_what = " with the [A]"
-			A.do_special_attack_effect(usr, L, null, src, usr.zone_selected) // I'll just dig it out with my SILVER dagger...
 		if(usr == src)
 			usr.visible_message("<span class='warning'>[usr] attempts to remove [I] from [usr.p_their()] [L.name][with_what].</span>","<span class='warning'>I attempt to remove [I] from my [L.name][with_what]...</span>")
 		else
@@ -67,6 +66,7 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 			var/hort = FALSE
 			// OV Edit Start: Digging embedded objects out with a knife.
 			if(foundstab)
+				A.do_special_attack_effect(usr, L, null, src, usr.zone_selected) // I'll just dig it out with my SILVER dagger...
 				hort = L.receive_damage(ceil(I.embedding.embedded_unsafe_removal_pain_multiplier*I.w_class/2)) // Hurts less. Surgery is still better though.
 			else
 				hort = L.receive_damage(I.embedding.embedded_unsafe_removal_pain_multiplier*I.w_class)//It hurts to rip it out, get surgery you dingus.

--- a/code/modules/mob/living/carbon/human/human_topic.dm
+++ b/code/modules/mob/living/carbon/human/human_topic.dm
@@ -55,6 +55,7 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 		if (foundstab)
 			time_taken = ceil(time_taken/2) // It's faster to dig it out with a tool instead of your fingers.
 			with_what = " with the [A]"
+			A.do_special_attack_effect(usr, L, null, src, usr.zone_selected) // I'll just dig it out with my SILVER dagger...
 		if(usr == src)
 			usr.visible_message("<span class='warning'>[usr] attempts to remove [I] from [usr.p_their()] [L.name][with_what].</span>","<span class='warning'>I attempt to remove [I] from my [L.name][with_what]...</span>")
 		else

--- a/code/modules/mob/living/carbon/human/human_topic.dm
+++ b/code/modules/mob/living/carbon/human/human_topic.dm
@@ -41,17 +41,35 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 		var/obj/item/I = locate(href_list["embedded_object"]) in L.embedded_objects
 		if(!I) //no item, no limb, or item is not in limb or in the person anymore
 			return
+		// OV Edit Start: Digging embedded objects out with a knife.
+		var/obj/item/A = usr.get_active_held_item()
+		var/foundstab = FALSE
+		if(A)
+			for(var/X in A.possible_item_intents)
+				var/datum/intent/D = new X
+				if(D.blade_class in GLOB.stab_bclasses)
+					foundstab = TRUE
+					break
 		var/time_taken = I.embedding.embedded_unsafe_removal_time*I.w_class
+		var/with_what = ""
+		if (foundstab)
+			time_taken = ceil(time_taken/2) // It's faster to dig it out with a tool instead of your fingers.
+			with_what = " with the [A]"
 		if(usr == src)
-			usr.visible_message("<span class='warning'>[usr] attempts to remove [I] from [usr.p_their()] [L.name].</span>","<span class='warning'>I attempt to remove [I] from my [L.name]...</span>")
+			usr.visible_message("<span class='warning'>[usr] attempts to remove [I] from [usr.p_their()] [L.name][with_what].</span>","<span class='warning'>I attempt to remove [I] from my [L.name][with_what]...</span>")
 		else
-			usr.visible_message("<span class='warning'>[usr] attempts to remove [I] from [src]'s [L.name].</span>","<span class='warning'>I attempt to remove [I] from [src]'s [L.name]...</span>")
+			usr.visible_message("<span class='warning'>[usr] attempts to remove [I] from [src]'s [L.name][with_what].</span>","<span class='warning'>I attempt to remove [I] from [src]'s [L.name][with_what]...</span>")
 		if(do_after(usr, time_taken, needhand = TRUE, target = src))
 			if(QDELETED(I) || QDELETED(L) || !L.remove_embedded_object(I))
 				return
 			var/hort = FALSE
-			hort = L.receive_damage(I.embedding.embedded_unsafe_removal_pain_multiplier*I.w_class)//It hurts to rip it out, get surgery you dingus.
-			usr.put_in_hands(I)
+			if(foundstab)
+				hort = L.receive_damage(ceil(I.embedding.embedded_unsafe_removal_pain_multiplier*I.w_class/2)) // Hurts less. Surgery is still better though.
+				L.remove_embedded_object(I) // This drops the embedded item without touching it: good for vampyres and silver.
+			else
+				hort = L.receive_damage(I.embedding.embedded_unsafe_removal_pain_multiplier*I.w_class)//It hurts to rip it out, get surgery you dingus.
+				usr.put_in_hands(I)
+			// OV Edit End
 			if (hort)
 				emote("pain", TRUE)
 			playsound(loc, 'sound/foley/flesh_rem.ogg', 100, TRUE, -2)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -227,6 +227,7 @@
 			if(prob(embedded.embedding.embedded_pain_chance))
 				bodypart.receive_damage(embedded.w_class*embedded.embedding.embedded_pain_multiplier)
 				to_chat(src, span_danger("[embedded] in my [bodypart.name] hurts!"))
+				embedded.do_special_attack_effect(null, bodypart, null, src, null, TRUE) // OV Edit: Fix embedded silver
 
 			if(prob(embedded.embedding.embedded_fall_chance))
 				bodypart.receive_damage(embedded.w_class*embedded.embedding.embedded_fall_pain_multiplier)


### PR DESCRIPTION
## About The Pull Request
While researching embedding mechanics to see what it would take to make embedded silver act on silver weak characters, I found that an attempt to do just that was already made seven months ago on Azure Peak when they reworked silver effects. The code is unreachable in mob/living/handle_embedded_objects(), which is overridden by mob/living/carbon/handle_embedded_objects() and lacks the ignite line to make the sunder actually burn. In this PR, I implement silver embedding mechanics in the carbon proc, using the item's do_special_attack_effect() procedure instead.

Additionally, I added mechanics for removing embedded items with a knife, or any item with stab, pick, or pierce intent. So players can remove embedded items faster and less painful than by hand, and vampyre players can remove silver items without touching them, reigniting themselves, and falling over.

Just for fun, using a silver item to dig an embedded item out of a silver weak character will sunder them.
<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence
<img width="1199" height="695" alt="Die Monster" src="https://github.com/user-attachments/assets/96ed2b3c-6045-4da0-8f33-52bc5664762e" />
<img width="1166" height="670" alt="Helpful Bishop" src="https://github.com/user-attachments/assets/6d3f5c42-9e7f-4922-8b81-ed8fd0aaf6be" />
I embedded silver and non silver items in silver weak mobs and players etc. to make sure sunder is applied only for silver items and only in silver weak mobs and players.
I testing removing items by hand and with a tool, using view variables to verify that the correct amount of damage is applied and the correct amount of time is taken.

While testing, I noticed that the chat messages to the sunder victim are mixed up. Unblessed silver gives the blessed silver message and vice versa. The logic that is supposed to prevent spamming the message is also mixed up. I'm unsure if I should fix it or let AP handle it, because they have been making changes to the silver logic recently and might have noticed the bug too.
<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game
Currently, if a vampyre or player-controlled skeleton has a silver item embedded in them, it is better to leave it in until it falls out on its own, because embedded silver doesn't do much, and removing it by hand is punishing and tedious because holding silver causes them to burn and collapse.

This change makes it better to get the silver out and provides a way to do that without holding it in your hands. Any item that can be used to roast meat over a fire can be used to dig embedded items out with this change.
<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Made silver cause sunder when embedded in silver weak mobs.
add: Added mechanics to remove embedded items faster and safer with a knife (or anything pointy enough to cook with).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
