### PR TITLE
Vore tab tweaks

### DIFF
--- a/modular_causticcove/code/modules/vore/chat_healthbars.dm
+++ b/modular_causticcove/code/modules/vore/chat_healthbars.dm
@@ -116,7 +116,7 @@
 
 /mob/living/verb/print_healthbars()
 	set name = "Print Prey Healthbars"
-	set category = "Abilities.Vore"
+	set category = "Vore" //OV EDIT
 
 	var/nuffin = TRUE
 

--- a/modular_causticcove/code/modules/vore/eating/living_vr.dm
+++ b/modular_causticcove/code/modules/vore/eating/living_vr.dm
@@ -442,7 +442,7 @@
 //
 /mob/living/verb/lick_taste(mob/living/tasted in living_mobs_in_view(1, TRUE))
 	set name = "Lick someone"
-	set category = "Abilities.Vore"
+	set category = "Vore" //OV EDIT
 	set desc = "Lick someone nearby!"
 	set popup_menu = FALSE // Stop licking by accident!
 
@@ -495,7 +495,7 @@
 //This is just the above proc but switched about.
 /mob/living/verb/smell(mob/living/smelled in living_mobs(1, TRUE))
 	set name = "Smell someone"
-	set category = "Abilities.Vore"
+	set category = "Vore" //OV EDIT
 	set desc = "Smell someone nearby!"
 	set popup_menu = FALSE
 
@@ -806,7 +806,7 @@
 
 /mob/living/verb/eat_trash()
 	set name = "Eat object"
-	set category = "Abilities.Vore"
+	set category = "Vore" //OV EDIT
 	set desc = "Consume held object into currently selected belly."
 
 	//on chomp it worked off a whitelist of items you could devour, hope is that here it can be replaced by a long windup before eating something
@@ -855,7 +855,7 @@
 /* //Caustic - Do we enable this?
 /mob/living/proc/toggle_trash_catching() //Ported from chompstation
 	set name = "Toggle Trash Catching"
-	set category = "Abilities.Vore"
+	set category = "Vore" //OV EDIT
 	set desc = "Toggle Trash Eater throw vore abilities."
 	trash_catching = !trash_catching
 	to_chat(src, span_warning("Trash catching [trash_catching ? "enabled" : "disabled"]."))*/
@@ -863,7 +863,7 @@
 /*
 /mob/living/proc/eat_minerals() //Actual eating abstracted so the user isn't given a prompt due to an argument in this verb.
 	set name = "Eat Minerals"
-	set category = "Abilities.Vore"
+	set category = "Vore" //OV EDIT
 	set desc = "Consume held raw ore, gems and refined minerals. Snack time!"
 
 	handle_eat_minerals()
@@ -993,7 +993,7 @@
 
 /*/mob/living/verb/toggle_stuffing_mode() <-- Pains me so fucking much to comment this out but this is for later //Caustic - Enable this as well sometime?
 	set name = "Toggle feeding mode"
-	set category = "Abilities.Vore"
+	set category = "Vore" //OV EDIT
 	set desc = "Switch whether you will try to feed other people food whole or normally, bite by bite."
 
 	stuffing_feeder = !stuffing_feeder
@@ -1316,7 +1316,7 @@
 
 /mob/living/verb/vore_check_reagents()
 	set name = "Check Belly Liquid (Vore)"
-	set category = "Abilities.Vore"
+	set category = "Vore" //OV EDIT
 	set desc = "Check the amount of liquid in your belly."
 
 	var/obj/belly/RTB = tgui_input_list(src, "Choose which vore belly to check", "Select Belly", vore_organs)
@@ -1332,7 +1332,7 @@
 
 /mob/living/verb/vore_transfer_reagents()
 	set name = "Transfer Liquid (Vore)"
-	set category = "Abilities.Vore"
+	set category = "Vore" //OV EDIT
 	set desc = "Transfer liquid from an organ to another or stomach, or into another person or container."
 	set popup_menu = FALSE
 
@@ -1538,7 +1538,7 @@
 
 /mob/living/proc/restrict_trasheater()
 	set name = "Restrict Trash Eater"
-	set category = "Abilities.Vore"
+	set category = "Vore" //OV EDIT
 	set desc = "Toggle Trash Eater restriction level."
 	adminbus_trash = !adminbus_trash
 	to_chat(src, span_warning("Trash Eater restriction level set to [adminbus_trash ? "everything not blacklisted" : "only whitelisted items"]."))
@@ -1567,7 +1567,7 @@
 
 /mob/living/verb/vore_check_nutrition()
 	set name = "Check Nutrition"
-	set category = "Abilities.Vore"
+	set category = "Vore" //OV EDIT
 	set desc = "Check your current nutrition level."
 	to_chat(src, span_notice("Current nutrition level: [nutrition]."))
 

--- a/modular_causticcove/code/modules/vore/eating/simple_animal_vr.dm
+++ b/modular_causticcove/code/modules/vore/eating/simple_animal_vr.dm
@@ -13,7 +13,7 @@
 //
 /mob/living/simple_animal/proc/animal_nom(mob/living/T in living_mobs_in_view(1))
 	set name = "Animal Nom"
-	set category = "Abilities.Vore" // Moving this to abilities from IC as it's more fitting there
+	set category = "Vore" //OV EDIT // Moving this to abilities from IC as it's more fitting there
 	set desc = "Since you can't grab, you get a verb!"
 
 	if(vore_active && !voremob_loaded) // On-demand belly loading.

--- a/modular_causticcove/code/modules/vore/eating/vertical_nom_vr.dm
+++ b/modular_causticcove/code/modules/vore/eating/vertical_nom_vr.dm
@@ -1,7 +1,7 @@
 /mob/living/verb/vertical_nom()
 	set name = "Nom from Above"
 	set desc = "Allows you to eat people who are below your tile or adjacent one. Requires passability."
-	set category = "Abilities.Vore"
+	set category = "Vore" //OV EDIT
 
 	if(stat == DEAD || IsParalyzed() || IsImmobilized() || IsStun() || IsKnockdown())
 		to_chat(src, span_notice("You cannot do that while in your current state."))

--- a/modular_causticcove/code/modules/vore/eating/vore_verbs.dm
+++ b/modular_causticcove/code/modules/vore/eating/vore_verbs.dm
@@ -50,7 +50,7 @@
 	return ..(target)
 
 /mob/living/verb/shred_limb()
-	set name = "Damage Prey's Organ"
+	set name = "Damage Prey's Organ" //OV EDIT
 	set desc = "Severely damages prey's organ. If the limb is already severely damaged, it will be torn off."
 	set category = "Vore" //OV EDIT
 
@@ -126,7 +126,7 @@
 		log_combat(src,T,"Shredded (hardvore)")
 
 /mob/living/proc/shred_limb_temp()
-	set name = "Damage Prey's Organ (beartrap)"
+	set name = "Damage Prey's Organ (beartrap)" //OV EDIT
 	set desc = "Severely damages prey's organ. If the limb is already severely damaged, it will be torn off."
 	set category = "Vore" //OV EDIT
 	shred_limb()

--- a/modular_causticcove/code/modules/vore/eating/vore_verbs.dm
+++ b/modular_causticcove/code/modules/vore/eating/vore_verbs.dm
@@ -50,9 +50,9 @@
 	return ..(target)
 
 /mob/living/verb/shred_limb()
-	set name = "Damage/Remove Prey's Organ"
+	set name = "Damage Prey's Organ"
 	set desc = "Severely damages prey's organ. If the limb is already severely damaged, it will be torn off."
-	set category = "Abilities.Vore"
+	set category = "Vore" //OV EDIT
 
 	//can_shred() will return a mob we can shred, if we can shred any.
 	var/mob/living/carbon/human/T = can_shred()
@@ -126,9 +126,9 @@
 		log_combat(src,T,"Shredded (hardvore)")
 
 /mob/living/proc/shred_limb_temp()
-	set name = "Damage/Remove Prey's Organ (beartrap)"
+	set name = "Damage Prey's Organ (beartrap)"
 	set desc = "Severely damages prey's organ. If the limb is already severely damaged, it will be torn off."
-	set category = "Abilities.Vore"
+	set category = "Vore" //OV EDIT
 	shred_limb()
 
 /mob/verb/toggle_vore_health_bars()
@@ -162,3 +162,40 @@
 	if(client?.prefs)
 		client.prefs.belch_noises = !client.prefs.belch_noises
 		to_chat(src, span_notice("You [client.prefs.belch_noises ? "will" : "will not"] hear burps and belches."))
+
+//OV edit
+/mob/verb/toggle_vore_fx()
+	set name = "Toggle Vore FX"
+	set category = "Vore"
+
+	show_vore_fx = !show_vore_fx
+	if(client.prefs_vr)
+		client.prefs_vr.show_vore_fx = show_vore_fx
+	if (isbelly(loc))
+		var/obj/belly/B = loc
+		B.vore_fx(src, TRUE)
+	else
+		clear_fullscreen("belly")
+	if(!hud_used.hud_shown)
+		toggle_hud_vis()
+	
+	to_chat(src, span_notice("You [show_vore_fx ? "will now" : "will no longer"] see vore belly overlays. NOTE: This preferences has NOT been saved, to save please use the vore panel."))
+
+/mob/verb/toggle_spont_pred()
+	set name = "Toggle Spont Pred"
+	set category = "Vore"
+
+	can_be_drop_pred = !can_be_drop_pred
+	if(client.prefs_vr)
+		client.prefs_vr.can_be_drop_pred = can_be_drop_pred
+	to_chat(src, span_notice("You [can_be_drop_pred ? "will now" : "will not"] vore other players spontaneously. NOTE: This preferences has NOT been saved, to save please use the vore panel."))
+
+/mob/verb/toggle_spont_prey()
+	set name = "Toggle Spont Prey"
+	set category = "Vore"
+
+	can_be_drop_prey = !can_be_drop_prey
+	if(client.prefs_vr)
+		client.prefs_vr.can_be_drop_prey = can_be_drop_prey
+	to_chat(src, span_notice("You [can_be_drop_prey ? "will now" : "will not"] be vored by other players spontaneously. NOTE: This preferences has NOT been saved, to save please use the vore panel."))
+//OV edit end


### PR DESCRIPTION
## About The Pull Request

Removed the Abilities.Vore tab, moving everything into the Vore tab.

Changed the name of Damage/Remove Prey's Organ to just be "Damage Prey's Organ" as the name is so long that it messes with the whole formatting.

Added 3 new quick toggle verbs for toggling Vore FX and spont prey/pred.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Tested and they seem to work as expected!

## Why It's Good For The Game

The abilities.vore tab seems to have always been a bit of an oversight, on account of the fact that virgo/chomp use a different type of stat panel.

The quick toggles are a little jank, but given how much of a pain it is to swap spont prey off/on when going into combat, it's honestly necessary. The Vore FX one is just nice to have.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added 3 new quick toggle verbs for toggling Vore FX and spont prey/pred.
qol: Changed the name of Damage/Remove Prey's Organ to just be "Damage Prey's Organ" as the name is so long that it messes with the whole formatting.
qol: Removed the Abilities.Vore tab, moving everything into the Vore tab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
