### PR TITLE
Make digestion_death trigger contract completion

### DIFF
--- a/code/__DEFINES/dcs/signals/ov/signals_vore.dm
+++ b/code/__DEFINES/dcs/signals/ov/signals_vore.dm
@@ -1,0 +1,2 @@
+/// From /obj/belly/proc/digestion_death() (mob/living/prey, obj/belly/grave, mob/living/pred)
+#define COMSIG_MOB_DIGESTION_DEATH "mob_digestion_death"

--- a/code/modules/roguetown/roguemachine/questing/questing_components.dm
+++ b/code/modules/roguetown/roguemachine/questing/questing_components.dm
@@ -17,6 +17,7 @@
 			var/mob/M = parent
 			M.add_filter(outline_filter_id, 2, list("type" = "outline", "color" = "#ff0000", "size" = 0.5))
 			RegisterSignal(parent, COMSIG_MOB_DEATH, PROC_REF(on_target_death))
+			RegisterSignal(parent, COMSIG_MOB_DIGESTION_DEATH, PROC_REF(on_target_death)) // OV Add: Digestion death counts as quest completion
 			RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_mob_examine))
 		else
 			var/obj/item/I = parent

--- a/modular_causticcove/code/modules/vore/eating/belly_obj.dm
+++ b/modular_causticcove/code/modules/vore/eating/belly_obj.dm
@@ -980,6 +980,7 @@
 	M.alpha = 0 
 	owner.handle_belly_update()
 	playsound(src, sfx, vary = 1, vol = 75, falloff = VORE_SOUND_FALLOFF, frequency = noise_freq, pref_toggle = "digestion_noises")
+	SEND_SIGNAL(M, COMSIG_MOB_DIGESTION_DEATH, src, owner)
 	//OV edit end
 
 // Handle a mob being absorbed

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -194,6 +194,7 @@
 #include "code\__DEFINES\dcs\signals\signals_tgui.dm"
 #include "code\__DEFINES\dcs\signals\signals_tram.dm"
 #include "code\__DEFINES\dcs\signals\signals_turf.dm"
+#include "code\__DEFINES\dcs\signals\ov\signals_vore.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_client.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_mind.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_mob.dm"


### PR DESCRIPTION
## About The Pull Request

digestion_death now sends a signal, COMSIG_MOB_DIGESTION_DEATH(mob/living/prey, obj/belly/grave, mob/living/pred) that quests listen for to complete kill objectives.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence
<img width="545" height="43" alt="dreamseeker_1LwBJYpSqM" src="https://github.com/user-attachments/assets/2df7c644-8781-4812-9f8c-f65f0058261d" />
<img width="530" height="78" alt="dreamseeker_s7qHlbzfS0" src="https://github.com/user-attachments/assets/f591cc0a-5baa-45d7-93a7-8f051d7849f3" />


## Why It's Good For The Game
vorny bounty hunters (and also people not stealing other's bounty targets and making contracts incompletable lol)

## Changelog
:cl:
fix: Digesting bounty targets now correctly counts their death
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
