### PR TITLE
No lockpicking private rooms

### DIFF
--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -547,6 +547,13 @@
 		return
 	if(!keylock)
 		return
+	//OV edit
+	var/our_area = get_area(src)
+	if(istype(our_area, /area/rogue/indoors/town/bath) || istype(our_area, /area/rogue/indoors/town/tavern))
+		message_admins("[user.name]([key_name(user)]) was denied lockpicking [src.name]. [ADMIN_JMP(src)]")
+		to_chat(user, "<span class='warning'>This door can not be lockpicked.</span>")
+		return
+	//OV edit end
 	if(lockbroken)
 		to_chat(user, "<span class='warning'>The lock to this door is broken.</span>")
 		user.changeNext_move(CLICK_CD_INTENTCAP)

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -551,7 +551,7 @@
 	var/our_area = get_area(src)
 	if(istype(our_area, /area/rogue/indoors/town/bath) || istype(our_area, /area/rogue/indoors/town/tavern))
 		message_admins("[user.name]([key_name(user)]) was denied lockpicking [src.name]. [ADMIN_JMP(src)]")
-		to_chat(user, "<span class='warning'>This door can not be lockpicked.</span>")
+		to_chat(user, span_warning("This door can not be lockpicked."))
 		return
 	//OV edit end
 	if(lockbroken)


### PR DESCRIPTION


## About The Pull Request

Disables lockpicking in the inn and baths, as these are private areas and almost always a rule break. This comes up often enough that it is worth disabling.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Disables lockpicking in the inn and baths, as these are private areas and almost always a rule break. This comes up often enough that it is worth disabling.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
