### PR TITLE
Fixes some ooze bugs

### DIFF
--- a/modular_ochrevalley/code/modules/mob/living/carbon/human/species_types/roguetown/other/ooze.dm
+++ b/modular_ochrevalley/code/modules/mob/living/carbon/human/species_types/roguetown/other/ooze.dm
@@ -39,9 +39,9 @@
 		)
 	race_bonus = list(STAT_PERCEPTION = 1, STAT_INTELLIGENCE = -1)
 	inherent_traits = list(
-						TRAIT_NOBREATH,
+						//TRAIT_NOBREATH,
 						TRAIT_ZOMBIE_IMMUNE,
-						TRAIT_BLOODLOSS_IMMUNE,
+						//TRAIT_BLOODLOSS_IMMUNE,
 						TRAIT_EASYDISMEMBER,
 						TRAIT_REGROW_LIMBS,
 						)
@@ -239,7 +239,7 @@
 	if(ishuman(caster))
 		var/mob/living/carbon/human/human_caster = caster
 		shape.color = "#[human_caster.dna.features["mcolor"]]"
-	H = new(shape,src,caster)
+	H = new(shape,src,caster,shape)
 	shape.name = "[shape]"
 	shape.faction = caster.faction
 
@@ -255,10 +255,15 @@
 		return ..()
 	shape = loc
 	if(!istype(shape))
+		to_chat(caster, "Initialize failure: please report: | stored=[caster] shape=[shape]")
 		CRASH("shapeshift holder created outside mob/living")
 	stored = caster
 	if(stored.mind)
 		stored.mind.transfer_to(shape)
+
+	rebuild_perception(shape)
+	hard_reset_spatial(shape)
+
 	stored.forceMove(src)
 	stored.notransform = TRUE
 	shape.visible_message(span_warning("[stored] has lost their form, they are vulnerable and near death."),span_warningbig("You have been near killed, you can no longer maintain your form. You will need to be revived to return to your humen form."))
@@ -271,26 +276,38 @@
 		return
 
 	restoring = TRUE
-	qdel(slink)
-	if (stored)
-		stored.forceMove(get_turf(src))
-		stored.notransform = FALSE
 
-		// leave a track to indicate something has shifted out here
-		var/obj/effect/track/the_evidence = new(stored.loc)
-		the_evidence.handle_creation(stored)
-		the_evidence.track_type = "expanding animal tracks into humanoid footprints"
-		the_evidence.ambiguous_track_type = "curious footprints"
-		the_evidence.base_diff = 6
+	if(slink)
+		qdel(slink)
+		slink = null
 
-	if(shape && shape.mind)
-		shape.mind?.transfer_to(stored)
-	stored.revive(full_heal = TRUE, admin_revive = FALSE)
-	to_chat(stored, span_notice("Bug notice: If you can no longer see emotes, move to a different z level and back (up/down a level). This is a known bug."))
-	stored.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shapeshift/ooze)
-	stored.Knockdown(200)
-	stored.Stun(200)
-	stored.apply_status_effect(/datum/status_effect/debuff/revived)
-	stored.adjust_fire_stacks(2)
+	if(!stored)
+		qdel(src)
+		return
+
+	var/mob/living/temp = stored
+	stored = null
+
+	var/turf/original_turf = get_turf(src)
+
+	if(original_turf)
+		temp.forceMove(original_turf)
+		hard_reset_spatial(temp)
+
+	temp.notransform = FALSE
+
+	var/datum/mind/M = temp?.mind || shape?.mind
+	if(M)
+		M.transfer_to(temp)
+
+	rebuild_perception(temp)
+
+	temp.revive(full_heal = TRUE, admin_revive = FALSE)
+	to_chat(temp, span_notice("Bug notice: If you can no longer see emotes, move to a different z level and back (up/down a level). This is a known bug."))
+	temp.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shapeshift/ooze)
+	temp.Knockdown(200)
+	temp.Stun(200)
+	temp.apply_status_effect(/datum/status_effect/debuff/revived)
+	temp.adjust_fire_stacks(2)
 	qdel(shape)
 	shape = null


### PR DESCRIPTION


## About The Pull Request

This updates Ooze shapeshifting code to match the recent upstream changes. This also makes it so that they won't get stuck in infinite death loops.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Tested and works

## Why It's Good For The Game

bug fixes

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: This updates Ooze shapeshifting code to match the recent upstream changes. This also makes it so that they won't get stuck in infinite death loops.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
