### PR TITLE
Make damage organ command functional again

### DIFF
--- a/modular_causticcove/code/modules/vore/eating/vore_verbs.dm
+++ b/modular_causticcove/code/modules/vore/eating/vore_verbs.dm
@@ -112,14 +112,31 @@
 				visible_message(span_danger("[src] severely damages [T]'s [T_ext.name]!"))
 			else if(B)
 				playsound(T, 'sound/gore/flesh_eat_01.ogg', 100)
-				T_ext.drop_limb(1) //Clean cut so it doesn't kill the prey completely.
-				T_ext.forceMove(B)
-				visible_message(span_warning("[src] swallows [T]'s [T_ext.name] into their [lowertext(B.name)]!"))
+				//Add head check and move organs with limb
+				if (T_ext.body_part == HEAD)
+					T_ext.dismember(BRUTE, BCLASS_CUT, T, T_ext.body_part, 200, FALSE, TRUE)
+					T_ext.forceMove(B)
+					visible_message(span_warning("[src] swallows [T]'s [T_ext.name] into their [lowertext(B.name)]!"))
+					//Set as vore death if head
+					var/mob/dead/observer/G = T.ghostize(TRUE)
+					G.vore_death = TRUE
+				else
+					T_ext.drop_limb(1) //Clean cut so it doesn't kill the prey completely.
+					T_ext.forceMove(B)
+					visible_message(span_warning("[src] swallows [T]'s [T_ext.name] into their [lowertext(B.name)]!"))
 			else
 				playsound(T, 'sound/gore/flesh_eat_01.ogg', 100)
-				T_ext.drop_limb(1) //Clean cut so it doesn't kill the prey completely.
-				T_ext.forceMove(T.loc)
-				visible_message(span_warning("[src] tears off [T]'s [T_ext.name]!"),span_warning("You tear off [T]'s [T_ext.name]!"))
+				if (T_ext.body_part == HEAD)
+					T_ext.dismember(BRUTE, BCLASS_CUT, T, T_ext.body_part, 200, FALSE, TRUE)
+					T_ext.forceMove(B)
+					visible_message(span_warning("[src] tears off [T]'s [T_ext.name]!"),span_warning("You tear off [T]'s [T_ext.name]!"))
+					//Set as vore death if head
+					var/mob/dead/observer/G = T.ghostize(TRUE)
+					G.vore_death = TRUE
+				else
+					T_ext.drop_limb(1) //Clean cut so it doesn't kill the prey completely.
+					T_ext.forceMove(T.loc)
+					visible_message(span_warning("[src] tears off [T]'s [T_ext.name]!"),span_warning("You tear off [T]'s [T_ext.name]!"))
 
 		//Not targeting an internal organ w/ > 25 damage , and the limb doesn't have < 25 damage.
 		else

--- a/modular_causticcove/code/modules/vore/eating/vore_verbs.dm
+++ b/modular_causticcove/code/modules/vore/eating/vore_verbs.dm
@@ -114,12 +114,17 @@
 				playsound(T, 'sound/gore/flesh_eat_01.ogg', 100)
 				//Add head check and move organs with limb
 				if (T_ext.body_part == HEAD)
-					T_ext.dismember(BRUTE, BCLASS_CUT, T, T_ext.body_part, 200, FALSE, TRUE)
-					T_ext.forceMove(B)
-					visible_message(span_warning("[src] swallows [T]'s [T_ext.name] into their [lowertext(B.name)]!"))
-					//Set as vore death if head
-					var/mob/dead/observer/G = T.ghostize(TRUE)
-					G.vore_death = TRUE
+					if (HAS_TRAIT(T, TRAIT_DEATHLESS) && HAS_TRAIT(T, TRAIT_EASYDECAPITATION))
+						T_ext.drop_limb(FALSE)
+						T_ext.forceMove(B)
+						visible_message(span_warning("[src] swallows [T]'s [T_ext.name] into their [lowertext(B.name)]!"))
+					else
+						T_ext.dismember(BRUTE, BCLASS_CUT, T, T_ext.body_part, 200, FALSE, TRUE)
+						T_ext.forceMove(B)
+						visible_message(span_warning("[src] swallows [T]'s [T_ext.name] into their [lowertext(B.name)]!"))
+						//Set as vore death if head
+						var/mob/dead/observer/G = T.ghostize(TRUE)
+						G.vore_death = TRUE
 				else
 					T_ext.drop_limb(1) //Clean cut so it doesn't kill the prey completely.
 					T_ext.forceMove(B)
@@ -127,15 +132,20 @@
 			else
 				playsound(T, 'sound/gore/flesh_eat_01.ogg', 100)
 				if (T_ext.body_part == HEAD)
-					T_ext.dismember(BRUTE, BCLASS_CUT, T, T_ext.body_part, 200, FALSE, TRUE)
-					T_ext.forceMove(B)
-					visible_message(span_warning("[src] tears off [T]'s [T_ext.name]!"),span_warning("You tear off [T]'s [T_ext.name]!"))
-					//Set as vore death if head
-					var/mob/dead/observer/G = T.ghostize(TRUE)
-					G.vore_death = TRUE
+					if (HAS_TRAIT(T, TRAIT_DEATHLESS) && HAS_TRAIT(T, TRAIT_EASYDECAPITATION))
+						T_ext.drop_limb(FALSE)
+						put_in_active_hand(T_ext)
+						visible_message(span_warning("[src] tears off [T]'s [T_ext.name]!"),span_warning("You tear off [T]'s [T_ext.name]!"))
+					else
+						T_ext.dismember(BRUTE, BCLASS_CUT, T, T_ext.body_part, 200, FALSE, TRUE)
+						visible_message(span_warning("[src] tears off [T]'s [T_ext.name]!"),span_warning("You tear off [T]'s [T_ext.name]!"))
+						put_in_active_hand(T_ext)
+						//Set as vore death if head
+						var/mob/dead/observer/G = T.ghostize(TRUE)
+						G.vore_death = TRUE
 				else
 					T_ext.drop_limb(1) //Clean cut so it doesn't kill the prey completely.
-					T_ext.forceMove(T.loc)
+					put_in_active_hand(T_ext)
 					visible_message(span_warning("[src] tears off [T]'s [T_ext.name]!"),span_warning("You tear off [T]'s [T_ext.name]!"))
 
 		//Not targeting an internal organ w/ > 25 damage , and the limb doesn't have < 25 damage.

--- a/modular_causticcove/code/modules/vore/eating/vore_verbs.dm
+++ b/modular_causticcove/code/modules/vore/eating/vore_verbs.dm
@@ -105,14 +105,18 @@
 		//Removing an external organ
 		/*else*/ if(/*!T_int && */T_ext.brute_dam >= 25)
 			//Is it groin/chest? You can't remove those.
+			//Updated damage numbers to work with OV's HP scaling, so that limbs can actually be removed.  Also added sound.
 			if(!T_ext.dismemberable)
-				T.apply_damage(25, BRUTE, T_ext)
+				T.apply_damage(250, BRUTE, T_ext)
+				playsound(T, 'sound/gore/flesh_eat_01.ogg', 100)
 				visible_message(span_danger("[src] severely damages [T]'s [T_ext.name]!"))
 			else if(B)
+				playsound(T, 'sound/gore/flesh_eat_01.ogg', 100)
 				T_ext.drop_limb(1) //Clean cut so it doesn't kill the prey completely.
 				T_ext.forceMove(B)
 				visible_message(span_warning("[src] swallows [T]'s [T_ext.name] into their [lowertext(B.name)]!"))
 			else
+				playsound(T, 'sound/gore/flesh_eat_01.ogg', 100)
 				T_ext.drop_limb(1) //Clean cut so it doesn't kill the prey completely.
 				T_ext.forceMove(T.loc)
 				visible_message(span_warning("[src] tears off [T]'s [T_ext.name]!"),span_warning("You tear off [T]'s [T_ext.name]!"))
@@ -121,8 +125,10 @@
 		else
 			//if(T_int)
 			//	T_int.damage = 25 //Internal organs can only take damage, not brute damage.
-			T.apply_damage(25, BRUTE, T_ext)
+			T.apply_damage(50, BRUTE, T_ext)
+			playsound(T, 'sound/gore/flesh_eat_01.ogg', 100)
 			visible_message(span_danger("[src] severely damages [T]'s [T_ext.name]!"))
+
 
 		log_combat(src,T,"Shredded (hardvore)")
 

--- a/modular_causticcove/code/modules/vore/eating/vore_verbs.dm
+++ b/modular_causticcove/code/modules/vore/eating/vore_verbs.dm
@@ -28,9 +28,10 @@
 	if(!istype(G))
 		to_chat(src,span_warning("You have to have a very strong grip on someone first!"))
 		return FALSE
-	if(G.grab_state != GRAB_NECK)
-		to_chat(src,span_warning("You must have a tighter grip to severely damage this creature!"))
-		return FALSE
+// Removing this check since it doesn't seem to be working.  Neck grabs don't allow bypassing it.
+//	if(G.grab_state != GRAB_NECK)
+//		to_chat(src,span_warning("You must have a tighter grip to severely damage this creature!"))
+//		return FALSE
 
 	return ..(G.grabbed)
 

--- a/modular_causticcove/code/modules/vore/eating/vore_verbs.dm
+++ b/modular_causticcove/code/modules/vore/eating/vore_verbs.dm
@@ -152,7 +152,7 @@
 		else
 			//if(T_int)
 			//	T_int.damage = 25 //Internal organs can only take damage, not brute damage.
-			T.apply_damage(50, BRUTE, T_ext)
+			T.apply_damage(25, BRUTE, T_ext)
 			playsound(T, 'sound/gore/flesh_eat_01.ogg', 100)
 			visible_message(span_danger("[src] severely damages [T]'s [T_ext.name]!"))
 


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->
Fixed the "damage prey organs" command under the vore tab from file vore_verbs.dm in modular_causticcove>code>modules>vore>eating.  Commented out a check for grab location as neck which was nonfunctional, modified damage values, ensured limb removal triggers properly on the second use per limb (or first if already damaged with >=25 brute damage), and set head removal to be lethal and count as a vore death, as far as local testing showed.  Also set a sound effect to play for the damaging of limbs rather than being completely silent.
## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [ ] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [ ] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [ ] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->
Local testing allows removal of limbs from any mobs which can be dismembered, including head.  Head removal now kills with this rather than leaving a headless mob able to move and shout.  Possessing a mob right before it dies from head removal wit this put the ghost generated in a state able to use the vore portals in the grove and coast, same as digestion death in a belly.
## Why It's Good For The Game

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your reasoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->
Limb removal for hard vore scenes can now function without needing an axe or risking bleeding out mid scene, as the limb removal function does not leave the prey bleeding (other than head removal).  Hard vore deaths from head eating count as a vore death to allow reformation, the same as digestion would provoke.
<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:Robin
fix: Damage Prey Organs command should now work to remove limbs without killing prey in a scene, unless you remove the head.  Organs may be auto-passed to vore organs or removed and dropped.  Head removal counts as a vore death and allows respawns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
