### PR TITLE
Dark Star over Sinistar

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/axe/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axe/axes.dm
@@ -274,8 +274,10 @@
 /obj/item/rogueweapon/stoneaxe/woodcut/steel/graggar
 	name = "vicious tomahawk"
 	icon_state = "graggartomahawk"
-	desc = "A handaxe of greater stature, intricately decorated with the Sinistar's heraldry. Worshippers wield it to strengthen their soul's connection \
+	//OV edit
+	desc = "A handaxe of greater stature, intricately decorated with the Dark Star's heraldry. Worshippers wield it to strengthen their soul's connection \
 	to the force of violence; a blessing, before they pursue the most dangerous game of all."
+	//OV edit end
 	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/axe/bash, /datum/intent/axe/thrust)
 	force = 30
 	wdefense = 5

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -464,7 +464,7 @@
 /obj/item/rogueweapon/handclaw/steel/graggaredged
 	name = "vicious sickleclaw"
 	desc = "A tainted mimicry of Ravox's falx, forever stained with the blood of the one they both cherished above all else. The fury of God, for \
-	just a moment, wilted before the sorrow of Man; before the wounded champion lept forth and drove His blade straight into the Sinistar's eye."
+	just a moment, wilted before the sorrow of Man; before the wounded champion lept forth and drove His blade straight into the Dark Star's eye." //OV edit
 	icon_state = "graggarpatasickle"
 	icon = 'icons/roguetown/weapons/unarmed32.dmi'
 	wdefense = 3

--- a/code/modules/clothing/rogueclothes/armor/chainmail.dm
+++ b/code/modules/clothing/rogueclothes/armor/chainmail.dm
@@ -265,7 +265,7 @@
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/graggar
 	name = "vicious hauberk"
-	desc = "The blessing of a Martyr is nothing, when put before the Sinistar's rage."
+	desc = "The blessing of a Martyr is nothing, when put before the Dark Star's rage." //OV EDIT
 	color = "#ddc0a7"
 	smeltresult = /obj/item/ingot/component/graggar
 	unenchantable = TRUE

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -425,7 +425,7 @@
 
 /obj/item/clothing/mask/rogue/facemask/steel/graggar
 	name = "vicious jawmask"
-	desc = "Shattered jaws, chipped teeth, sunken metal - fit for a skull of the same. It snarls in mimicry of the Sinistar's visage."
+	desc = "Shattered jaws, chipped teeth, sunken metal - fit for a skull of the same. It snarls in mimicry of the Dark Star's visage." //OV EDIT
 	icon_state = "graggarplatemask_heavy"
 	block2add = null
 

--- a/code/modules/spells/pantheon/inhumen/graggar.dm
+++ b/code/modules/spells/pantheon/inhumen/graggar.dm
@@ -29,9 +29,21 @@
 	overlay_icon = 'icons/mob/actions/graggarmiracles.dmi'
 	overlay_state = "bloodrage"
 	recharge_time = 5 MINUTES
-	invocations = list("SINISTAR, SHATTER MY BINDS!!", // VERY CLEAR that you are a heretic and VERY clear you've popped
-						"GRAGGAR, GRAGGAR, GRAGGAR!!", // your anti-stun Im Going to Kill You Now spell
-						"I EMBODY THE MOTIVE FORCE!!") // DO NOT add any ambiguious invocations
+	//OV edit - We just prefer this big range of incantations
+	invocations = list("GRAGGAAAAAAAAAAAR!!",
+		"WHERE'S THE DEATH?!!",
+		"YOU! CAN'T!! KILL!!! ME!!!!",
+		"I CAN HEAR EVERYTHING!!",
+		"WE'LL ALL GO TOGETHER!!",
+		"BLOOD AND NOISE, FOREVER PIERCING MY SKULL!!",
+		"I AM THE INSIDE OF THIS WORLD!!",
+		"I TASTE THE GORE! I SMELL THE CRYING! I! WANT! MORE!!",
+		"THE BLOOD IS IN MY EYES!! IT'S WAVES CRASH AGAINST MY FOREHEAD!!",
+		"LOOK AT ME WHEN I SCREAM INTO YOUR SOUL!!",
+		"GRAGGARDAMMERUUUUNG!!" // they took our night awayyy gotterdammeruuungggg
+	)
+	//OV edit end
+						
 	invocation_type = "shout"
 	sound = 'sound/magic/bloodrage.ogg'
 	releasedrain = 10
@@ -93,9 +105,11 @@
 //T1: Call to Slaughter - AoE buff for Inhumen surrounding you, debuff for Pantheoneers
 /datum/action/cooldown/spell/graggar/graggar_battlecry
 	name = "Call to Slaughter"
+	//OV edit
 	desc = "Grants you and all allies nearby a buff to their strength, willpower, and constitution. Debuffs followers of the Ten, but not Psydonites."
-	fluff_desc = "The battlefield quakes with your roar! Shaken to their core, they will prove easy pickings for a worthy champion such as yourself; the power of the Sinistar, unleashed.\
-	SLAUGHTER THE LAMBS - DRINK THEIR MARROW - FEAST UPON THEIR FLESH - LEAVE NO TRACE OF THEIR PATHETIC EXISTENCE! - THE SINISTAR HUNGERS!"
+	fluff_desc = "The battlefield quakes with your roar! Shaken to their core, they will prove easy pickings for a worthy champion such as yourself; the power of the Dark Star, unleashed.\
+	SLAUGHTER THE LAMBS - DRINK THEIR MARROW - FEAST UPON THEIR FLESH - LEAVE NO TRACE OF THEIR PATHETIC EXISTENCE! - THE DARK STAR HUNGERS!"
+	//OV edit end
 	button_icon_state = "call_to_slaughter"
 	sound = 'sound/magic/battle_cry_graggar.ogg'
 	glow_intensity = 0
@@ -107,7 +121,7 @@
 
 	secondary_resource_cost = SPELLCOST_UTILITY_BUFF
 
-	invocations = list("LAMBS TO THE SLAUGHTER!")
+	invocations = list("LAMBS TO THE SLAUGHTER!", "THE DARK STAR IS WATCHING!") //OV EDIT
 	invocation_type = INVOCATION_SHOUT
 
 	charge_required = FALSE
@@ -175,7 +189,7 @@
 	chargetime = 15
 	recharge_time = 40 SECONDS // no running, super slow. this FUCKS people. lower it if 40 is too much.
 	invocation_type = "shout"
-	invocations = list("BE STILL!!") // VERY loud. do NOT add other invocations, this projectile can FUUUCK people up and needs to be telegraphed.
+	invocations = list("TURN AND FACE THE BLOOD GOD!!") //OV EDIT - VERY loud. do NOT add other invocations, this projectile can FUUUCK people up and needs to be telegraphed.
 	sound = 'sound/magic/blood_net.ogg'
 	range = 8
 
@@ -256,7 +270,7 @@
 	chargetime = 10
 	chargedrain = 0
 	chargedloop = /datum/looping_sound/invokeevil
-	invocations = list("SINISTAR, MAKE THEM BLEED!")
+	invocations = list("SUFFER FOR THE DARK STAR!", "DARK STAR, MAKE THEM BLEED!") //OV EDIT
 	invocation_type = "shout"
 	sound = 'sound/magic/bleed_out.ogg'
 	releasedrain = 30

--- a/code/modules/spells/pantheon/inhumen/graggar.dm
+++ b/code/modules/spells/pantheon/inhumen/graggar.dm
@@ -129,7 +129,7 @@
 
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_SAME_Z
 
-/datum/action/cooldown/spell/ravox/graggar_battlecry/cast(atom/cast_on)
+/datum/action/cooldown/spell/graggar/graggar_battlecry/cast(atom/cast_on) //OV EDIT - corrects path
 	. = ..()
 	var/mob/living/carbon/human/H = owner
 	if(!istype(H))


### PR DESCRIPTION
## About The Pull Request

On request of other staff, I have changed most references of sinistar to dark star in cases where graggarites are referring to him, but kept sinistar in places where he's referred to by other groups.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game

We just prefer dark star over sinistar on the whole, it sounds much less cartoonish.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: On request of other staff, I have changed most references of sinistar to dark star in cases where graggarites are referring to him, but kept sinistar in places where he's referred to by other groups.
fix: Fixed path on call to slaughter cast
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
