### PR TITLE
Functional tanto sheath parrying + reinforced variant for the Sasu

### DIFF
--- a/code/game/objects/items/scabbard.dm
+++ b/code/game/objects/items/scabbard.dm
@@ -608,9 +608,9 @@
 	possible_item_intents = list(SHIELD_BASH, SHIELD_BLOCK)
 	can_parry = TRUE
 	sewrepair = FALSE
-	wdefense = 3
+	wdefense = 6 ///OV change, from 3. Less than sword sheath at 8 and parry daggers at 9.
 
-	max_integrity = 0
+	max_integrity = 220 ///OV change, from infinite. Same as sword sheath on the gui-in and seonjang.
 
 /obj/item/rogueweapon/scabbard/sheath/courtphysician
 	name = "fancy cane"


### PR DESCRIPTION
## About The Pull Request

The tanto sheath that the Ruma Sasu gets can be used to parry, much like the sword scabbards of the other Ruma mercenaries. However, it has a weapon defense value of three, the same as the steel dagger that goes with it, so if you try to offhand it the game just uses the dagger to defend and ignores the scabbard entirely, rendering it useless. It also has infinite integrity.

This PR forks the tanto sheath into two types, the default one and a reinforced one. The default sheath has its wdef bumped up from 3 to 4, enough to make it function, while the reinforced variant clocks in at 6 wdef, enough to make it useful while still being below the sword sheaths (at 8) and actual parrying daggers and shields (at 9+), while also giving both a finite integrity of 220, the same as the sword scabbards get.

The majority of roles that spawn with this can also access the superior sword sheaths (both other Ruma, Mistwalker, Hangyako chonin), so this change should mostly only impact the Sasu and the Eastern Adventurer (the latter being the reason for the split, so it's defensive capabilities were not increased too significantly) 

firstPRsohopeitworkssmoothly


## Developer's checklist

- [X] Try to modularize as much as possible.
- [X] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
- [ ] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Still trying to get a local testing setup working, but this is relatively small.



## Why It's Good For The Game

Sheath parrying is cool, a sheath that's got a listed defense value yet completely refuses to work alongside its dagger is uncool. This lets everyone with a tanto sheath use it as a defensive tool in a pinch.

Helps support the Sasu having more playstyle options, in that they could always focus on their bow and quickly swap to their knife to finish weakened foes, but fully leaning into melee could face issues due to limited durability and defense. Buying a parrying dagger currently allows them to compensate and perform as a faster, weaker version of their sword duelist siblings, and this PR aims to allow them to use their sheath as a stepping stone to that point, or as a weaker alternative that is less demanding on storage space.

Ideally, this results in the Sasu fluidly swapping between bow, knife, and knife+sheath configurations as the situation demands, with the ability to fork out and upgrade to an improved parrying tool when expecting particularly difficult melee fights.


## Changelog

:cl:
add: Added new mechanics or gameplay changes
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
code: changed some code
/:cl:
