### PR TITLE
Functional tanto sheath parrying + reinforced variant

### DIFF
--- a/code/game/objects/items/scabbard.dm
+++ b/code/game/objects/items/scabbard.dm
@@ -608,9 +608,18 @@
 	possible_item_intents = list(SHIELD_BASH, SHIELD_BLOCK)
 	can_parry = TRUE
 	sewrepair = FALSE
-	wdefense = 3
+	wdefense = 4 ///OV edit, from 3 to 4 to make sure offhand parrying functions when used alongside the 3 wdef steel dagger
 
-	max_integrity = 0
+	max_integrity = 220 ///OV edit, on par with the sword scabbards
+
+///OV edit start, variant sheath for the Sasu with improved defence. Exists so that the Eastern Assassin adventurer is not rocking 6 wdef on knife scaling.
+
+/obj/item/rogueweapon/scabbard/sheath/kazengun/reinforced
+	name = "reinforced lacquer sheath"
+	desc = "A simple lacquered sheath with additional reinforcement, for shorter eastern-styled blades."
+	wdefense = 6 ///Less than a sword sheath at 8, or a parrying dagger at 9, so still a weaker duelist and room to buy upgrades.
+
+///OV edit end
 
 /obj/item/rogueweapon/scabbard/sheath/courtphysician
 	name = "fancy cane"

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/rumaclan.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/rumaclan.dm
@@ -99,6 +99,6 @@
 		/obj/item/roguekey/mercenary = 1,
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
 		/obj/item/rogueweapon/huntingknife/idagger/steel/kazengun = 1,
-		/obj/item/rogueweapon/scabbard/sheath/kazengun = 1,
+		/obj/item/rogueweapon/scabbard/sheath/kazengun/reinforced = 1, ///OV edit for improved variant sheath
 		)
 	H.merctype = 9


### PR DESCRIPTION
## About The Pull Request

The tanto sheath that the Ruma Sasu gets can be used to parry, much like the sword scabbards of the other Ruma mercenaries. However, it has a weapon defense value of three, the same as the steel dagger that goes with it, so if you try to offhand it the game just uses the dagger to defend and ignores the scabbard entirely, rendering it useless. It also has infinite integrity.

This PR forks the tanto sheath into two types, the default one and a reinforced one. The default sheath has its wdef bumped up from 3 to 4, enough to make it function, while the reinforced variant clocks in at 6 wdef, enough to make it useful while still being below the sword sheaths (at 8) and actual parrying daggers and shields (at 9+), while also giving both a finite integrity of 220 (in the code, actually 176 ingame for reasons), the same as the sword scabbards get.

The majority of roles that spawn with this can also access the superior sword sheaths (both other Ruma, Mistwalker, Hangyako chonin), so this change should mostly only impact the Sasu and the Eastern Adventurer (the latter being the reason for the split, so it's defensive capabilities were not increased too significantly)

firstPRsohopeitworkssmoothly


## Developer's checklist

- [X] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [X] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
- [X] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.


## Testing Evidence

<img width="597" height="343" alt="image" src="https://github.com/user-attachments/assets/67fc7d2a-b172-4d8f-92bf-5844cc02a975" />
<img width="582" height="76" alt="image" src="https://github.com/user-attachments/assets/de064b82-2661-4b96-8435-4a6bdb6afa37" />
<img width="590" height="343" alt="image" src="https://github.com/user-attachments/assets/248344e9-96d1-4cda-b01d-f6644f6034c7" />
<img width="588" height="369" alt="image" src="https://github.com/user-attachments/assets/23a76365-1e3d-4f13-9a00-bc7059abf5b4" />




## Why It's Good For The Game

Sheath parrying is cool, a sheath that's got a listed defense value yet completely refuses to work alongside its dagger is uncool. This lets everyone with a tanto sheath use it as a defensive tool in a pinch.

Helps support the Sasu having more playstyle options, in that they could always focus on their bow and quickly swap to their knife to finish weakened foes, but fully leaning into melee could face issues due to limited durability and defense. Buying a parrying dagger currently allows them to compensate and perform as a faster, weaker version of their sword duelist siblings, and this PR aims to allow them to use their sheath as a stepping stone to that point, or as a weaker alternative that is less demanding on storage space.

Ideally, this results in the Sasu fluidly swapping between bow, knife, and knife+sheath configurations as the situation demands, with the ability to fork out and upgrade to an improved parrying tool when expecting particularly difficult melee fights.

## Changelog


:cl:
add: Added new mechanics or gameplay changes
add: Added more things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
code: changed some code
/:cl:
