### PR TITLE
Stomach Growl Emote

### DIFF
--- a/code/modules/mob/living/carbon/human/voicepacks/genfemale.dm
+++ b/code/modules/mob/living/carbon/human/voicepacks/genfemale.dm
@@ -176,4 +176,6 @@
 				used = list('sound/vo/LizardThump.ogg')
 			if("coo") // OV Add: Coo emote
 				used = list('modular_ochrevalley/sounds/vo/mobs/bird/dovecoo.ogg') // OV Add: Coo emote
+			if("stomach_growl") //OV ADD
+				used = list('sound/vo/hungry1.ogg','sound/vo/hungry2.ogg','sound/vo/hungry3.ogg','sound/vo/hungry4.ogg') //OV ADD
 	return used

--- a/code/modules/mob/living/carbon/human/voicepacks/genmale.dm
+++ b/code/modules/mob/living/carbon/human/voicepacks/genmale.dm
@@ -179,4 +179,6 @@
 				used = list('sound/vo/LizardThump.ogg')
 			if("coo") // OV Add: Coo emote
 				used = list('modular_ochrevalley/sounds/vo/mobs/bird/dovecoo.ogg') // OV Add: Coo emote
+			if("stomach_growl") //OV ADD
+				used = list('sound/vo/hungry1.ogg','sound/vo/hungry2.ogg','sound/vo/hungry3.ogg','sound/vo/hungry4.ogg') //OV ADD
 	return used

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -2003,3 +2003,17 @@
 		
 	to_chat(src, span_warning("You can't [direction == UP ? "emerge" : "dive"] here."))
 	return FALSE
+
+//OV edit
+/datum/emote/living/stomach_growl
+	key = "stomach_growl"
+	message = "emits a rumbling growl from their middle."
+	emote_type = EMOTE_AUDIBLE
+	show_runechat = FALSE
+
+/mob/living/carbon/human/verb/emote_stomach_growl()
+	set name = "Stomach Growl"
+	set category = "Noises"
+
+	emote("stomach_growl", intentional = TRUE)
+//OV edit end


### PR DESCRIPTION


## About The Pull Request

Added a Stomach Growl emote to play hunger noises on command.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Tested and works fine!

## Why It's Good For The Game

hot

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added a Stomach Growl emote to play hunger noises on command.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
