### PR TITLE
Fix marriage bug and adjust Nyx & Joey Larkens fluff items

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -179,7 +179,7 @@
 
 		if(!gibbed && yeae)
 			for(var/mob/living/carbon/human/HU in viewers(7, src))
-				if(HU.marriedto == src)
+				if(HU.marriedto == name) // OV Edit: Fix bug
 					HU.adjust_triumphs(-1)
 
 	. = ..()
@@ -214,7 +214,7 @@
 		if(CA != src && !HAS_TRAIT(CA, TRAIT_BLIND))
 			if(HAS_TRAIT(CA, TRAIT_STEELHEARTED))
 				continue
-			if(CA.marriedto == src)
+			if(CA.marriedto == name) // OV Edit: Fix bug
 				CA.adjust_triumphs(-1)
 			CA.add_stress(/datum/stressevent/viewgib)
 	return ..()

--- a/modular_ochrevalley/code/datums/loadout/fluff/loadout_accessories.dm
+++ b/modular_ochrevalley/code/datums/loadout/fluff/loadout_accessories.dm
@@ -17,6 +17,12 @@
 	. = ..()
 	add_filter("fluff", 2, list("type" = "outline", "color" = "#800080", "alpha" = 120, "size" = 1))
 
+/obj/item/clothing/ring/band/paalloy/childsoldieropportunist_wedding_band/equipped(mob/living/carbon/human/user, slot)
+	. = ..()
+	// automatically reapply marriage when equipped by correct person
+	if(istype(user) && user.ckey == "childsoldieropportunist" && !user.marriedto)
+		user.marriedto = "Nyx Larkens"
+
 //tigercat2000:Nyx Larkens
 /datum/loadout_item/ochre_fluff/tigercat2000_wedding_band
 	name = "Bunny Ring"
@@ -30,3 +36,9 @@
 /obj/item/clothing/ring/band/tigercat2000_wedding_band/Initialize()
 	. = ..()
 	add_filter("fluff", 2, list("type" = "outline", "color" = "#4cdbe5", "alpha" = 120, "size" = 1))
+
+/obj/item/clothing/ring/band/tigercat2000_wedding_band/equipped(mob/living/carbon/human/user, slot)
+	. = ..()
+	// automatically reapply marriage when equipped by correct person
+	if(istype(user) && user.ckey == "tigercat2000" && !user.marriedto)
+		user.marriedto = "Joey Larkens"


### PR DESCRIPTION
## About The Pull Request

This makes me and Joey's rings automatically set `marriedto` when being picked up by the correct person. All that `marriedto` actually does is show some cute examine text saying "This is my partner!" and prevent us from partaking in another marriage ceremony, so there shouldn't be any gameplay implications.

Also fixes a bug I spotted - married people are supposed to lose a triumph upon observing each other dying, but it checked against a reference instead of their name.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence
I tested it I prommie

## Why It's Good For The Game
Just a little thing that makes us both happy~

## Changelog
:cl:
fix: Married people witnessing their partner's death lose a triumph correctly now.
/:cl:
