### PR TITLE
Retain vore_selected in belly transfers

### DIFF
--- a/modular_ochrevalley/code/modules/vore/shapeshift_vore.dm
+++ b/modular_ochrevalley/code/modules/vore/shapeshift_vore.dm
@@ -1,4 +1,5 @@
 /mob/living/proc/mob_belly_transfer(var/mob/living/M)
+	var/obj/belly/vore_selected_storage = M.vore_selected
 	for(var/obj/belly/B as anything in vore_organs) //First remove all existing bellies in the MOB you're transforming into, otherwise it duplicates the bellies and I'm not sure why
 		qdel(B)
 	for(var/obj/belly/B as anything in M.vore_organs) //Then move all the bellies over, including all their contents
@@ -7,3 +8,7 @@
 		B.owner = src
 		M.vore_organs -= B
 		src.vore_organs += B
+	if(vore_selected_storage)
+		vore_selected = vore_selected_storage
+	else
+		vore_selected = pick(vore_organs)


### PR DESCRIPTION


## About The Pull Request

Ensure that the selected belly is maintained when bellies are transferred between mobs.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game

This should prevent errors appearing on mob TF.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Ensure that the selected belly is maintained when bellies are transferred between mobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
