### PR TITLE
Dolabra option for Laborious Apprentice virtue

### DIFF
--- a/code/modules/virtues/crafter.dm
+++ b/code/modules/virtues/crafter.dm
@@ -126,7 +126,8 @@
 		"Mining Skill (+3, Up to Legendary)" = list(/datum/skill/labor/mining, TRAIT_SMITHING_EXPERT),
 		"Lumberjacking Skill (+3, Up to Legendary)" = /datum/skill/labor/lumberjacking,
 		"Stashed Steel Axe" = /obj/item/rogueweapon/stoneaxe/woodcut/steel/woodcutter,
-		"Stashed Steel Pickaxe" = /obj/item/rogueweapon/pick/steel
+		"Stashed Steel Pickaxe" = /obj/item/rogueweapon/pick/steel,
+		"Stashed Bronze Dolabra" = /obj/item/rogueweapon/pick/bronze /// OV edit, worse than both other tools at their job, but can do both jobs.
 	)
 
 /datum/virtue/utility/apprentice/apply_to_human(mob/living/carbon/human/recipient)


### PR DESCRIPTION
## About The Pull Request

Adds a bronze dolabra option to the laborious apprentice virtue, as a more versatile but lower force/integ alternative to the existing steel tools.

## Developer's checklist
- [X] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [X] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
- [X] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Works fine, 2-line change.

<img width="400" height="373" alt="image" src="https://github.com/user-attachments/assets/dd026172-affd-4dd8-bcdc-143921d67181" />
<img width="361" height="294" alt="image" src="https://github.com/user-attachments/assets/44f31a76-1a00-462b-aa19-5bf13200a36a" />
<img width="601" height="452" alt="image" src="https://github.com/user-attachments/assets/46c06201-a180-41c2-a3be-2cf9bb320b61" />


## Why It's Good For The Game

More options are good, dolabra are neat, and it's firmly a sidegrade to the existing options.

## Changelog
:cl:
add: Added new mechanics or gameplay changes
add: Added more things
code: changed some code
/:cl: