### PR TITLE
Disables storyteller dreamwalker event

### DIFF
--- a/code/modules/events/antagonist/solo/dreamwalker.dm
+++ b/code/modules/events/antagonist/solo/dreamwalker.dm
@@ -1,3 +1,6 @@
+// OV Add Start: We've disabled this event.
+#error This file has been deliberately disabled by Ochre Valley and must remain unticked!
+// OV Add End
 /datum/round_event_control/antagonist/solo/dreamwalker
 	name = "Dreamwalker"
 	tags = list(

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1869,7 +1869,6 @@
 #include "code\modules\events\antagonist\solo\_base.dm"
 #include "code\modules\events\antagonist\solo\assassins.dm"
 #include "code\modules\events\antagonist\solo\bandits.dm"
-#include "code\modules\events\antagonist\solo\dreamwalker.dm"
 #include "code\modules\events\antagonist\solo\lich.dm"
 #include "code\modules\events\antagonist\solo\masquerade.dm"
 #include "code\modules\events\antagonist\solo\rebels.dm"

--- a/tools/ticked_file_enforcement/schemas/roguetown_dme.json
+++ b/tools/ticked_file_enforcement/schemas/roguetown_dme.json
@@ -8,6 +8,7 @@
 		"code/modules/photography/_pictures.dm",
         "code/modules/events/raids/goblin.dm",
         "code/modules/events/raids/skeleton.dm",
+		"code/modules/events/antagonist/solo/dreamwalker.dm",
 		"code/modules/tgs/**/*.dm",
 		"code/modules/unit_tests/[!_]*.dm"
 	]


### PR DESCRIPTION
(cherry picked from commit 34b1a423eebea971f4a0a01ede5ec9eca50ded98)

## About The Pull Request

<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->
Stops the Dreamwalker character injection event from compiling, thereby stopping storytellers from completely ignoring all event settings to force such an event anyway (why do they do this)

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [ ] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [ ] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [ ] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->
This one is difficult to test due to the event requiring a population threshold to be met before triggering that I physically cannot replicate in my own private testing server. However, like with https://github.com/Ochre-Valley/Ochre-Valley/pull/237 , this should work just fine.

## Why It's Good For The Game

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
<img width="495" height="275" alt="image" src="https://github.com/user-attachments/assets/9e088c03-163a-4251-a49d-8636f5186acf" />


## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
sound: added/modified/removed audio or sound effects
image: added/modified/removed some icons or images
map: added/modified/removed map content
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
