### PR TITLE
Ravenous - A vice of more reasonable appetite than Bottomless

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\ovdun_world\ochre_CentCom.dmm"
 

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\ovdun_world\ochre_CentCom.dmm"
 

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -45,6 +45,7 @@ GLOBAL_LIST_INIT(character_flaws, list(
 	//OV Add Start
 	/datum/charflaw/hemovore::name=/datum/charflaw/hemovore,
 	/datum/charflaw/dendor_touched::name=/datum/charflaw/dendor_touched,
+	/datum/charflaw/ravenous::name=/datum/charflaw/ravenous,
 	//OV Add End
 	))
 

--- a/modular_causticcove/code/modules/vices/bottomless/bottomless.dm
+++ b/modular_causticcove/code/modules/vices/bottomless/bottomless.dm
@@ -1,6 +1,6 @@
 /datum/charflaw/bottomless
 	name = "Bottomless"
-	desc = "More food! MORE!"
+	desc = "My hunger grows exponentially and without limit! I need more food! MORE!" //OV Edit - Description expanded upon to differentiate from Ravenous
 	var/last_check = 0
 
 /datum/charflaw/bottomless/flaw_on_life(mob/user)

--- a/modular_causticcove/code/modules/vices/bottomless/bottomless.dm
+++ b/modular_causticcove/code/modules/vices/bottomless/bottomless.dm
@@ -1,6 +1,8 @@
 /datum/charflaw/bottomless
 	name = "Bottomless"
-	desc = "My hunger grows exponentially and without limit! I need more food! MORE!" //OV Edit - Description expanded upon to differentiate from Ravenous
+	//OV edit - Description expanded upon to differentiate from Ravenous
+	desc = "My hunger grows exponentially and without limit! I need more food! MORE!"
+	//OV edit end
 	var/last_check = 0
 
 /datum/charflaw/bottomless/flaw_on_life(mob/user)

--- a/modular_ochrevalley/code/modules/vices/ravenous.dm
+++ b/modular_ochrevalley/code/modules/vices/ravenous.dm
@@ -1,7 +1,5 @@
-/mob //Code taken directly from the "Bottomless" Vice from Caustic Cove, modified for linear progression rather than exponential
-	var/maxnutrition = NUTRITION_LEVEL_FULL
-/datum/charflaw/ravenous 
-//The Vice itself
+/Code taken directly from the "Bottomless" Vice from Caustic Cove, modified for linear progression rather than exponential
+/datum/charflaw/ravenous //The Vice itself
 	name = "Ravenous"
 	desc = "No matter how much I eat, I still feel empty..."
 	var/last_check = 0

--- a/modular_ochrevalley/code/modules/vices/ravenous.dm
+++ b/modular_ochrevalley/code/modules/vices/ravenous.dm
@@ -1,11 +1,10 @@
-/mob //Code taken directly from the "Bottomless" Vice from Caustic Cove, modified for linear progression rather than exponential
-	var/maxnutrition = NUTRITION_LEVEL_FULL
+//Code taken directly from the "Bottomless" Vice from Caustic Cove, modified for linear progression rather than exponential
 //The Vice itself
+//We're calling variables that are defined by Caustic Cove's Bottomless vice, so if that vice gets tweaked down the line, this one will need to be updated accordingly!
 /datum/charflaw/ravenous
 	name = "Ravenous"
 	desc = "No matter how much I eat, I still feel empty..."
-	var/last_check = 0
-//The Vice's workflow
+//The Vice's workflow, again taken directly from CC but with two minor modifications
 /datum/charflaw/ravenous/flaw_on_life(mob/user)
 	. = ..()
 	if(world.time < last_check + 10 SECONDS)
@@ -15,14 +14,9 @@
 	if(user.stat == DEAD)
 		return
 	last_check = world.time
-	
-	user.maxnutrition += user.maxnutrition + 2.500
+	if(user.maxnutrition < 2000)
+		user.maxnutrition += user.maxnutrition + 10
 	if(user.maxnutrition * 0.8 > user.nutrition)
-		user.add_stress(/datum/stressevent/hungy)
+		user.add_stress(/datum/stressevent/glutton)
 	else
-		user.remove_stress(/datum/stressevent/hungy)
-//The Vice's mood penalty if it isn't fulfilled
-/datum/stressevent/hungy
-	timer = 10 MINUTES
-	stressadd = 5
-	desc = span_red("I feel painfully empty, I need to eat more! More!!")
+		user.remove_stress(/datum/stressevent/glutton)

--- a/modular_ochrevalley/code/modules/vices/ravenous.dm
+++ b/modular_ochrevalley/code/modules/vices/ravenous.dm
@@ -1,3 +1,6 @@
+/mob
+	var/maxnutrition = NUTRITION_LEVEL_FULL
+
 /datum/charflaw/ravenous //Code taken directly from the "Bottomless" Vice from Caustic Cove, modified for linear progression rather than exponential
 	name = "Ravenous" //The Vice itself
 	desc = "My hunger constantly grows, up to a point. Even when I should be full, I still feel empty..."

--- a/modular_ochrevalley/code/modules/vices/ravenous.dm
+++ b/modular_ochrevalley/code/modules/vices/ravenous.dm
@@ -1,6 +1,6 @@
 /datum/charflaw/ravenous //Code taken directly from the "Bottomless" Vice from Caustic Cove, modified for linear progression rather than exponential
 	name = "Ravenous" //The Vice itself
-	desc = "No matter how much I eat, I still feel empty..."
+	desc = "My hunger constantly grows, up to a point. Even when I should be full, I still feel empty..."
 	var/last_check = 0
 
 /datum/charflaw/ravenous/flaw_on_life(mob/user) //The Vice's workflow, again taken directly from CC but with two minor modifications

--- a/modular_ochrevalley/code/modules/vices/ravenous.dm
+++ b/modular_ochrevalley/code/modules/vices/ravenous.dm
@@ -12,7 +12,7 @@
 	if(user.stat == DEAD)
 		return
 	last_check = world.time
-	if(user.maxnutrition < 7000) //This is the Cap that prevents it from scaling beyond a value: 6k-8k nutrition cap suggested by Ryumi
+	if(user.maxnutrition < 7000) //This is the Cap that prevents it from scaling beyond a value: 6k-8k value suggested by Ryumi
 		user.maxnutrition += user.maxnutrition + 10 //Calling a CC variable
 	if(user.maxnutrition * 0.8 > user.nutrition)
 		user.add_stress(/datum/stressevent/glutton) //Calling a CC stressevent

--- a/modular_ochrevalley/code/modules/vices/ravenous.dm
+++ b/modular_ochrevalley/code/modules/vices/ravenous.dm
@@ -1,6 +1,3 @@
-/mob
-	var/maxnutrition = NUTRITION_LEVEL_FULL
-
 /datum/charflaw/ravenous //Code taken directly from the "Bottomless" Vice from Caustic Cove, modified for linear progression rather than exponential
 	name = "Ravenous" //The Vice itself
 	desc = "My hunger constantly grows, up to a point. Even when I should be full, I still feel empty..."

--- a/modular_ochrevalley/code/modules/vices/ravenous.dm
+++ b/modular_ochrevalley/code/modules/vices/ravenous.dm
@@ -1,8 +1,9 @@
 /datum/charflaw/ravenous //Code taken directly from the "Bottomless" Vice from Caustic Cove, modified for linear progression rather than exponential
 //The Vice itself
-//We're calling variables that are defined by Caustic Cove's Bottomless vice, so if that vice gets tweaked down the line, this one will need to be updated accordingly!
+//We're calling some variables that are defined by Caustic Cove's Bottomless vice, so if that vice gets tweaked down the line, this one will need to be updated accordingly!
 	name = "Ravenous"
 	desc = "No matter how much I eat, I still feel empty..."
+	var/last_check = 0
 //The Vice's workflow, again taken directly from CC but with two minor modifications
 /datum/charflaw/ravenous/flaw_on_life(mob/user)
 	. = ..()
@@ -12,7 +13,7 @@
 		return
 	if(user.stat == DEAD)
 		return
-	last_check = world.time //Calling a CC variable
+	last_check = world.time
 	if(user.maxnutrition < 7000) //This is the Cap that prevents it from scaling beyond a value: 6k-8k nutrition cap suggested by Ryumi
 		user.maxnutrition += user.maxnutrition + 10 //Also calling a CC variable
 	if(user.maxnutrition * 0.8 > user.nutrition)

--- a/modular_ochrevalley/code/modules/vices/ravenous.dm
+++ b/modular_ochrevalley/code/modules/vices/ravenous.dm
@@ -12,8 +12,8 @@
 	if(user.stat == DEAD)
 		return
 	last_check = world.time
-	if(user.maxnutrition < 7000) //This is the Cap that prevents it from scaling beyond a value: 6k-8k value suggested by Ryumi
-		user.maxnutrition += user.maxnutrition + 10 //Calling a CC variable
+	//if(user.maxnutrition < 7000) //This is the Cap that prevents it from scaling beyond a value: 6k-8k value suggested by Ryumi
+	user.maxnutrition += user.maxnutrition + 10 //Calling a CC variable
 	if(user.maxnutrition * 0.8 > user.nutrition)
 		user.add_stress(/datum/stressevent/glutton) //Calling a CC stressevent
 	else

--- a/modular_ochrevalley/code/modules/vices/ravenous.dm
+++ b/modular_ochrevalley/code/modules/vices/ravenous.dm
@@ -1,4 +1,4 @@
-/Code taken directly from the "Bottomless" Vice from Caustic Cove, modified for linear progression rather than exponential
+//Code taken directly from the "Bottomless" Vice from Caustic Cove, modified for linear progression rather than exponential
 /datum/charflaw/ravenous //The Vice itself
 	name = "Ravenous"
 	desc = "No matter how much I eat, I still feel empty..."

--- a/modular_ochrevalley/code/modules/vices/ravenous.dm
+++ b/modular_ochrevalley/code/modules/vices/ravenous.dm
@@ -1,10 +1,9 @@
-//Code taken directly from the "Bottomless" Vice from Caustic Cove, modified for linear progression rather than exponential
-/datum/charflaw/ravenous //The Vice itself
-	name = "Ravenous"
+/datum/charflaw/ravenous //Code taken directly from the "Bottomless" Vice from Caustic Cove, modified for linear progression rather than exponential
+	name = "Ravenous" //The Vice itself
 	desc = "No matter how much I eat, I still feel empty..."
 	var/last_check = 0
-//The Vice's workflow, again taken directly from CC but with two minor modifications
-/datum/charflaw/ravenous/flaw_on_life(mob/user)
+
+/datum/charflaw/ravenous/flaw_on_life(mob/user) //The Vice's workflow, again taken directly from CC but with two minor modifications
 	. = ..()
 	if(world.time < last_check + 10 SECONDS)
 		return
@@ -14,7 +13,7 @@
 		return
 	last_check = world.time
 	if(user.maxnutrition < 7000) //This is the Cap that prevents it from scaling beyond a value: 6k-8k nutrition cap suggested by Ryumi
-		user.maxnutrition += user.maxnutrition + 10 //Also calling a CC variable
+		user.maxnutrition += user.maxnutrition + 10 //Calling a CC variable
 	if(user.maxnutrition * 0.8 > user.nutrition)
 		user.add_stress(/datum/stressevent/glutton) //Calling a CC stressevent
 	else

--- a/modular_ochrevalley/code/modules/vices/ravenous.dm
+++ b/modular_ochrevalley/code/modules/vices/ravenous.dm
@@ -1,0 +1,28 @@
+/mob
+	var/maxnutrition = NUTRITION_LEVEL_FULL
+
+/datum/charflaw/ravenous
+	name = "Ravenous"
+	desc = "No matter how much I eat, I still feel empty..."
+	var/last_check = 0
+
+/datum/charflaw/ravenous/flaw_on_life(mob/user)
+	. = ..()
+	if(world.time < last_check + 10 SECONDS)
+		return
+	if(!user)
+		return
+	if(user.stat == DEAD)
+		return
+	last_check = world.time
+	
+	user.maxnutrition += user.maxnutrition + 2.500
+	if(user.maxnutrition * 0.8 > user.nutrition)
+		user.add_stress(/datum/stressevent/hungy)
+	else
+		user.remove_stress(/datum/stressevent/hungy)
+
+/datum/stressevent/hungy
+	timer = 10 MINUTES
+	stressadd = 5
+	desc = span_red("I feel painfully empty, I need to eat more! More!!")

--- a/modular_ochrevalley/code/modules/vices/ravenous.dm
+++ b/modular_ochrevalley/code/modules/vices/ravenous.dm
@@ -1,7 +1,6 @@
-//Code taken directly from the "Bottomless" Vice from Caustic Cove, modified for linear progression rather than exponential
+/datum/charflaw/ravenous //Code taken directly from the "Bottomless" Vice from Caustic Cove, modified for linear progression rather than exponential
 //The Vice itself
 //We're calling variables that are defined by Caustic Cove's Bottomless vice, so if that vice gets tweaked down the line, this one will need to be updated accordingly!
-/datum/charflaw/ravenous
 	name = "Ravenous"
 	desc = "No matter how much I eat, I still feel empty..."
 //The Vice's workflow, again taken directly from CC but with two minor modifications

--- a/modular_ochrevalley/code/modules/vices/ravenous.dm
+++ b/modular_ochrevalley/code/modules/vices/ravenous.dm
@@ -1,6 +1,7 @@
-/datum/charflaw/ravenous //Code taken directly from the "Bottomless" Vice from Caustic Cove, modified for linear progression rather than exponential
+/mob //Code taken directly from the "Bottomless" Vice from Caustic Cove, modified for linear progression rather than exponential
+	var/maxnutrition = NUTRITION_LEVEL_FULL
+/datum/charflaw/ravenous 
 //The Vice itself
-//We're calling some variables that are defined by Caustic Cove's Bottomless vice, so if that vice gets tweaked down the line, this one will need to be updated accordingly!
 	name = "Ravenous"
 	desc = "No matter how much I eat, I still feel empty..."
 	var/last_check = 0

--- a/modular_ochrevalley/code/modules/vices/ravenous.dm
+++ b/modular_ochrevalley/code/modules/vices/ravenous.dm
@@ -16,7 +16,7 @@
 		return
 	last_check = world.time
 		if(user.maxnutrition < 7000) //This is the Cap that prevents it from scaling beyond a value: 6k-8k value suggested by Ryumi
-	user.maxnutrition += (user.maxnutrition + 10) //Calling a CC variable
+	user.maxnutrition += user.maxnutrition * 0.1 //Calling a CC variable
 	if(user.maxnutrition * 0.8 > user.nutrition)
 		user.add_stress(/datum/stressevent/glutton) //Calling a CC stressevent
 	else

--- a/modular_ochrevalley/code/modules/vices/ravenous.dm
+++ b/modular_ochrevalley/code/modules/vices/ravenous.dm
@@ -12,8 +12,8 @@
 	if(user.stat == DEAD)
 		return
 	last_check = world.time
-		if(user.maxnutrition < 7000) //This is the Cap that prevents it from scaling beyond a value: 6k-8k value suggested by Ryumi
-	user.maxnutrition += user.maxnutrition * 0.1 //Calling a CC variable
+	if(user.maxnutrition < 7000) //This is the Cap that prevents it from scaling beyond a value: 6k-8k value suggested by Ryumi
+		user.maxnutrition += 10.0 //Calling a CC variable
 	if(user.maxnutrition * 0.8 > user.nutrition)
 		user.add_stress(/datum/stressevent/glutton) //Calling a CC stressevent
 	else

--- a/modular_ochrevalley/code/modules/vices/ravenous.dm
+++ b/modular_ochrevalley/code/modules/vices/ravenous.dm
@@ -13,10 +13,10 @@
 		return
 	if(user.stat == DEAD)
 		return
-	last_check = world.time
-	if(user.maxnutrition < 2000)
-		user.maxnutrition += user.maxnutrition + 10
+	last_check = world.time //Calling a CC variable
+	if(user.maxnutrition < 7000) //This is the Cap that prevents it from scaling beyond a value: 6k-8k nutrition cap suggested by Ryumi
+		user.maxnutrition += user.maxnutrition + 10 //Also calling a CC variable
 	if(user.maxnutrition * 0.8 > user.nutrition)
-		user.add_stress(/datum/stressevent/glutton)
+		user.add_stress(/datum/stressevent/glutton) //Calling a CC stressevent
 	else
 		user.remove_stress(/datum/stressevent/glutton)

--- a/modular_ochrevalley/code/modules/vices/ravenous.dm
+++ b/modular_ochrevalley/code/modules/vices/ravenous.dm
@@ -12,7 +12,7 @@
 	if(user.stat == DEAD)
 		return
 	last_check = world.time
-	//if(user.maxnutrition < 7000) //This is the Cap that prevents it from scaling beyond a value: 6k-8k value suggested by Ryumi
+		if(user.maxnutrition < 7000) //This is the Cap that prevents it from scaling beyond a value: 6k-8k value suggested by Ryumi
 	user.maxnutrition += user.maxnutrition + 10 //Calling a CC variable
 	if(user.maxnutrition * 0.8 > user.nutrition)
 		user.add_stress(/datum/stressevent/glutton) //Calling a CC stressevent

--- a/modular_ochrevalley/code/modules/vices/ravenous.dm
+++ b/modular_ochrevalley/code/modules/vices/ravenous.dm
@@ -1,11 +1,11 @@
-/mob
+/mob //Code taken directly from the "Bottomless" Vice from Caustic Cove, modified for linear progression rather than exponential
 	var/maxnutrition = NUTRITION_LEVEL_FULL
-
+//The Vice itself
 /datum/charflaw/ravenous
 	name = "Ravenous"
 	desc = "No matter how much I eat, I still feel empty..."
 	var/last_check = 0
-
+//The Vice's workflow
 /datum/charflaw/ravenous/flaw_on_life(mob/user)
 	. = ..()
 	if(world.time < last_check + 10 SECONDS)
@@ -21,7 +21,7 @@
 		user.add_stress(/datum/stressevent/hungy)
 	else
 		user.remove_stress(/datum/stressevent/hungy)
-
+//The Vice's mood penalty if it isn't fulfilled
 /datum/stressevent/hungy
 	timer = 10 MINUTES
 	stressadd = 5

--- a/modular_ochrevalley/code/modules/vices/ravenous.dm
+++ b/modular_ochrevalley/code/modules/vices/ravenous.dm
@@ -16,7 +16,7 @@
 		return
 	last_check = world.time
 		if(user.maxnutrition < 7000) //This is the Cap that prevents it from scaling beyond a value: 6k-8k value suggested by Ryumi
-	user.maxnutrition += user.maxnutrition + 10 //Calling a CC variable
+	user.maxnutrition += (user.maxnutrition + 10) //Calling a CC variable
 	if(user.maxnutrition * 0.8 > user.nutrition)
 		user.add_stress(/datum/stressevent/glutton) //Calling a CC stressevent
 	else

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3566,6 +3566,7 @@
 #include "modular_causticcove\code\modules\size_scaling\sizecats.dm"
 #include "modular_causticcove\code\modules\size_scaling\resizing\holder_micro_vr.dm"
 #include "modular_causticcove\code\modules\size_scaling\resizing\resize_vr.dm"
+#include "modular_causticcove\code\modules\size_scaling\size_verbs\standardized_sprite_verb.dm"
 #include "modular_causticcove\code\modules\size_scaling\spells\shrink.dm"
 #include "modular_causticcove\code\modules\spells\animagus\animagus.dm"
 #include "modular_causticcove\code\modules\spells\animagus\animagus_transformation.dm"

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3566,7 +3566,6 @@
 #include "modular_causticcove\code\modules\size_scaling\sizecats.dm"
 #include "modular_causticcove\code\modules\size_scaling\resizing\holder_micro_vr.dm"
 #include "modular_causticcove\code\modules\size_scaling\resizing\resize_vr.dm"
-#include "modular_causticcove\code\modules\size_scaling\size_verbs\standardized_sprite_verb.dm"
 #include "modular_causticcove\code\modules\size_scaling\spells\shrink.dm"
 #include "modular_causticcove\code\modules\spells\animagus\animagus.dm"
 #include "modular_causticcove\code\modules\spells\animagus\animagus_transformation.dm"

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3581,6 +3581,7 @@
 #include "modular_ochrevalley\code\modules\dcbot\makenote.dm"
 #include "modular_causticcove\code\modules\taurs\taur_markings.dm"
 #include "modular_causticcove\code\modules\vices\combat_adverse.dm"
+#include "modular_ochrevalley\code\modules\vices\ravenous.dm"
 #include "modular_causticcove\code\modules\vices\mind_broken.dm"
 #include "modular_causticcove\code\modules\vices\bottomless\bottomless.dm"
 #include "modular_causticcove\code\modules\vices\bottomless\maxfood.dm"


### PR DESCRIPTION
## About The Pull Request
Adds a new vice to the game, Ravenous. It's meant to be a toned-down version of Bottomless, with linear scaling rather than exponential, and a hard cap to how far it can raise maximum nutrition. It can be stacked with Bottomless if you **REALLY** want to make a black-hole-bellied character, which will likely make Bottomless scale a lot faster and more aggressively due to how it works.
<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [*] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [*] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [*] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence
Booted this up in a local instance via VSC, it compiled just fine without any warnings or errors, and when I created a character with the vice, it worked as intended, gaining 10 max nutrition every ten seconds. The initial scaling is more aggressive than Bottomless, but it tapers off in comparison before too long.
<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game
Bottomless is an excellent vice in theory, but in practice it scales extremely aggressively and the lack of a cap makes it very punishing. You need to eat upwards of **nine** whole, fully-cooked pumpkins to sate Bottomless by the end of a typical 4hr round, assuming you're hungry. Ravenous, in comparison, scales linearly and has a cap of 7k nutrition, meaning you would need to eat approximately **five** whole, fully-cooked pumpkins to sate your hunger. While still a lot of food, it feels more reasonable on account of the less aggressive scaling. Bottomless is left intact for the people who enjoy black hole bellies.
<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl: Rando001
add: Ravenous vice, a more tame version of Bottomless
qol: Re-described Bottomless to mention that it scales exponentially and has no cap
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
