### PR TITLE
grave loot fix back to AP standards

### DIFF
--- a/code/game/objects/structures/crates_lockers/roguetown.dm
+++ b/code/game/objects/structures/crates_lockers/roguetown.dm
@@ -70,39 +70,6 @@
 		var/I = pickweight(loot)
 		new I(src)
 
-//Caustic Edit
-/obj/structure/closet/crate/chest/gravechest
-
-/obj/structure/closet/crate/chest/gravechest/PopulateContents()
-	var/list/loot = list(/obj/item/rogueweapon/huntingknife/idagger/steel=10,
-		/obj/item/rogueweapon/mace/steel=10,
-		/obj/item/rogueweapon/pick=20,
-		/obj/item/rogueweapon/shovel=20,
-		/obj/item/clothing/suit/roguetown/armor/gambeson=15,
-		/obj/item/clothing/suit/roguetown/armor/leather=15,
-		/obj/item/ingot/iron=20,
-		/obj/item/ingot/gold=5,
-		/obj/item/ingot/silver=3,
-		/obj/item/riddleofsteel=1,
-		/obj/item/roguegem/ruby=2,
-		/obj/item/roguegem/blue=3,
-		/obj/item/roguegem/violet=4,
-		/obj/item/roguegem/green=6,
-		/obj/item/roguegem/yellow=10,
-		/obj/item/roguecoin/silver/pile=2,
-		/obj/item/roguecoin/gold/pile=6,
-		/obj/item/storage/belt/rogue/pouch/coins/mid=8,
-		/obj/item/storage/belt/rogue/pouch/coins/rich=8,
-		/obj/item/storage/backpack/rogue/satchel/otavan=30,
-		/obj/item/roguestatue/gold/loot=1,
-		/obj/item/clothing/neck/roguetown/talkstone=2)
-	
-	var/i
-	for(i=0, i<3, i++)
-		var/I = pickweight(loot)
-		new I(src)
-//Caustic Edit End
-
 /obj/structure/closet/crate/roguecloset
 	name = "closet"
 	desc = "A simple wooden closet, used to store whatever it is you would like out of sight."

--- a/code/modules/roguetown/roguejobs/gravedigger/hole.dm
+++ b/code/modules/roguetown/roguejobs/gravedigger/hole.dm
@@ -64,16 +64,14 @@
 			playsound(src, 'sound/foley/bodyfall (3).ogg', 90, TRUE)
 			user.visible_message(span_warning("[user] emerges from [src]!"),span_alert("I emerge from [src]!"))
 
-/obj/structure/closet/dirthole/closed/loot/Initialize()
-	. = ..()
-	lootroll = rand(1,10)	//Caustic Edit - Make the loot a bit more interesting. 1 - Skeleton, 2 - Buried Loot
-							//3 - 5 - Bones, small chance of decrepit item, 6 - 8 - Commoner Body, 9 - Noble Body, 10 - Nothing
-
 /obj/structure/closet/dirthole/closed/loot
 	var/hole_looted = FALSE
 	var/lootroll = 0
 
-//Caustic Edit - Making the drops more interesting!
+/obj/structure/closet/dirthole/closed/loot/Initialize()
+	. = ..()
+	lootroll = rand(1,6)
+
 /obj/structure/closet/dirthole/closed/loot/open()
 	if(!hole_looted)
 		hole_looted = TRUE
@@ -81,257 +79,18 @@
 			if(1)
 				new /mob/living/carbon/human/species/skeleton/npc/easy(mastert) //Let's go gambling
 			if(2)
-				new /obj/structure/closet/crate/chest/gravechest(mastert)
+				new /obj/structure/closet/crate/chest/coffinlootbox(mastert) //How it be
 			if(3)
-				corpse_bones()
-				decrepit_chance()
+				new /mob/living/carbon/human/species/skeleton/npc/medium(mastert) //How it be
 			if(4)
-				corpse_bones()
-				decrepit_chance()
+				new /mob/living/carbon/human/species/skeleton/npc/medium(mastert)
+				new /obj/structure/closet/crate/chest/coffinlootbox_middle(mastert) //Starts locked
 			if(5)
-				corpse_bones()
-				decrepit_chance()
+				new /mob/living/carbon/human/species/skeleton/npc/hard(mastert)
 			if(6)
-				corpse_bones()
-				towner_chance()
-			if(7)
-				corpse_bones()
-				towner_chance()
-			if(8)
-				corpse_bones()
-				towner_chance()
-			if(9)
-				corpse_bones()
-				noble_chance()
+				new /mob/living/carbon/human/species/skeleton/npc/hard(mastert) //Starts locked & has a skeleton guard
+				new /obj/structure/closet/crate/chest/coffinlootbox_high(mastert)
 	..()
-
-/obj/structure/closet/dirthole/closed/loot/proc/corpse_bones()
-	new /obj/item/skull(mastert)
-	var/num_bones = rand(2,5)
-
-	var/i
-	for(i=0, i<num_bones, i++)
-		new /obj/item/natural/bone(mastert)
-
-/obj/structure/closet/dirthole/closed/loot/proc/decrepit_chance()
-	var/num_item = rand(0,2)
-	if(num_item == 0)
-		return
-	
-	var/list/loot = list(/obj/item/rogueweapon/huntingknife/idagger/adagger=6,
-		/obj/item/rogueweapon/mace/alloy=5,
-		/obj/item/rogueweapon/spear/aalloy=9,
-		/obj/item/rogueweapon/pitchfork/aalloy=4,
-		/obj/item/rogueweapon/sickle/aalloy=5,
-		/obj/item/rogueweapon/shovel/aalloy=8,
-		/obj/item/rogueweapon/hammer/aalloy=7,
-		/obj/item/clothing/suit/roguetown/armor/chainmail/aalloy=1,
-		/obj/item/clothing/under/roguetown/chainlegs/kilt/aalloy=1,
-		/obj/item/reagent_containers/glass/cup/aalloygob=2,
-		/obj/item/reagent_containers/glass/bowl/aalloy=2,
-		/obj/item/clothing/ring/aalloy=3)
-	
-	var/i
-	for(i=0, i<num_item, i++)
-		var/J = pickweight(loot)
-		new J(mastert)
-
-/obj/structure/closet/dirthole/closed/loot/proc/towner_chance()
-	var/num_weapon = rand(1,2)
-	
-	var/list/weapon_loot = list(/obj/item/rogueweapon/huntingknife/idagger=5,
-		/obj/item/rogueweapon/huntingknife/idagger/steel=2,
-		/obj/item/rogueweapon/mace=4,
-		/obj/item/rogueweapon/mace/steel=1,
-		/obj/item/rogueweapon/shield/buckler=2,
-		/obj/item/rogueweapon/shield/heater=1,
-		/obj/item/rogueweapon/stoneaxe/battle=5,
-		/obj/item/rogueweapon/stoneaxe/woodcut/wardenpick=2,
-		/obj/item/rogueweapon/flail/militia=3,
-		/obj/item/rogueweapon/spear=6,
-		/obj/item/rogueweapon/pitchfork/aalloy=4,
-		/obj/item/rogueweapon/pick/militia=3,
-		/obj/item/rogueweapon/sword/falchion/militia=4,
-		/obj/item/rogueweapon/sword/iron=3,
-		/obj/item/rogueweapon/sword/falx=1,
-		/obj/item/rogueweapon/sword/long/shotel/iron=1,
-		/obj/item/rogueweapon/sword/short/iron=4,
-		/obj/item/rogueweapon/sword/short/falchion=2,
-		/obj/item/rogueweapon/sword/short/messer=3,
-		/obj/item/rogueweapon/pitchfork=7,
-		/obj/item/rogueweapon/sickle=6,
-		/obj/item/rogueweapon/shovel=9,
-		/obj/item/rogueweapon/hammer/iron=6,
-		/obj/item/rogueweapon/tongs=4,
-		/obj/item/rogueweapon/pick=6)
-	
-	var/i
-	for(i=0, i<num_weapon, i++)
-		var/W = pickweight(weapon_loot)
-		new W(mastert)
-	
-	if(prob(80))
-		var/list/armor_loot = list(/obj/item/clothing/suit/roguetown/armor/gambeson=5,
-			/obj/item/clothing/suit/roguetown/armor/gambeson/heavy=2,
-			/obj/item/clothing/suit/roguetown/armor/chainmail/iron=3,
-			/obj/item/clothing/wrists/roguetown/bracers=3,
-			/obj/item/clothing/wrists/roguetown/bracers/leather/heavy=1,
-			/obj/item/clothing/gloves/roguetown/leather=2,
-			/obj/item/clothing/gloves/roguetown/chain/iron=2,
-			/obj/item/clothing/head/roguetown/helmet/leather/advanced=2,
-			/obj/item/clothing/head/roguetown/helmet=3,
-			/obj/item/clothing/neck/roguetown/chaincoif=2,
-			/obj/item/clothing/under/roguetown/heavy_leather_pants=2,
-			/obj/item/clothing/under/roguetown/splintlegs=3,
-			/obj/item/clothing/under/roguetown/chainlegs/iron=3,
-			/obj/item/clothing/shoes/roguetown/boots/leather/reinforced=2,
-			/obj/item/clothing/shoes/roguetown/boots/armor/iron=3)
-		
-		var/A = pickweight(armor_loot)
-		new A(mastert)
-
-		if(prob(50))
-			var/A_bonus = pickweight(armor_loot)
-			new A_bonus(mastert)
-	
-	var/num_other = rand(0,3)
-	if(num_other == 0)
-		return
-	
-	var/list/other_loot = list(/obj/item/clothing/neck/roguetown/psicross=3,
-		/obj/item/clothing/neck/roguetown/psicross/undivided=1,
-		/obj/item/clothing/neck/roguetown/psicross/noc=1,
-		/obj/item/clothing/neck/roguetown/psicross/abyssor=1,
-		/obj/item/clothing/neck/roguetown/psicross/dendor=1,
-		/obj/item/clothing/neck/roguetown/psicross/necra=1,
-		/obj/item/clothing/neck/roguetown/psicross/pestra=1,
-		/obj/item/clothing/neck/roguetown/psicross/ravox=1,
-		/obj/item/clothing/neck/roguetown/psicross/malum=1,
-		/obj/item/clothing/neck/roguetown/psicross/eora=1,
-		/obj/item/clothing/neck/roguetown/psicross/xylix=1,
-		/obj/item/clothing/ring/band=8,
-		/obj/item/clothing/ring/aalloy=6,
-		/obj/item/clothing/ring/silver=3,
-		/obj/item/clothing/ring/gold=5,
-		/obj/item/storage/keyring=4,
-		/obj/item/clothing/neck/roguetown/ornateamulet=2,
-		/obj/item/roguecoin/copper/pile=5,
-		/obj/item/roguecoin/silver/pile=3,
-		/obj/item/roguecoin/aalloy/pile=7,
-		/obj/item/roguecoin/inqcoin/pile=2,
-		/obj/item/reagent_containers/glass/bottle/rogue/beer/murkwine=2,
-		/obj/item/reagent_containers/glass/bottle/rogue/beer/rtoper=2,
-		/obj/item/reagent_containers/glass/bottle/rogue/beer/hagwoodbitter=2,
-		/obj/item/reagent_containers/glass/cup=4,
-		/obj/item/reagent_containers/glass/cup/silver/pewter=3,
-		/obj/item/reagent_containers/glass/bowl/iron=4)
-	
-	for(i=0, i<num_other, i++)
-		var/O = pickweight(other_loot)
-		new O(mastert)
-
-/obj/structure/closet/dirthole/closed/loot/proc/noble_chance()
-	var/num_weapon = rand(1,2)
-	
-	var/list/weapon_loot = list(/obj/item/rogueweapon/sword/blacksteel=1,
-		/obj/item/rogueweapon/sword/decorated=3,
-		/obj/item/rogueweapon/sword/long/dec=2,
-		/obj/item/rogueweapon/sword/sabre/dec=3,
-		/obj/item/rogueweapon/sword/rapier/dec=3,
-		/obj/item/rogueweapon/huntingknife/idagger/silver/stake=1,
-		/obj/item/rogueweapon/huntingknife/idagger/silver/elvish/poopknife=1,
-		/obj/item/rogueweapon/huntingknife/idagger/silver/elvish=3,
-		/obj/item/rogueweapon/huntingknife/idagger/steel/parrying/vaquero=2,
-		/obj/item/rogueweapon/huntingknife/combat/iron=2,
-		/obj/item/rogueweapon/mace/cudgel/justice=1,
-		/obj/item/rogueweapon/mace/parasol/noble=1,
-		/obj/item/rogueweapon/mace/steel=4,
-		/obj/item/rogueweapon/mace/maul/grand=2,
-		/obj/item/rogueweapon/stoneaxe/woodcut/steel/slayer=1,
-		/obj/item/rogueweapon/stoneaxe/woodcut/steel/atgervi=3,
-		/obj/item/rogueweapon/stoneaxe/battle/steppesman=3,
-		/obj/item/rogueweapon/greataxe/steel/gilded=2,
-		/obj/item/rogueweapon/spear/lance=4,
-		/obj/item/rogueweapon/hammer/blacksteel=2)
-	
-	var/i
-	for(i=0, i<num_weapon, i++)
-		var/W = pickweight(weapon_loot)
-		new W(mastert)
-	
-	var/list/armor_loot = list(/obj/item/clothing/mask/rogue/lordmask=3,
-		/obj/item/clothing/mask/rogue/facemask/goldmask=2,
-		/obj/item/clothing/suit/roguetown/shirt/dress/royal/hand_m=1,
-		/obj/item/clothing/suit/roguetown/shirt/dress/emerald=2,
-		/obj/item/clothing/suit/roguetown/shirt/dress/royal/princess=1,
-		/obj/item/clothing/suit/roguetown/shirt/dress/royal/prince=1,
-		/obj/item/clothing/suit/roguetown/shirt/dress/silkydress/random=3,
-		/obj/item/clothing/suit/roguetown/shirt/fancyjacket=2,
-		/obj/item/clothing/suit/roguetown/armor/plate/cuirass=2,
-		/obj/item/clothing/suit/roguetown/armor/plate/cuirass/fencer=3,
-		/obj/item/clothing/suit/roguetown/armor/plate/otavan=1,
-		/obj/item/clothing/suit/roguetown/armor/armordress/winterdress/monarch=2,
-		/obj/item/clothing/suit/roguetown/armor/leather/vest/winterjacket=3,
-		/obj/item/clothing/head/roguetown/helmet/heavy/knight/gilded=2,
-		/obj/item/clothing/head/roguetown/helmet/sallet/visored/gilded=2,
-		/obj/item/clothing/head/roguetown/helmet/otavan=2,
-		/obj/item/clothing/head/roguetown/nyle/consortcrown=3,
-		/obj/item/clothing/head/roguetown/circlet=3,
-		/obj/item/clothing/gloves/roguetown/nomagic=1,
-		/obj/item/clothing/gloves/roguetown/otavan/psygloves=3,
-		/obj/item/clothing/gloves/roguetown/otavan=3,
-		/obj/item/clothing/under/roguetown/heavy_leather_pants/otavan=3,
-		/obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants=3,
-		/obj/item/clothing/shoes/roguetown/boots/psydonboots=3,
-		/obj/item/clothing/shoes/roguetown/boots/leather/atgervi=2,
-		/obj/item/clothing/shoes/roguetown/boots/otavan=2,
-		/obj/item/clothing/shoes/roguetown/boots/nobleboot=3,
-		/obj/item/clothing/climbing_gear=1)
-	
-	var/A = pickweight(armor_loot)
-	new A(mastert)
-
-	if(prob(55))
-		var/A_bonus = pickweight(armor_loot)
-		new A_bonus(mastert)
-	
-	var/num_other = rand(1,3)
-	
-	var/list/other_loot = list(/obj/item/clothing/neck/roguetown/psicross=2,
-		/obj/item/clothing/neck/roguetown/psicross/astrata=3,
-		/obj/item/clothing/ring/band=3,
-		/obj/item/clothing/ring/emerald=2,
-		/obj/item/clothing/ring/ruby=1,
-		/obj/item/clothing/ring/topaz=3,
-		/obj/item/clothing/ring/quartz=3,
-		/obj/item/clothing/ring/sapphire=2,
-		/obj/item/clothing/ring/diamond=1,
-		/obj/item/clothing/ring/emeralds=2,
-		/obj/item/clothing/ring/rubys=1,
-		/obj/item/clothing/ring/topazs=3,
-		/obj/item/clothing/ring/quartzs=3,
-		/obj/item/clothing/ring/sapphires=2,
-		/obj/item/clothing/ring/diamonds=1,
-		/obj/item/clothing/neck/roguetown/ornateamulet/noble=2,
-		/obj/item/clothing/neck/roguetown/skullamulet=2,
-		/obj/item/clothing/neck/roguetown/skullamulet/gemerald=1,
-		/obj/item/roguecoin/gold/pile=3,
-		/obj/item/roguecoin/silver/pile=5,
-		/obj/item/roguecoin/aalloy/pile=2,
-		/obj/item/roguecoin/inqcoin/pile=3,
-		/obj/item/reagent_containers/glass/bottle/rogue/elfblue=3,
-		/obj/item/reagent_containers/glass/bottle/rogue/elfred=3,
-		/obj/item/reagent_containers/glass/cup/silver=3,
-		/obj/item/reagent_containers/glass/cup/golden=4,
-		/obj/item/reagent_containers/glass/bowl/silver=2,
-		/obj/item/reagent_containers/glass/bowl/gold=3,
-		/obj/item/clothing/neck/roguetown/talkstone=1,
-		/obj/item/scomstone=1)
-	
-	for(i=0, i<num_other, i++)
-		var/O = pickweight(other_loot)
-		new O(mastert)
-//Caustic Edit End
 
 /obj/structure/closet/dirthole/closed/loot/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->
Reverts a caustic PR made 2 days before we forked that significantly buffed grave loot far above AP levels. Reverted by just smashing the AP code into ours and not seeing anything important getting removed.
## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [X] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [X] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [X] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence
Ran it, dug up the town graves, got parried by skeletons for 10 minutes because apprentice weapons skill is very mid. Confirmed the coffins spawned were the expected type.
<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game
You probably should not be able to get dungeon levels of loot for opening graves in the peasant graveyard. When we have our own map, we can add high value ones to dungeons and the gated town grave. Currently it's free money for basically anyone whose character is willing to do it for near 0 risk.

Also Econ 2+3 happened and now mammon matters again so being able to routinely get hundreds to thousands of mammons of riches from the town graveyard is probably not good for the economy.
<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your reasoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Reset grave loot to AP's in order to undo a PR made to significantly buff grave loot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
