### PR TITLE
adds the Itinerant Tinkerer subclass

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -76,6 +76,7 @@ GLOBAL_VAR_INIT(adventurer_hugbox_duration_still, 3 MINUTES)
 		///Caustic edit
 		// /datum/advclass/mage/spellthief, //OV Edit AP Merge 4.2.26 - Commented out Pending Rework
 		/datum/advclass/rogue/buccaneer,
+		/datum/advclass/rogue/tinkerer,
 		///Caustic edit end
 		/datum/advclass/true_random, //OV ADD
 		/datum/advclass/foreigner/shepherd,

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -70,7 +70,7 @@
 			if("Pistol")
 				H.adjust_skillrank_up_to(/datum/skill/combat/firearms, SKILL_LEVEL_APPRENTICE, TRUE)
 				beltl = /obj/item/quiver/bulletpouch/iron
-				r_hand = /obj/item/gun/ballistic/arquebus_pistol
+				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/arquebus/pistol
 				l_hand = /obj/item/powderflask
 			if("Grappling Hook")
 				H.adjust_skillrank_up_to(/datum/skill/misc/climbing, SKILL_LEVEL_EXPERT, TRUE)

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -58,6 +58,7 @@
 		/datum/skill/craft/engineering = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE
 	)
+	extra_context = "Chooses between a Pistol, a Grappler, a Clockwork Drill, Voltic Gauntlets (+2 STR, -2 SPD), Bronze Arms(+2 STR, -2 SPD), or Bronze Legs."
 
 /datum/outfit/job/roguetown/adventurer/tinkerer/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -54,6 +54,7 @@
 		/datum/skill/craft/blacksmithing = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/sewing = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/tanning = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/smelting = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/engineering = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/magic/arcane = SKILL_LEVEL_NOVICE
 	)

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -24,3 +24,125 @@
         /obj/item/flashlight/flare/torch/lantern = 1,
         /obj/item/recipe_book/survival = 1
         )
+
+/datum/advclass/rogue/tinkerer //
+	name = "Itinerant Tinkerer"
+	tutorial = "In another life, your intellect, connections, and aptitude for blending well-worked bronze with Arcyne mysteries would have made for a fine guildsman. Whilst unnaccustomed to combat, your cleverness and inventions offer you a novel edge."
+	outfit = /datum/outfit/job/roguetown/adventurer/antiquarian
+	cmode_music = 'sound/music/cmode/adventurer/combat_outlander3.ogg'
+	traits_applied = list(TRAIT_SEEPRICES, TRAIT_DECEIVING_MEEKNESS, TRAIT_ARCYNE, TRAIT_SMITHING_EXPERT)
+	subclass_stats = list(
+		STATKEY_INT = 3,
+		STATKEY_PER = 2,
+		STATKEY_SPD = 2,
+		STATKEY_STR = -1,
+	)
+	subclass_skills = list(
+		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/unarmed = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/sneaking = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/lockpicking = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/traps = SKILL_LEVEL_APPRENTICE, 
+		/datum/skill/craft/crafting = SKILL_LEVEL_NOVICE,//besides engineering, they have the bare minimum to maintain most equipment. Meant to run a repair-support role in most parties
+		/datum/skill/craft/weaponsmithing = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/armorsmithing = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/blacksmithing = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/sewing = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/engineering = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/magic/arcane = SKILL_LEVEL_NOVICE
+	)
+
+/datum/outfit/job/roguetown/adventurer/tinkerer/pre_equip(mob/living/carbon/human/H)
+	..()
+	to_chat(H, span_warning("In another life, your intellect, connections, and aptitude for blending well-worked bronze with Arcyne mysteries would have made for a fine guildsman. Whilst unnaccustomed to combat, your cleverness and inventions offer you a novel edge."))
+	if(H.mind)
+		var/gadgets = list("Pistol", "Grappler", "Clockwork Drill", "Voltic Gauntlets", "Bronze Arms", "Bronze Legs")
+		var/gadget_choice = input(H, "Choose a gadget.", "YOUR LATEST MASTERPIECE") as anything in gadgets
+		H.set_blindness(0)
+		switch(gadget_choice)
+			if("Pistol")
+				H.adjust_skillrank_up_to(/datum/skill/combat/firearms, SKILL_LEVEL_APPRENTICE, TRUE)
+				beltl = /obj/item/quiver/bulletpouch/iron
+				r_hand = /obj/item/gun/ballistic/arquebus_pistol
+				l_hand = /obj/item/powderflask
+			if("Grappling Hook")
+				H.adjust_skillrank_up_to(/datum/skill/misc/climbing, SKILL_LEVEL_EXPERT, TRUE)
+				r_hand = /obj/item/grapplinghook
+			if("Clockwork Drill")
+				H.adjust_skillrank_up_to(/datum/skill/labor/mining, SKILL_LEVEL_APPRENTICE, TRUE)
+				r_hand = /obj/item/contraption/pick/drill/precharged
+			if("Voltic Gauntlets")
+				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_APPRENTICE, TRUE)
+				gloves = /obj/item/clothing/gloves/roguetown/chain/contraption/voltic/precharged
+				H.change_stat(STATKEY_STR, 2) //we're gonna make the gauntlet tinkerers punchier and slower. trust me, they'll want this
+				H.change_stat(STATKEY_SPD, -2)
+				to_chat(H, span_warning("Compared to your average Tinkerer, I'm a bit burly (+2 Strength, -2 Speed)"))
+			if("Bronze Arms")
+				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_APPRENTICE, TRUE)
+				H.change_stat(STATKEY_STR, 2) //Tinkerers with big buff metal arms *also* get to feel kinda buff. for a rogue.
+				H.change_stat(STATKEY_SPD, -2)
+				to_chat(H, span_warning("Compared to your average Tinkerer, I'm a bit burly (+2 Strength, -2 Speed)"))
+				var/obj/item/bodypart/rightarm = H.get_bodypart(BODY_ZONE_R_ARM)
+				if(rightarm)
+					rightarm.drop_limb()
+					qdel(rightarm)
+				if(H.charflaws.len)
+					var/obj/item/bodypart/r_arm/prosthetic/bronzeright/rightbarm = new()
+					rightbarm.attach_limb(H)
+				var/obj/item/bodypart/leftarm = H.get_bodypart(BODY_ZONE_L_ARM)
+				if(leftarm)
+					leftarm.drop_limb()
+					qdel(leftarm)
+				if(H.charflaws.len)
+					var/obj/item/bodypart/l_arm/prosthetic/bronzeleft/leftbarm = new()
+					leftbarm.attach_limb(H)
+			if("Bronze Legs")
+				H.adjust_skillrank_up_to(/datum/skill/misc/athletics, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				var/obj/item/bodypart/rightleg = H.get_bodypart(BODY_ZONE_R_LEG)
+				if(rightleg)
+					rightleg.drop_limb()
+					qdel(rightleg)
+				if(H.charflaws.len)
+					var/obj/item/bodypart/r_leg/prosthetic/bronzeright/rightbleg = new()
+					rightbleg.attach_limb(H)
+				var/obj/item/bodypart/leftleg = H.get_bodypart(BODY_ZONE_L_LEG)
+				if(leftleg)
+					leftleg.drop_limb()
+					qdel(leftleg)
+				if(H.charflaws.len)
+					var/obj/item/bodypart/l_leg/prosthetic/bronzeleft/leftbleg = new()
+					leftbleg.attach_limb(H)
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/jacket/artijacket
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+	backl = /obj/item/storage/backpack/rogue/backpack
+	backr = /obj/item/rogueweapon/scabbard/sheath
+	pants = /obj/item/clothing/under/roguetown/trou/leather
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
+	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+	beltr = /obj/item/flashlight/flare/torch/lantern
+	belt = /obj/item/storage/belt/rogue/leather
+	backpack_contents = list(
+		/obj/item/rogueweapon/huntingknife/idagger/steel = 1,
+		/obj/item/recipe_book/survival = 1,
+		/obj/item/chalk = 1,
+		/obj/item/lockpick = 1,
+		/obj/item/clothing/mask/rogue/spectacles/golden = 1// a good tinkerer needs a pair of sickass looking goggles. In backpack so vices won't replace 'em
+		)
+	H.AddSpell(new /obj/effect/proc_holder/spell/invoked/secularbarter) //They have the Connections like an antiquarian does, but none of the alchemical tricks
+	H.mind.AddSpell(new /datum/action/cooldown/spell/touch/prestidigitation)//A tinkerer is a bit magical, but one of their spells has to be mending 
+	H.mind.AddSpell(new /datum/action/cooldown/spell/mending)
+	if(!LAZYLEN(H.mind.mage_aspect_config)) 
+		H.mind.setup_mage_aspects(list("mastery" = FALSE, "major" = 0, "minor" = 0, "utilities" = 2))
+		H.mind.check_learnspell()
+
+/obj/item/clothing/gloves/roguetown/chain/contraption/voltic/precharged
+	current_charge = 20
+
+/obj/item/contraption/pick/drill/precharged
+	current_charge = 600

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -56,7 +56,7 @@
 		/datum/skill/craft/tanning = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/smelting = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/engineering = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/magic/arcane = SKILL_LEVEL_NOVICE
+		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE
 	)
 
 /datum/outfit/job/roguetown/adventurer/tinkerer/pre_equip(mob/living/carbon/human/H)

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -28,7 +28,7 @@
 /datum/advclass/rogue/tinkerer //
 	name = "Itinerant Tinkerer"
 	tutorial = "In another life, your intellect, connections, and aptitude for blending well-worked bronze with Arcyne mysteries would have made for a fine guildsman. Whilst unnaccustomed to combat, your cleverness and inventions offer you a novel edge."
-	outfit = /datum/outfit/job/roguetown/adventurer/antiquarian
+	outfit = /datum/outfit/job/roguetown/adventurer/tinkerer
 	cmode_music = 'sound/music/cmode/adventurer/combat_outlander3.ogg'
 	traits_applied = list(TRAIT_SEEPRICES, TRAIT_DECEIVING_MEEKNESS, TRAIT_ARCYNE, TRAIT_SMITHING_EXPERT)
 	subclass_stats = list(
@@ -61,7 +61,7 @@
 	..()
 	to_chat(H, span_warning("In another life, your intellect, connections, and aptitude for blending well-worked bronze with Arcyne mysteries would have made for a fine guildsman. Whilst unnaccustomed to combat, your cleverness and inventions offer you a novel edge."))
 	if(H.mind)
-		var/gadgets = list("Pistol", "Grappler", "Clockwork Drill", "Voltic Gauntlets", "Bronze Arms", "Bronze Legs")
+		var/gadgets = list("Pistol", "Grappling Hook", "Clockwork Drill", "Voltic Gauntlets", "Bronze Arms", "Bronze Legs")
 		var/gadget_choice = input(H, "Choose a gadget.", "YOUR LATEST MASTERPIECE") as anything in gadgets
 		H.set_blindness(0)
 		switch(gadget_choice)

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -30,7 +30,7 @@
 	tutorial = "In another life, your intellect, connections, and aptitude for blending well-worked bronze with Arcyne mysteries would have made for a fine guildsman. Whilst unnaccustomed to combat, your cleverness and inventions offer you a novel edge."
 	outfit = /datum/outfit/job/roguetown/adventurer/tinkerer
 	cmode_music = 'sound/music/cmode/adventurer/combat_outlander3.ogg'
-	traits_applied = list(TRAIT_SEEPRICES, TRAIT_DECEIVING_MEEKNESS, TRAIT_ARCYNE, TRAIT_SMITHING_EXPERT, TRAIT_LEYLINE_ATTUNEMENT)
+	traits_applied = list(TRAIT_SEEPRICES, TRAIT_INTELLECTUAL, TRAIT_ARCYNE, TRAIT_SMITHING_EXPERT, TRAIT_LEYLINE_ATTUNEMENT)
 	subclass_stats = list(
 		STATKEY_INT = 3,
 		STATKEY_PER = 2,

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -53,6 +53,7 @@
 		/datum/skill/craft/armorsmithing = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/blacksmithing = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/sewing = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/tanning = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/engineering = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/magic/arcane = SKILL_LEVEL_NOVICE
 	)
@@ -128,7 +129,7 @@
 	beltr = /obj/item/flashlight/flare/torch/lantern
 	belt = /obj/item/storage/belt/rogue/leather
 	backpack_contents = list(
-		/obj/item/rogueweapon/huntingknife/idagger/steel = 1,
+		/obj/item/rogueweapon/huntingknife/idagger/steel/parrying = 1,
 		/obj/item/recipe_book/survival = 1,
 		/obj/item/chalk = 1,
 		/obj/item/lockpick = 1,

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -134,6 +134,7 @@
 		/obj/item/recipe_book/survival = 1,
 		/obj/item/chalk = 1,
 		/obj/item/lockpick = 1,
+		/obj/item/rogueweapon/hammer/iron,
 		/obj/item/clothing/mask/rogue/spectacles/golden = 1// a good tinkerer needs a pair of sickass looking goggles. In backpack so vices won't replace 'em
 		)
 	H.AddSpell(new /obj/effect/proc_holder/spell/invoked/secularbarter) //They have the Connections like an antiquarian does, but none of the alchemical tricks

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -30,7 +30,7 @@
 	tutorial = "In another life, your intellect, connections, and aptitude for blending well-worked bronze with Arcyne mysteries would have made for a fine guildsman. Whilst unnaccustomed to combat, your cleverness and inventions offer you a novel edge."
 	outfit = /datum/outfit/job/roguetown/adventurer/tinkerer
 	cmode_music = 'sound/music/cmode/adventurer/combat_outlander3.ogg'
-	traits_applied = list(TRAIT_SEEPRICES, TRAIT_DECEIVING_MEEKNESS, TRAIT_ARCYNE, TRAIT_SMITHING_EXPERT)
+	traits_applied = list(TRAIT_SEEPRICES, TRAIT_DECEIVING_MEEKNESS, TRAIT_ARCYNE, TRAIT_SMITHING_EXPERT, TRAIT_LEYLINE_ATTUNEMENT)
 	subclass_stats = list(
 		STATKEY_INT = 3,
 		STATKEY_PER = 2,
@@ -81,7 +81,7 @@
 			if("Voltic Gauntlets")
 				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_APPRENTICE, TRUE)
 				gloves = /obj/item/clothing/gloves/roguetown/chain/contraption/voltic/precharged
-				H.change_stat(STATKEY_STR, 2) //we're gonna make the gauntlet tinkerers punchier and slower. trust me, they'll want this
+				H.change_stat(STATKEY_STR, 2) //we're gonna make the gauntlet tinkerers punchier and slower. trust me, they'll want this. This changes them from a +2 spd, -1 str class, to a +1 str class
 				H.change_stat(STATKEY_SPD, -2)
 				to_chat(H, span_warning("Compared to your average Tinkerer, I'm a bit burly (+2 Strength, -2 Speed)"))
 			if("Bronze Arms")

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -134,7 +134,7 @@
 		/obj/item/rogueweapon/huntingknife/idagger/steel/parrying = 1,
 		/obj/item/recipe_book/survival = 1,
 		/obj/item/chalk = 1,
-		/obj/item/lockpick = 1,
+		/obj/item/rogueweapon/handsaw = 1,
 		/obj/item/rogueweapon/hammer/iron,
 		/obj/item/clothing/mask/rogue/spectacles/golden = 1// a good tinkerer needs a pair of sickass looking goggles. In backpack so vices won't replace 'em
 		)

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3703,7 +3703,11 @@
 #include "modular_ochrevalley\code\modules\dcbot\kickplayer.dm"
 #include "modular_causticcove\code\modules\size_scaling\sizecats.dm"
 #include "modular_causticcove\code\modules\size_scaling\resizing\holder_micro_vr.dm"
+<<<<<<< HEAD
 #include "modular_ochrevalley\code\modules\roguetown\roguecrafting\alchemy\ingredients.dm"
+=======
+#include "modular_ochrevalley\code\modules\jobs\job_types\roguetown\adventurer\types\combat\rogue.dm"
+>>>>>>> d5c1d9cbbf (adds the Tinkerer)
 #include "modular_causticcove\code\modules\size_scaling\resizing\resize_vr.dm"
 #include "modular_causticcove\code\modules\size_scaling\size_verbs\standardized_sprite_verb.dm"
 #include "modular_ochrevalley\code\modules\roguetown\roguejobs\alchemist\herb_seeds.dm"

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3832,6 +3832,7 @@
 #include "modular_ochrevalley\code\modules\logging\categories\log_category_misc.dm"
 #include "modular_ochrevalley\code\modules\client\verbs\character_directory.dm"
 #include "modular_ochrevalley\code\recipes\pastry_recipes.dm"
+#include "modular_ochrevalley\code\modules\jobs\job_types\roguetown\adventurer\types\combat\rogue.dm"
 #include "modular_ochrevalley\code\modules\jobs\job_types\roguetown\adventurer\types\combat\spellblade_pre_rework.dm"
 #include "modular_ochrevalley\code\modules\jobs\job_types\roguetown\courtier\legacycouncillor.dm"
 #include "modular_ochrevalley\code\modules\jobs\job_types\roguetown\garrison\legacywarden.dm"

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3703,11 +3703,7 @@
 #include "modular_ochrevalley\code\modules\dcbot\kickplayer.dm"
 #include "modular_causticcove\code\modules\size_scaling\sizecats.dm"
 #include "modular_causticcove\code\modules\size_scaling\resizing\holder_micro_vr.dm"
-<<<<<<< HEAD
 #include "modular_ochrevalley\code\modules\roguetown\roguecrafting\alchemy\ingredients.dm"
-=======
-#include "modular_ochrevalley\code\modules\jobs\job_types\roguetown\adventurer\types\combat\rogue.dm"
->>>>>>> d5c1d9cbbf (adds the Tinkerer)
 #include "modular_causticcove\code\modules\size_scaling\resizing\resize_vr.dm"
 #include "modular_causticcove\code\modules\size_scaling\size_verbs\standardized_sprite_verb.dm"
 #include "modular_ochrevalley\code\modules\roguetown\roguejobs\alchemist\herb_seeds.dm"
@@ -3810,7 +3806,6 @@
 #include "modular_ochrevalley\code\game\objects\items\weapons\ranged\ammo.dm"
 #include "modular_ochrevalley\code\game\objects\items\weapons\ranged\arquebus.dm"
 #include "modular_ochrevalley\code\modules\cargo\packsrogue\merchant\weapons\merch_weapons_foreign.dm"
-#include "modular_ochrevalley\code\modules\jobs\job_types\roguetown\adventurer\types\combat\rogue.dm"
 #include "modular_ochrevalley\code\modules\roguetown\roguejobs\engineer\anvil_recipes\mechanical.dm"
 #include "modular_ochrevalley\code\datums\character_flaw\_character_flaw.dm"
 #include "modular_ochrevalley\code\datums\stress\negative_events.dm"


### PR DESCRIPTION
## About The Pull Request

Adds the itinerant tinkerer rogue subclass. A support rogue similar to the antiquarian, it gets the following features:
+3 int, +2 per, +2 spd, -1 str
- apprentice knives, no other notable combat skills
- core to their identity is their Smithing Expert trait, making them great potential crafters if the effort is put in
- they also get appraisals, and decieving meekness. The latter is the least necessary trait to their identity, and could easily be replaced by something like Intellectual, Alchemy, etc- but i thought alchemy trod too much upon the antiquarian. I kinda like the flavor, but am open to smth to replace it...
- arcane skill, prestidigitation, and the mending spell. They get 2 utility points otherwise
- novice in most crafting skills, but journeyman engineering. If reviewers think they should have some skills boosted, this is probably where that'll go?
- the secular barter spell, as the antiquarian has. They recieve no flash powder or vapours
- their most notable feature is a choice of Gadget. The gadgets may be one of the following

1. an arquebus pistol, ammo, and apprentice firearm training. Might change this to allow more choices of guns when guns are reworked
2. a clockwork drill and apprentice mining training
3. voltic gauntlets and apprentice unarmed training. +2 str, -2 speed
4. a grappler and expert climbing training
5. bronze arms and apprentice unarmed training. +2 str, -2 speed
6. bronze legs and journeyman athletics training. 
I split the bronze arms and legs into two, especially as a buff for bronze limbs is coming down the pipes, from what i've read- this is intended to work with the oncoming Overclock feature
I'd love to give them a belt of throwing knives (because i love throwing knives) but i doubt that'd fly.
I'm quite open to suggestions on shifting this to better fit the server and balance if necessary. I'm no stranger to class design and balance for other systems, and to ss13 balance as a whole, but roguecode balance is quite new to me
## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence
<img width="223" height="333" alt="{36EB40A6-362A-45ED-B655-5D4FE2A72C3C}" src="https://github.com/user-attachments/assets/6ee6d7d4-57ec-40c8-8b5a-e860fed03f03" />
<img width="54" height="48" alt="{6C7E099B-CFB4-49A7-A3FA-1D76074F1742}" src="https://github.com/user-attachments/assets/6c508de0-c4aa-468a-8185-c527c20394b6" /> bronze arms functioning
<img width="72" height="62" alt="{BF20904B-7442-43E9-9181-08A6DE2A7EEC}" src="https://github.com/user-attachments/assets/ad010b65-e5fe-4605-a858-da92e3065b76" />bronze legs functioning
all other loadouts function as well, but those are the ones i was most concerned about! 



## Why It's Good For The Game
This PR adds a class to fit the more conventional 'artificer' fantasy, though more as a crafter than a spellcaster. I'm fond of tinkerer archetypes, and think it'd allow some more infrequently seen engineering gadgets to shine. I think there's a niche in the class pool for such a class, which I'm more than happy to fill
<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Itinerant Tinkerer rogue subclass, a support rogue focused on crafting, enchantment, and repair, which starts with a special gadget of your choice
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
