### PR TITLE
Mana drain

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -619,10 +619,14 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 					var/obj/structure/flora/newbranch/branch = locate() in loc
 					if(branch)
 						sleepy_mod = 2 //Worse than a bedroll, better than nothing.
-		//Caustic edit
+		//OV edit
 		else if(istype(loc,/obj/belly))
-			sleepy_mod = 3
-		//Caustic edit end
+			var/obj/belly/our_belly = loc
+			if(our_belly.mode_flags & DM_FLAG_MANA_DRAIN)
+				sleepy_mod = 0
+			else
+				sleepy_mod = 2
+		//OV edit end
 		if(sleepy_mod > 0)
 			if(eyesclosed)
 				if(HAS_TRAIT(src, TRAIT_NOSLEEP) && !sleepless_flaw)

--- a/modular_causticcove/code/__DEFINES/belly_modes.dm
+++ b/modular_causticcove/code/__DEFINES/belly_modes.dm
@@ -30,6 +30,7 @@
 #define DM_FLAG_WETTENS			0x1000
 #define DM_FLAG_STRIP_DIGEST	0x2000	//OV ADD - As opposed to stripping, this specifically attempts to strip items on digestion
 #define DM_FLAG_LEWD_STRUGGLES	0x4000	//OV ADD - Increase arousal as prey struggles
+#define DM_FLAG_MANA_DRAIN		0x8000	//OV ADD - Increase arousal as prey struggles
 
 //Item related modes
 #define IM_HOLD									"Hold"

--- a/modular_causticcove/code/modules/vore/eating/belly_obj.dm
+++ b/modular_causticcove/code/modules/vore/eating/belly_obj.dm
@@ -131,7 +131,7 @@
 	//Actual full digest modes
 	var/tmp/static/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_ABSORB,DM_DRAIN,DM_SELECT,DM_UNABSORB,DM_HEAL,DM_SHRINK,DM_GROW,DM_SIZE_STEAL,DM_EGG)
 	//Digest mode addon flags
-	var/tmp/static/list/mode_flag_list = list("Numbing" = DM_FLAG_NUMBING, "Stripping" = DM_FLAG_STRIPPING, "Leave Remains" = DM_FLAG_LEAVEREMAINS, "Muffles" = DM_FLAG_THICKBELLY, "Affect Worn Items" = DM_FLAG_AFFECTWORN, "Complete Absorb" = DM_FLAG_FORCEPSAY, "Spare Prosthetics" = DM_FLAG_SPARELIMB, "Slow Body Digestion" = DM_FLAG_SLOWBODY, "Muffle Items" = DM_FLAG_MUFFLEITEMS, "TURBO MODE" = DM_FLAG_TURBOMODE, "Absorbed Prey Can Devour" = DM_FLAG_ABSORBEDVORE, "Makes Prey Wet" = DM_FLAG_WETTENS, "Strip Digest" = DM_FLAG_STRIP_DIGEST, "Lewd Struggles" = DM_FLAG_LEWD_STRUGGLES) //OV EDIT
+	var/tmp/static/list/mode_flag_list = list("Numbing" = DM_FLAG_NUMBING, "Stripping" = DM_FLAG_STRIPPING, "Leave Remains" = DM_FLAG_LEAVEREMAINS, "Muffles" = DM_FLAG_THICKBELLY, "Affect Worn Items" = DM_FLAG_AFFECTWORN, "Complete Absorb" = DM_FLAG_FORCEPSAY, "Spare Prosthetics" = DM_FLAG_SPARELIMB, "Slow Body Digestion" = DM_FLAG_SLOWBODY, "Muffle Items" = DM_FLAG_MUFFLEITEMS, "TURBO MODE" = DM_FLAG_TURBOMODE, "Absorbed Prey Can Devour" = DM_FLAG_ABSORBEDVORE, "Makes Prey Wet" = DM_FLAG_WETTENS, "Strip Digest" = DM_FLAG_STRIP_DIGEST, "Lewd Struggles" = DM_FLAG_LEWD_STRUGGLES, "Mana Drain" = DM_FLAG_MANA_DRAIN) //OV EDIT
 	//Item related modes
 	var/tmp/static/list/item_digest_modes = list(IM_HOLD,IM_DIGEST_FOOD,IM_DIGEST,IM_DIGEST_PARALLEL,IM_SMELTING)
 	//drain modes

--- a/modular_causticcove/code/modules/vore/eating/bellymodes_vr.dm
+++ b/modular_causticcove/code/modules/vore/eating/bellymodes_vr.dm
@@ -133,6 +133,10 @@
 			to_update = TRUE
 		if(istype(returns) && returns["soundToPlay"] && !play_sound)
 			play_sound = returns["soundToPlay"]
+		//OV edit
+		if(mode_flags & DM_FLAG_MANA_DRAIN)
+			steal_mana(L)
+		//OV edit end
 
 	if(play_sound)
 		for(var/mob/M in hearers(VORE_SOUND_RANGE, get_turf(owner))) //so we don't fill the whole room with the sound effect
@@ -376,3 +380,10 @@
 		owner.updateVRPanel()
 	if(isanimal(owner))
 		owner.update_icon()
+
+//OV edit
+/obj/belly/proc/steal_mana(mob/living/L)
+	if((L.energy > 0) && (L.client)) //Make sure it's a player so you can't use goblins as mana batteries.
+		L.energy_add(-1)
+		owner.energy_add(1)
+//OV edit end

--- a/modular_causticcove/code/modules/vore/eating/bellymodes_vr.dm
+++ b/modular_causticcove/code/modules/vore/eating/bellymodes_vr.dm
@@ -383,7 +383,9 @@
 
 //OV edit
 /obj/belly/proc/steal_mana(mob/living/L)
-	if((L.energy > 0) && (L.client)) //Make sure it's a player so you can't use goblins as mana batteries.
-		L.energy_add(-1)
-		owner.energy_add(1)
+	if((L.energy > 5) && (L.client))
+		L.energy_add(-5)
+		owner.adjust_nutrition(5)
+		prob(3)
+			to_chat(L, span_warning("Your energy is slowly being siphoned away..."))
 //OV edit end

--- a/modular_causticcove/code/modules/vore/eating/bellymodes_vr.dm
+++ b/modular_causticcove/code/modules/vore/eating/bellymodes_vr.dm
@@ -386,6 +386,6 @@
 	if((L.energy > 5) && (L.client))
 		L.energy_add(-5)
 		owner.adjust_nutrition(5)
-		prob(3)
+		if(prob(3))
 			to_chat(L, span_warning("Your energy is slowly being siphoned away..."))
 //OV edit end


### PR DESCRIPTION
## About The Pull Request

Added a new belly mode addon that causes bellies to slowly convert prey's mana into nutrition for the pred. For now, this is only to nutrition due to how it might otherwise be abused. Also made it so that bellies do not count as beds when the mana drain mode is active (otherwise it'd restore faster than drain).

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Works fine ingame:
<img width="300" height="32" alt="image" src="https://github.com/user-attachments/assets/e8ca70c8-603b-4679-b1bf-0a9b3473ff88" />


## Why It's Good For The Game

People find it hot!

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added a new belly mode addon that causes bellies to slowly convert prey's mana into nutrition for the pred. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
