### PR TITLE
Spare Prosthetic Limbs From Digestion

### DIFF
--- a/modular_causticcove/code/modules/vore/eating/bellymodes_vr.dm
+++ b/modular_causticcove/code/modules/vore/eating/bellymodes_vr.dm
@@ -337,6 +337,7 @@
 	if((mode_flags & DM_FLAG_LEAVEREMAINS) && M.digest_leave_remains)
 		handle_remains_leaving(M)
 	
+	//OV edit
 	if((mode_flags & DM_FLAG_SPARELIMB) && M.digest_leave_remains && ishuman(M))
 		var/mob/living/carbon/human/H = M
 		for(var/obj/item/bodypart/l_arm/prosthetic/limb in H.bodyparts)
@@ -347,6 +348,7 @@
 			limb.drop_limb()
 		for(var/obj/item/bodypart/r_leg/prosthetic/limb in H.bodyparts)
 			limb.drop_limb()
+	//OV edit end
 
 	digestion_death(M)
 	if(show_liquids && reagent_mode_flags & DM_FLAG_REAGENTSDIGEST && reagents.total_volume < reagents.maximum_volume) // digestion producing reagents

--- a/modular_causticcove/code/modules/vore/eating/bellymodes_vr.dm
+++ b/modular_causticcove/code/modules/vore/eating/bellymodes_vr.dm
@@ -336,6 +336,17 @@
 
 	if((mode_flags & DM_FLAG_LEAVEREMAINS) && M.digest_leave_remains)
 		handle_remains_leaving(M)
+	
+	if((mode_flags & DM_FLAG_SPARELIMB) && M.digest_leave_remains && ishuman(M))
+		var/mob/living/carbon/human/H = M
+		for(var/obj/item/bodypart/l_arm/prosthetic/limb in H.bodyparts)
+			limb.drop_limb()
+		for(var/obj/item/bodypart/r_arm/prosthetic/limb in H.bodyparts)
+			limb.drop_limb()
+		for(var/obj/item/bodypart/l_leg/prosthetic/limb in H.bodyparts)
+			limb.drop_limb()
+		for(var/obj/item/bodypart/r_leg/prosthetic/limb in H.bodyparts)
+			limb.drop_limb()
 
 	digestion_death(M)
 	if(show_liquids && reagent_mode_flags & DM_FLAG_REAGENTSDIGEST && reagents.total_volume < reagents.maximum_volume) // digestion producing reagents


### PR DESCRIPTION

## About The Pull Request

Added the ability to make it so that prosthetic limbs from digested prey are dropped into your belly. This uses the "Spare Prosthetics" belly mode add-on, and requires the prey to have "Leave Remains" enabled.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<img width="1002" height="232" alt="image" src="https://github.com/user-attachments/assets/354d9fb8-c0af-49be-91a0-72925960acb1" />

## Why It's Good For The Game

This was something that I added to virgo, but was never made to actually function here until now. Now it works, so people can burp out Kara's arm :D

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added the ability to make it so that prosthetic limbs from digested prey are dropped into your belly. This uses the "Spare Prosthetics" belly mode add-on, and requires the prey to have "Leave Remains" enabled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
