### PR TITLE
Temporarily fix emotes not working for vore/micros/closets/etc

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -199,7 +199,7 @@ GLOBAL_VAR_INIT(mobids, 1)
 		ignored_mobs = list(ignored_mobs)
 	if(!isnum(vision_distance))
 		vision_distance = DEFAULT_MESSAGE_RANGE
-	var/list/hearers = hearers(vision_distance, src) //caches the hearers and then removes ignored mobs.
+	var/list/hearers = get_hearers_in_view(vision_distance, src) //caches the hearers and then removes ignored mobs. // OV Edit: this must be get_hearers_in_view or vore breaks, remove when upstream fixes this
 	add_remote_hearing_atom_listeners(hearers, src, vision_distance) //OV Add
 	hearers -= ignored_mobs
 	if(self_message)
@@ -243,7 +243,7 @@ GLOBAL_VAR_INIT(mobids, 1)
  * * hearing_distance (optional) is the range, how many tiles away the message can be heard.
  */
 /atom/proc/audible_message(message, deaf_message, hearing_distance = DEFAULT_MESSAGE_RANGE, self_message, runechat_message = null, log_seen = NONE, log_seen_msg = null, custom_spans = list("emote"), used_language = /datum/language/common)
-	var/list/hearers = hearers(hearing_distance, src)
+	var/list/hearers = get_hearers_in_view(hearing_distance, src) // OV Edit: this must be get_hearers_in_view or vore breaks, remove when upstream fixes this
 	add_remote_hearing_atom_listeners(hearers, src, hearing_distance) //OV Add
 	if(self_message)
 		hearers -= src
@@ -271,7 +271,7 @@ GLOBAL_VAR_INIT(mobids, 1)
  */
 
 /atom/proc/loud_message(message, hearing_distance = DEFAULT_MESSAGE_RANGE, directional = TRUE)
-	var/list/listening = hearers(hearing_distance, src)
+	var/list/listening = get_hearers_in_view(hearing_distance, src) // OV Edit: this must be get_hearers_in_view or vore breaks, remove when upstream fixes this
 	add_remote_hearing_atom_listeners(listening, src, hearing_distance) //OV Add
 	for(var/_M in GLOB.player_list)
 		var/mob/M = _M


### PR DESCRIPTION
## About The Pull Request
This will need to be fixed upstream and addressed in the next merge PR but as this is a critical issue, here's a temp fix

Closes #410, this is the correct way to fix it

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game
sceneing lol

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: you can play again without being unable to hear your partner lol
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
