### PR TITLE
Categorizes a buncha verbs

### DIFF
--- a/modular_causticcove/code/modules/client/customizers/organ/genitals.dm
+++ b/modular_causticcove/code/modules/client/customizers/organ/genitals.dm
@@ -63,7 +63,7 @@
 //OV edit
 /mob/living/carbon/verb/changebellysize()
 	set name = "Change Asset Size"
-	set category = "Vore"
+	set category = "Vore.Misc"
 	set desc = "Change the size of your belly or other assets"
 	var/list/all_assets = list("Belly", "Breasts", "Butt", "Penis", "Testicles")
 	var/option = tgui_input_list(src, "Which asset do you wish to resize?", "Asset Selection", all_assets)

--- a/modular_causticcove/code/modules/size_scaling/size_verbs/standardized_sprite_verb.dm
+++ b/modular_causticcove/code/modules/size_scaling/size_verbs/standardized_sprite_verb.dm
@@ -1,6 +1,6 @@
 /mob/verb/standardsprite()
 	set name = "Standardize sprite"
-	set category = "Vore"
+	set category = "Vore.Misc" // OV Edit
 	set desc = "Standardizes your sprite to 100%. ONLY FOR YOURSELF!"
 	if(isliving(src))
 		var/mob/living/curruser = src

--- a/modular_causticcove/code/modules/vore/caustic_integration.dm
+++ b/modular_causticcove/code/modules/vore/caustic_integration.dm
@@ -25,5 +25,5 @@
 
 /mob/living/carbon/verb/toggle_vore_mode_verb()
 	set name = "Toggle Vore Mode"
-	set category = "Vore"
+	set category = "Vore.Preferences" // OV Edit
 	toggle_vore_mode()

--- a/modular_causticcove/code/modules/vore/chat_healthbars.dm
+++ b/modular_causticcove/code/modules/vore/chat_healthbars.dm
@@ -115,8 +115,8 @@
 		to_chat(reciever,span_notice("[ourbar]"))
 
 /mob/living/verb/print_healthbars()
-	set name = "Print Prey Healthbars"
-	set category = "Vore" //OV EDIT
+	set name = "Print Prey Healthbars" // OV Edit
+	set category = "Vore.Misc" //OV EDIT
 
 	var/nuffin = TRUE
 

--- a/modular_causticcove/code/modules/vore/chat_healthbars.dm
+++ b/modular_causticcove/code/modules/vore/chat_healthbars.dm
@@ -115,7 +115,7 @@
 		to_chat(reciever,span_notice("[ourbar]"))
 
 /mob/living/verb/print_healthbars()
-	set name = "Print Prey Healthbars" // OV Edit
+	set name = "Print Prey Healthbars"
 	set category = "Vore.Misc" //OV EDIT
 
 	var/nuffin = TRUE

--- a/modular_causticcove/code/modules/vore/eating/living_vr.dm
+++ b/modular_causticcove/code/modules/vore/eating/living_vr.dm
@@ -442,7 +442,7 @@
 //
 /mob/living/verb/lick_taste(mob/living/tasted in living_mobs_in_view(1, TRUE))
 	set name = "Lick someone"
-	set category = "Vore" //OV EDIT
+	set category = "Vore.Misc" //OV EDIT
 	set desc = "Lick someone nearby!"
 	set popup_menu = FALSE // Stop licking by accident!
 
@@ -495,7 +495,7 @@
 //This is just the above proc but switched about.
 /mob/living/verb/smell(mob/living/smelled in living_mobs(1, TRUE))
 	set name = "Smell someone"
-	set category = "Vore" //OV EDIT
+	set category = "Vore.Misc" //OV EDIT
 	set desc = "Smell someone nearby!"
 	set popup_menu = FALSE
 
@@ -806,8 +806,8 @@
 
 /mob/living/verb/eat_trash()
 	set name = "Eat object"
-	set category = "Vore" //OV EDIT
-	set desc = "Consume held object into currently selected belly."
+	set category = "Vore.Actions" //OV EDIT
+	set desc = "Consume held object into currently selected vorgan." // OV Edit - vorgan instead of belly
 
 	//on chomp it worked off a whitelist of items you could devour, hope is that here it can be replaced by a long windup before eating something
 
@@ -1315,9 +1315,9 @@
 	return message
 
 /mob/living/verb/vore_check_reagents()
-	set name = "Check Belly Liquid (Vore)"
-	set category = "Vore" //OV EDIT
-	set desc = "Check the amount of liquid in your belly."
+	set name = "Check Vorgan Liquid" // OV Edit - Vorgan instead of belly
+	set category = "Vore.Vorgan Liquids" //OV EDIT
+	set desc = "Check the amount of liquid in your vorgan." // OV Edit - Vorgan instead of belly
 
 	var/obj/belly/RTB = tgui_input_list(src, "Choose which vore belly to check", "Select Belly", vore_organs)
 	if(!RTB)
@@ -1331,8 +1331,8 @@
 	to_chat(src, total_report)
 
 /mob/living/verb/vore_transfer_reagents()
-	set name = "Transfer Liquid (Vore)"
-	set category = "Vore" //OV EDIT
+	set name = "Transfer Liquid"
+	set category = "Vore.Vorgan Liquids" //OV EDIT
 	set desc = "Transfer liquid from an organ to another or stomach, or into another person or container."
 	set popup_menu = FALSE
 
@@ -1538,7 +1538,7 @@
 
 /mob/living/proc/restrict_trasheater()
 	set name = "Restrict Trash Eater"
-	set category = "Vore" //OV EDIT
+	set category = "Vore.Preferences" //OV EDIT
 	set desc = "Toggle Trash Eater restriction level."
 	adminbus_trash = !adminbus_trash
 	to_chat(src, span_warning("Trash Eater restriction level set to [adminbus_trash ? "everything not blacklisted" : "only whitelisted items"]."))
@@ -1567,7 +1567,7 @@
 
 /mob/living/verb/vore_check_nutrition()
 	set name = "Check Nutrition"
-	set category = "Vore" //OV EDIT
+	set category = "Vore.Misc" //OV EDIT
 	set desc = "Check your current nutrition level."
 	to_chat(src, span_notice("Current nutrition level: [nutrition]."))
 

--- a/modular_causticcove/code/modules/vore/eating/living_vr.dm
+++ b/modular_causticcove/code/modules/vore/eating/living_vr.dm
@@ -1331,7 +1331,7 @@
 	to_chat(src, total_report)
 
 /mob/living/verb/vore_transfer_reagents()
-	set name = "Transfer Liquid"
+	set name = "Transfer Liquid" // OV Edit
 	set category = "Vore.Vorgan Liquids" //OV EDIT
 	set desc = "Transfer liquid from an organ to another or stomach, or into another person or container."
 	set popup_menu = FALSE

--- a/modular_causticcove/code/modules/vore/eating/vertical_nom_vr.dm
+++ b/modular_causticcove/code/modules/vore/eating/vertical_nom_vr.dm
@@ -1,7 +1,7 @@
 /mob/living/verb/vertical_nom()
 	set name = "Nom from Above"
 	set desc = "Allows you to eat people who are below your tile or adjacent one. Requires passability."
-	set category = "Vore" //OV EDIT
+	set category = "Vore.Actions" //OV EDIT
 
 	if(stat == DEAD || IsParalyzed() || IsImmobilized() || IsStun() || IsKnockdown())
 		to_chat(src, span_notice("You cannot do that while in your current state."))

--- a/modular_causticcove/code/modules/vore/eating/vore_verbs.dm
+++ b/modular_causticcove/code/modules/vore/eating/vore_verbs.dm
@@ -51,9 +51,9 @@
 	return ..(target)
 
 /mob/living/verb/shred_limb()
-	set name = "Damage Prey's Organ" //OV EDIT
+	set name = "Damage Prey's Organ"
 	set desc = "Severely damages prey's organ. If the limb is already severely damaged, it will be torn off."
-	set category = "Vore" //OV EDIT
+	set category = "Vore.Actions" //OV EDIT
 
 	//can_shred() will return a mob we can shred, if we can shred any.
 	var/mob/living/carbon/human/T = can_shred()
@@ -160,14 +160,14 @@
 		log_combat(src,T,"Shredded (hardvore)")
 
 /mob/living/proc/shred_limb_temp()
-	set name = "Damage Prey's Organ (beartrap)" //OV EDIT
+	set name = "Damage Prey's Organ (beartrap)"
 	set desc = "Severely damages prey's organ. If the limb is already severely damaged, it will be torn off."
-	set category = "Vore" //OV EDIT
+	set category = "Vore.Actions" //OV EDIT
 	shred_limb()
 
 /mob/verb/toggle_vore_health_bars()
-	set name = "Toggle Auto Healthbars"
-	set category = "Vore"
+	set name = "Toggle Auto Healthbars" // OV Edit
+	set category = "Vore.Preferences" // OV Edit
 
 	if(client?.prefs)
 		client.prefs.vore_health_bars = !client.prefs.vore_health_bars
@@ -175,7 +175,7 @@
 
 /mob/verb/toggle_digest_noises()
 	set name = "Toggle Digest Noises"
-	set category = "Vore"
+	set category = "Vore.Preferences" // OV Edit
 
 	if(client?.prefs)
 		client.prefs.digestion_noises = !client.prefs.digestion_noises
@@ -183,7 +183,7 @@
 
 /mob/verb/toggle_eating_noises()
 	set name = "Toggle Eating Noises"
-	set category = "Vore"
+	set category = "Vore.Preferences" // OV Edit
 
 	if(client?.prefs)
 		client.prefs.eating_noises = !client.prefs.eating_noises
@@ -191,7 +191,7 @@
 
 /mob/verb/toggle_belch_noises()
 	set name = "Toggle Belch Noises"
-	set category = "Vore"
+	set category = "Vore.Preferences" // OV Edit
 
 	if(client?.prefs)
 		client.prefs.belch_noises = !client.prefs.belch_noises
@@ -200,7 +200,7 @@
 //OV edit
 /mob/verb/toggle_vore_fx()
 	set name = "Toggle Vore FX"
-	set category = "Vore"
+	set category = "Vore.Preferences" // OV Edit
 
 	show_vore_fx = !show_vore_fx
 	if(client.prefs_vr)
@@ -217,7 +217,7 @@
 
 /mob/verb/toggle_spont_pred()
 	set name = "Toggle Spont Pred"
-	set category = "Vore"
+	set category = "Vore.Preferences" // OV Edit
 
 	can_be_drop_pred = !can_be_drop_pred
 	if(client.prefs_vr)
@@ -226,7 +226,7 @@
 
 /mob/verb/toggle_spont_prey()
 	set name = "Toggle Spont Prey"
-	set category = "Vore"
+	set category = "Vore.Preferences" // OV Edit
 
 	can_be_drop_prey = !can_be_drop_prey
 	if(client.prefs_vr)

--- a/modular_causticcove/code/modules/vore/eating/vore_verbs.dm
+++ b/modular_causticcove/code/modules/vore/eating/vore_verbs.dm
@@ -160,13 +160,13 @@
 		log_combat(src,T,"Shredded (hardvore)")
 
 /mob/living/proc/shred_limb_temp()
-	set name = "Damage Prey's Organ (beartrap)"
+	set name = "Damage Prey's Organ (beartrap)" //OV EDIT
 	set desc = "Severely damages prey's organ. If the limb is already severely damaged, it will be torn off."
 	set category = "Vore.Actions" //OV EDIT
 	shred_limb()
 
 /mob/verb/toggle_vore_health_bars()
-	set name = "Toggle Auto Healthbars" // OV Edit
+	set name = "Toggle Auto Healthbars"
 	set category = "Vore.Preferences" // OV Edit
 
 	if(client?.prefs)

--- a/modular_causticcove/code/modules/vore/eating/vorepanel_vr.dm
+++ b/modular_causticcove/code/modules/vore/eating/vorepanel_vr.dm
@@ -13,7 +13,7 @@
 
 /mob/verb/insidePanel()
 	set name = "Vore Panel"
-	set category = "Vore"
+	set category = "Vore.Actions" // OV Edit
 
 	if(SSticker.current_state == GAME_STATE_STARTUP)
 		return

--- a/modular_ochrevalley/code/modules/admin/admin_manifest.dm
+++ b/modular_ochrevalley/code/modules/admin/admin_manifest.dm
@@ -1,7 +1,7 @@
 GLOBAL_DATUM(admin_manifest, /datum/admin_manifest)
 
 /client/proc/admin_manifest()
-	set name = "Show Manifest"
+	set name = "Show Manifest.Admin"
 	set category = "Admin"
 	if(!holder)
 		return

--- a/modular_ochrevalley/code/vore_verb.dm
+++ b/modular_ochrevalley/code/vore_verb.dm
@@ -324,7 +324,7 @@
 /mob/living/verb/vore_player()
 	set name = "Vore Player"
 	set desc = "Attempt to eat an adjacent player."
-	set category = "Vore"
+	set category = "Vore.Actions"
 
 	if(stat)
 		to_chat(src,span_warning("You can't do that right now."))
@@ -393,7 +393,7 @@
 /mob/living/verb/petrification()
 	set name = "Petrification"
 	set desc = "Petrify yourself or a nearby player."
-	set category = "Vore"
+	set category = "Vore.Misc"
 
 	if(stat)
 		to_chat(src, span_warning("You can't do that right now."))


### PR DESCRIPTION
## About The Pull Request

Adds categories to all vore verbs and one of the admin verbs

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [X] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [X] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [X] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

<img width="625" height="457" alt="dreamseeker_2026-06-30_02-21-23" src="https://github.com/user-attachments/assets/a0d50a96-6b27-445f-925e-dde9f8f42efc" />



## Why It's Good For The Game

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

Organization for our myriad of buttons is good and helpful!

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
