### PR TITLE
Dodge vore now needs stumble vore enabled

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -63,6 +63,9 @@ SUBSYSTEM_DEF(throwing)
 	var/delayed_time = 0
 	var/last_move = 0
 	var/extra = FALSE
+	//ov edit
+	var/throwvore = FALSE
+	//ov edit
 
 /datum/thrownthing/New(thrownthing, target, target_turf, init_dir, maxrange, speed, thrower, diagonals_first, force, callback, target_zone, extra)
 	. = ..()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -688,7 +688,9 @@
 		return
 	return throw_at(target, range, speed, thrower, spin, diagonals_first, callback, force)
 
-/atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin = FALSE, diagonals_first = FALSE, datum/callback/callback, force = MOVE_FORCE_STRONG, extra = FALSE) //If this returns FALSE then callback will not be called.
+//ov edit start- adding a "throwvore" var, to allow more fine control of whether or not throwvore can occur from a specific proc
+/atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin = FALSE, diagonals_first = FALSE, datum/callback/callback, force = MOVE_FORCE_STRONG, extra = FALSE, throwvore = TRUE) //If this returns FALSE then callback will not be called.
+//ov edit end
 	. = FALSE
 	if (!target || speed <= 0 || move_resist == INFINITY)
 		return
@@ -737,6 +739,9 @@
 	TT.force = force
 	TT.callback = callback
 	TT.extra = extra
+	//ov edit- throwvore var
+	TT.throwvore = throwvore
+	//ov edit end
 	if(!QDELETED(thrower))
 		TT.target_zone = thrower.zone_selected
 

--- a/code/modules/mob/living/combat/dodge.dm
+++ b/code/modules/mob/living/combat/dodge.dm
@@ -310,7 +310,7 @@
 	dodgecd = TRUE
 	playsound(src, 'sound/combat/dodge.ogg', 100, FALSE)
 	if(!HAS_TRAIT(src, TRAIT_DODGE_NO_MOVE))
-		throw_at(turfy, 1, 2, src, FALSE)
+		throw_at(turfy, 1, 2, src, FALSE, throwvore = stumble_vore) //ov edit- throwvore var. Dodgevore now needs the target to have stumblevore enabled
 	if(drained > 0)
 		src.visible_message(span_warning("<b>[src]</b> dodges [user]'s attack!"))
 	else

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -280,9 +280,11 @@
 	//Caustic Edit - Add Spontaneous Vore from throwing things!
 	var/speed = throwingdatum?.speed
 	var/mob/living/thrower = throwingdatum?.thrower
-
-	if(SEND_SIGNAL(src, COMSIG_LIVING_HIT_BY_THROWN_ENTITY, AM, thrower, speed) & COMSIG_CANCEL_HITBY)
-		return FALSE
+	//ov edit- allow for finer control of throwvore
+	if(throwingdatum?.throwvore)
+		if(SEND_SIGNAL(src, COMSIG_LIVING_HIT_BY_THROWN_ENTITY, AM, thrower, speed) & COMSIG_CANCEL_HITBY)
+			return FALSE
+	//ov edit end
 	//Caustic Edit End
 	
 	if(istype(AM, /obj/item))

--- a/tgui/packages/tgui/interfaces/VorePanel/VorePanelMainTabs/VoreUserPreferences.tsx
+++ b/tgui/packages/tgui/interfaces/VorePanel/VorePanelMainTabs/VoreUserPreferences.tsx
@@ -253,7 +253,7 @@ export const VoreUserPreferences = (props: { prefs: PrefData }) => {
       test: stumble_vore,
       tooltip: {
         main:
-          'Allows for stumble related spontaneous vore to occur. ' +
+          'Allows for stumble related spontaneous vore to occur. If enabled with throw vore, allows for vore to occur if you dodge into someone. ' +
           ' Note, you still need spontaneous vore pred and/or prey enabled.',
         enable: 'Click here to allow for stumble vore.',
         disable: 'Click here to disable stumble vore.',


### PR DESCRIPTION
## About The Pull Request
Dodge vore now needs both throw vore and stumble vore enabled
adds backend support so individual instances of throwvore can be enabled or disabled more finely

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence
This pr basically needs multiplayer to test well, unfortunately. I'm unable to test at this time
## Why It's Good For The Game

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: Dodging no longer triggers spontaneous vore, unless both Stumble vore and Throw vore are enabled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
