### PR TITLE
Adds A Scrying Protection Verb for Scening Purposes

### DIFF
--- a/code/game/objects/items/rogueitems/magic.dm
+++ b/code/game/objects/items/rogueitems/magic.dm
@@ -157,6 +157,9 @@
 	if(HAS_TRAIT(target, TRAIT_ANTISCRYING))
 		to_chat(user, span_warning("They are not within the gaze of the Orb."))
 		return
+	if(target.do_not_disturb == TRUE) // OV Add Start
+		to_chat(user, span_warning("They are not within the gaze of the Orb. (This player is under privacy rule protections! Please be respectful.)")) // OV Add End
+		return
 
 	if(!prob(success_chance))
 		on_failure(user, target, failure_severity)

--- a/code/game/objects/items/rogueitems/magic.dm
+++ b/code/game/objects/items/rogueitems/magic.dm
@@ -157,9 +157,11 @@
 	if(HAS_TRAIT(target, TRAIT_ANTISCRYING))
 		to_chat(user, span_warning("They are not within the gaze of the Orb."))
 		return
-	if(target.do_not_disturb == TRUE) // OV Add Start
-		to_chat(user, span_warning("They are not within the gaze of the Orb. (This player is under privacy rule protections! Please be respectful.)")) // OV Add End
+	// OV Edit Start
+	if(target.do_not_disturb == TRUE)
+		to_chat(user, span_warning("They are not within the gaze of the Orb. (This player is under privacy rule protections! Please be respectful.)"))
 		return
+	// OV Edit End
 
 	if(!prob(success_chance))
 		on_failure(user, target, failure_severity)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_structures/hag_mirror.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_structures/hag_mirror.dm
@@ -121,6 +121,9 @@
 				to_chat(user, span_warning("The gaze of the roots is rebuffed by a ward!"))
 				return
 			target = HL
+			if(target.do_not_disturb == TRUE) // OV Add Start
+				to_chat(user, span_warning("The gaze of the roots is rebuffed by a ward! (This player is under privacy rule protections! Please be respectful.)")) // OV Add End
+				return
 	if(!target)
 		to_chat(user, span_warning("They are not within the gaze of the mirror; they may be destroyed, utterly."))
 		return

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_structures/hag_mirror.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_structures/hag_mirror.dm
@@ -121,9 +121,11 @@
 				to_chat(user, span_warning("The gaze of the roots is rebuffed by a ward!"))
 				return
 			target = HL
-			if(target.do_not_disturb == TRUE) // OV Add Start
-				to_chat(user, span_warning("The gaze of the roots is rebuffed by a ward! (This player is under privacy rule protections! Please be respectful.)")) // OV Add End
+			// OV Edit Start
+			if(target.do_not_disturb == TRUE) 
+				to_chat(user, span_warning("The gaze of the roots is rebuffed by a ward! (This player is under privacy rule protections! Please be respectful.)")) 
 				return
+			// OV Edit End
 	if(!target)
 		to_chat(user, span_warning("They are not within the gaze of the mirror; they may be destroyed, utterly."))
 		return

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -110,8 +110,9 @@
 			cf.flaw_on_moved(src, OldLoc, Dir)
 //Caustic Edit End
 	if(do_not_disturb) // OV Add Start - To prevent toggling scrying protections permanently
-		do_not_disturb = FALSE
-		to_chat(src, span_notice("You are no longer marked as private and can be scried.")) // OV Add End
+		if(!isbelly(loc))
+			do_not_disturb = FALSE
+			to_chat(src, span_notice("You are no longer marked as private and can be scried.")) // OV Add End
 
 
 /mob/living/carbon/human/DeadLife()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -109,6 +109,10 @@
 		if(cf && !cf.ephemeral && mind)
 			cf.flaw_on_moved(src, OldLoc, Dir)
 //Caustic Edit End
+	if(do_not_disturb) // OV Add Start - To prevent toggling scrying protections permanently
+		do_not_disturb = FALSE
+		to_chat(src, span_notice("You are no longer marked as private and can be scried.")) // OV Add End
+
 
 /mob/living/carbon/human/DeadLife()
 	set invisibility = 0

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -109,10 +109,12 @@
 		if(cf && !cf.ephemeral && mind)
 			cf.flaw_on_moved(src, OldLoc, Dir)
 //Caustic Edit End
-	if(do_not_disturb) // OV Add Start - To prevent toggling scrying protections permanently
+	// OV Edit Start - To prevent toggling scrying protections permanently
+	if(do_not_disturb) 
 		if(!isbelly(loc))
 			do_not_disturb = FALSE
-			to_chat(src, span_notice("You are no longer marked as private and can be scried.")) // OV Add End
+			to_chat(src, span_notice("You are no longer marked as private and can be scried.")) 
+	// OV Edit End
 
 
 /mob/living/carbon/human/DeadLife()

--- a/modular_causticcove/code/modules/vore/eating/living_vr.dm
+++ b/modular_causticcove/code/modules/vore/eating/living_vr.dm
@@ -1602,9 +1602,11 @@
 	if(do_not_disturb)
 		to_chat(src, span_notice("You are no longer marked as private."))
 		do_not_disturb = FALSE
+		log_game("[src ? key_name(src) : "system"] has disabled scene privacy at [loc_name(src)].")
 	else
 		to_chat(src, span_notice("You are now marked as private and can no longer be scried."))
 		do_not_disturb = TRUE // OV Add End
+		log_game("[src ? key_name(src) : "system"] has enabled scene privacy at [loc_name(src)].")
 
 /mob/living/proc/absorb_langs()		//This should be called on the predator in the exchange
 	if(!mind || !mind.language_holder)

--- a/modular_causticcove/code/modules/vore/eating/living_vr.dm
+++ b/modular_causticcove/code/modules/vore/eating/living_vr.dm
@@ -1595,18 +1595,18 @@
 		away_from_keyboard = TRUE
 		manual_afk = TRUE
 
-/mob/living/verb/toggle_scening() // OV Add Start
+/mob/living/verb/toggle_scening()
 	set name = "Toggle Scene Privacy"
 	set category = "IC"
 	set desc = "Mark yourself as in a scene, to prevent scrying!"
 	if(do_not_disturb)
 		to_chat(src, span_notice("You are no longer marked as private."))
 		do_not_disturb = FALSE
-		log_game("[src ? key_name(src) : "system"] has disabled scene privacy at [loc_name(src)].")
+		log_game("[key_name(src)] has disabled scene privacy at [loc_name(src)].")
 	else
 		to_chat(src, span_notice("You are now marked as private and can no longer be scried."))
 		do_not_disturb = TRUE // OV Add End
-		log_game("[src ? key_name(src) : "system"] has enabled scene privacy at [loc_name(src)].")
+		log_game("[key_name(src)] has enabled scene privacy at [loc_name(src)].")
 
 /mob/living/proc/absorb_langs()		//This should be called on the predator in the exchange
 	if(!mind || !mind.language_holder)

--- a/modular_causticcove/code/modules/vore/eating/living_vr.dm
+++ b/modular_causticcove/code/modules/vore/eating/living_vr.dm
@@ -1595,6 +1595,17 @@
 		away_from_keyboard = TRUE
 		manual_afk = TRUE
 
+/mob/living/verb/toggle_scening() // OV Add Start
+	set name = "Toggle Scene Privacy"
+	set category = "IC"
+	set desc = "Mark yourself as in a scene, to prevent scrying!"
+	if(do_not_disturb)
+		to_chat(src, span_notice("You are no longer marked as private."))
+		do_not_disturb = FALSE
+	else
+		to_chat(src, span_notice("You are now marked as private and can no longer be scried."))
+		do_not_disturb = TRUE // OV Add End
+
 /mob/living/proc/absorb_langs()		//This should be called on the predator in the exchange
 	if(!mind || !mind.language_holder)
 		return

--- a/modular_causticcove/code/modules/vore/eating/mob_vr.dm
+++ b/modular_causticcove/code/modules/vore/eating/mob_vr.dm
@@ -115,4 +115,4 @@
 	var/size_multiplier = 1 //multiplier for the mob's icon size
 	var/faction_bump_vore = FALSE	// Don't bump nom mobs of the same faction
 
-	var/do_not_disturb = FALSE	// OV Add - ERP Scrying Privacy
+	var/do_not_disturb = FALSE	// ERP Scrying Privacy

--- a/modular_causticcove/code/modules/vore/eating/mob_vr.dm
+++ b/modular_causticcove/code/modules/vore/eating/mob_vr.dm
@@ -114,3 +114,5 @@
 
 	var/size_multiplier = 1 //multiplier for the mob's icon size
 	var/faction_bump_vore = FALSE	// Don't bump nom mobs of the same faction
+
+	var/do_not_disturb = FALSE	// OV Add - ERP Scrying Privacy


### PR DESCRIPTION
## About The Pull Request
Label!
Adds a verb ' Toggle Scene Privacy ' under the IC tab that prevents you from being scried by other players.
It disables when you move, but otherwise stays enabled indefinitely.
Also carries a little notice for the scrier that the person theyre targetting is under privacy protection rules.
<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence
Wyrd mirror and scrying orb fail to scry a mob with the toggle active, and the toggle disables when moving.
Works as intended!
<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game
There have been player concerns about being scried while in a scene, this should quell some issues around this, while allowing people with the ability to scry to fulfill their roles without worrying about accidentally intruding.

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Adds Toggle Scene Privacy verb
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
