### PR TITLE
Natural Armour Refactor

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -317,7 +317,7 @@
 //OV File Start
 #define TRAIT_LYFE_DRINK "Hemovore"
 #define TRAIT_ARMOR_AVERSE "Armor Averse"
-#define TRAIT_FERAL "Less Feral"
+#define TRAIT_FERAL_MINOR "Less Feral"
 //OV File End
 
 // Economic Roles Traits

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -316,6 +316,8 @@
 
 //OV File Start
 #define TRAIT_LYFE_DRINK "Hemovore"
+#define TRAIT_ARMOR_AVERSE "Armor Averse"
+#define TRAIT_FERAL "Less Feral"
 //OV File End
 
 // Economic Roles Traits

--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -50,7 +50,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(list(/area/rogue/indoors
 		guy.apply_status_effect(/datum/status_effect/buff/feraldebuff)
 		guy.add_stress(/datum/stressevent/feralintown)
 	//OV edit
-	if((src.town_area == TRUE) && HAS_TRAIT(guy, TRAIT_FERAL_MINOR) && !guy.has_status_effect(/datum/status_effect/buff/feraldebuff_minor)) //for domesticated wildsouls to discourage them being in town
+	if((src.town_area == TRUE) && HAS_TRAIT(guy, TRAIT_FERAL_MINOR)) //for domesticated wildsouls to discourage them being in town
 		guy.add_stress(/datum/stressevent/feralintown)
 	//OV edit end
 	if((src.town_area == TRUE) && HAS_TRAIT(guy, TRAIT_NECRAS_ABATEMENT) && !guy.has_status_effect(/datum/status_effect/buff/deadite_pacified)) //zombie pacification

--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -46,10 +46,10 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(list(/area/rogue/indoors
 	if((src.holy_area == TRUE) && HAS_TRAIT(guy, TRAIT_UNDIVIDED)) // get a long-lingering mood buff so long as we visit the church daily as Undivided.
 		guy.add_stress(/datum/stressevent/seeblessed)
 	//Caustic edit
+	//OV edit
 	if((src.town_area == TRUE) && HAS_TRAIT(guy, TRAIT_FERAL) && !guy.has_status_effect(/datum/status_effect/buff/feraldebuff)) //feral creatures don't do well in town
 		guy.apply_status_effect(/datum/status_effect/buff/feraldebuff)
 		guy.add_stress(/datum/stressevent/feralintown)
-	//OV edit
 	if((src.town_area == TRUE) && HAS_TRAIT(guy, TRAIT_FERAL_MINOR)) //for domesticated wildsouls to discourage them being in town
 		guy.add_stress(/datum/stressevent/feralintown)
 	//OV edit end

--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -48,6 +48,11 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(list(/area/rogue/indoors
 	//Caustic edit
 	if((src.town_area == TRUE) && HAS_TRAIT(guy, TRAIT_FERAL) && !guy.has_status_effect(/datum/status_effect/buff/feraldebuff)) //feral creatures don't do well in town
 		guy.apply_status_effect(/datum/status_effect/buff/feraldebuff)
+		guy.add_stress(/datum/stressevent/feralintown)
+	//OV edit
+	if((src.town_area == TRUE) && HAS_TRAIT(guy, TRAIT_FERAL_MINOR) && !guy.has_status_effect(/datum/status_effect/buff/feraldebuff_minor)) //for domesticated wildsouls to discourage them being in town
+		guy.add_stress(/datum/stressevent/feralintown)
+	//OV edit end
 	if((src.town_area == TRUE) && HAS_TRAIT(guy, TRAIT_NECRAS_ABATEMENT) && !guy.has_status_effect(/datum/status_effect/buff/deadite_pacified)) //zombie pacification
 		guy.apply_status_effect(/datum/status_effect/buff/deadite_pacified)
 	//Caustic edit end

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -770,6 +770,34 @@
 	return TRUE
 
 /mob/living/carbon/human/check_armor_skill()
+	//OV edit
+	if(HAS_TRAIT(src, TRAIT_ARMOR_AVERSE)) //With this, they can still get away with boots, gloves and bracers which should be relatively minor.
+		if(istype(src.wear_armor, /obj/item/clothing)) //May as well include an armour check here
+			var/obj/item/clothing/CL = src.wear_armor
+			if(CL.armor_class >= ARMOR_CLASS_LIGHT)
+				return FALSE
+		if(istype(src.wear_shirt, /obj/item/clothing))
+			var/obj/item/clothing/CL = src.wear_shirt
+			if(CL.armor_class >= ARMOR_CLASS_LIGHT)
+				return FALSE
+		if(istype(src.wear_pants, /obj/item/clothing))
+			var/obj/item/clothing/CL = src.wear_pants
+			if(CL.armor_class >= ARMOR_CLASS_LIGHT)
+				return FALSE
+		if(istype(src.head, /obj/item/clothing)) //This will allow them to continue to wear volfskin helmets etc
+			var/obj/item/clothing/CL = src.head
+			if(CL.armor_class >= ARMOR_CLASS_LIGHT)
+				return FALSE
+		if(istype(src.wear_neck, /obj/item/clothing)) //No gorgets etc
+			var/obj/item/clothing/CL = src.wear_neck
+			if(CL.armor)
+				return FALSE
+		if(istype(src.wear_mask, /obj/item/clothing)) //No coifs etc
+			var/obj/item/clothing/CL = src.wear_mask
+			if(CL.armor)
+				return FALSE
+		return TRUE //No need to run the rest of the checks, we've already ensured there's nothing better than light armour on them
+	//OV edit end
 	if(istype(src.wear_armor, /obj/item/clothing))
 		var/obj/item/clothing/CL = src.wear_armor
 		if(CL.armor_class == ARMOR_CLASS_HEAVY)

--- a/modular_causticcove/code/modules/classes/domesticated_wildsoul.dm
+++ b/modular_causticcove/code/modules/classes/domesticated_wildsoul.dm
@@ -3,7 +3,7 @@
 	tutorial = "You were once upon a time part of the wild. Now you have taken up the duty to protecting it, whenever because of the safety and curiosity of the settlement that you now serve, longing for a purpose, or merely being part of something greater and a concentrated effort, the safety of the roads for these fragile towners and traders rest in your hands and claws. Keep your cradle safe and free of riff raffs, together with your more civilized allies."
 	outfit = /datum/outfit/job/roguetown/warden/wildsoul
 	category_tags = list(CTAG_WARDEN)
-	traits_applied = list(TRAIT_CRITICAL_RESISTANCE, TRAIT_CIVILIZEDBARBARIAN, TRAIT_STRONGBITE, TRAIT_NATURAL_ARMOR) // Woodsman removed so it doesnt get applied twice. Feral removed, since theyre warden.
+	traits_applied = list(TRAIT_CRITICAL_RESISTANCE, TRAIT_CIVILIZEDBARBARIAN, TRAIT_STRONGBITE, TRAIT_ARMOR_AVERSE, TRAIT_FERAL_MINOR) // OV EDIT - Woodsman removed so it doesnt get applied twice. Feral removed, since theyre warden.
 	subclass_stats = list(
 		STATKEY_STR = 3,//7 points weighted, same as MAA. Direbear stats are kicked in the shins cause they get stat buffs in the woods instead of a debuff in the town.
 		STATKEY_CON = 2,
@@ -36,7 +36,7 @@
 	H.adjust_blindness(-3)
 	shoes = /obj/item/clothing/shoes/roguetown/boots/furlinedanklets
 	beltr = /obj/item/rogueweapon/huntingknife/stoneknife //OV Edit - Warden Sync
-	H.skin_armor = new /obj/item/clothing/suit/roguetown/armor/skin_armor/natural_armor/dense(H)
+	armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/wildsoul/dense //OV EDIT
 	gloves = /obj/item/clothing/gloves/roguetown/knuckles //OV Edit added steel knuckles
 	//OV Add Start
 	backpack_contents = list(

--- a/modular_causticcove/code/modules/classes/wildsoul.dm
+++ b/modular_causticcove/code/modules/classes/wildsoul.dm
@@ -43,7 +43,7 @@
 /datum/advclass/wildsoul/direbear
 	name = "Soul of the Direbear"
 	tutorial = "Strong, heavy, durable- but not swift. Not particularly wise, either, but does it matter how smart someone else is if you can crush their skull in one hand?"
-	traits_applied = list(TRAIT_CRITICAL_RESISTANCE, TRAIT_CIVILIZEDBARBARIAN, TRAIT_STRONGBITE, TRAIT_NATURAL_ARMOR)
+	traits_applied = list(TRAIT_CRITICAL_RESISTANCE, TRAIT_CIVILIZEDBARBARIAN, TRAIT_STRONGBITE, TRAIT_ARMOR_AVERSE) // OV EDIT
 	category_tags = list(CTAG_WILDSOUL)
 	subclass_stats = list(
 		STATKEY_STR = 3, // 9 points weighted, with favoring keeping durability and awareness over strength.
@@ -82,7 +82,7 @@
 	gloves = /obj/item/clothing/gloves/roguetown/bandages/weighted
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	beltl = /obj/item/rogueweapon/huntingknife/stoneknife
-	H.skin_armor = new /obj/item/clothing/suit/roguetown/armor/skin_armor/natural_armor/dense(H)
+	armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/wildsoul/dense //OV EDIT
 	give_feral_eyes(H)
 
 	var/techniques = list("Dropkick - Pushback + Extra Damage", "Chokeslam - Stamina Damage", "Stunner - Dazed Debuff", "Headbutt - Vulnerable Debuff") // cool wrestling moves
@@ -100,7 +100,7 @@
 /datum/advclass/wildsoul/mantid
 	name = "Soul of the Mantid"
 	tutorial = "To fight head on never was your style. You prefer the subtle options; to be hidden, quiet, and strike at the opportune moment. But be wary, as that lack of brute strength and thick armor means you can't cut yourself out of an aspiring hunter's net so easily."
-	traits_applied = list(TRAIT_WOODWALKER, TRAIT_DODGEEXPERT, TRAIT_PERFECT_TRACKER, TRAIT_LIGHT_STEP, TRAIT_NATURAL_ARMOR) // Lets try keeping the tanky traits on direbear instead. Sneaky hunter-like archetype- Should shine best in that lane.
+	traits_applied = list(TRAIT_WOODWALKER, TRAIT_DODGEEXPERT, TRAIT_PERFECT_TRACKER, TRAIT_LIGHT_STEP, TRAIT_ARMOR_AVERSE) // OV EDIT - Lets try keeping the tanky traits on direbear instead. Sneaky hunter-like archetype- Should shine best in that lane.
 	category_tags = list(CTAG_WILDSOUL)
 	subclass_stats = list(
 		STATKEY_STR = -2, // 9 stats weighted, with a focus on speed and perception for knives and bows.
@@ -142,7 +142,7 @@
 	beltl = /obj/item/rogueweapon/huntingknife
 	beltr = /obj/item/quiver/arrows
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
-	H.skin_armor = new /obj/item/clothing/suit/roguetown/armor/skin_armor/natural_armor(H)
+	armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/wildsoul	//OV EDIT
 	give_feral_eyes(H)
 
 /datum/advclass/wildsoul/lampternfly //OV Edit AP Merge 4.5.26 - RE-ENABLED 
@@ -295,3 +295,9 @@
 	if(!(our_area.town_area))
 		owner.remove_status_effect(/datum/status_effect/buff/feraldebuff)
 
+//OV edit
+/datum/stressevent/feralintown
+	desc = "So many walls, no trees, no grass... I have to get out of here!!!"
+	stressadd = 15
+	timer = 5 MINUTES
+//OV edit end

--- a/modular_causticcove/code/modules/nat_armor/virtue.dm
+++ b/modular_causticcove/code/modules/nat_armor/virtue.dm
@@ -1,3 +1,4 @@
+/* OV EDIT - Disabled
 /datum/virtue/combat/natarmor
 	name = "Natural Armor"
 	desc = "My hide is thick and resilient, enhancing my natural defense whilst making armor meerly vanity on my body. \
@@ -8,3 +9,4 @@
 
 /datum/virtue/combat/natarmor/apply_to_human(mob/living/carbon/human/recipient)
 	recipient.skin_armor = new /obj/item/clothing/suit/roguetown/armor/skin_armor/natural_armor(recipient)
+*/

--- a/modular_ochrevalley/code/modules/clothing/rogueclothes/armor/regenerating.dm
+++ b/modular_ochrevalley/code/modules/clothing/rogueclothes/armor/regenerating.dm
@@ -1,0 +1,16 @@
+/obj/item/clothing/suit/roguetown/armor/regenerating/skin/wildsoul
+	name = "natural armour"
+	desc = "The natural body of this person protects them from some amount of harm."
+	armor = ARMOR_LEATHER
+	body_parts_covered = COVERAGE_FULL_BODY_ACTUAL
+	body_parts_inherent = COVERAGE_FULL_BODY_ACTUAL
+	armor_class = ARMOR_CLASS_NONE
+
+	max_integrity = 300
+
+	repair_time = 25 SECONDS
+
+/obj/item/clothing/suit/roguetown/armor/regenerating/skin/wildsoul/dense
+	name = "dense natural armour"
+	armor = ARMOR_PLATE
+	max_integrity = 400

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3655,6 +3655,7 @@
 #include "modular_causticcove\code\modules\dcbot\topichandlers\fetchplayers.dm"
 #include "modular_causticcove\code\modules\deadite_pac\deadite_pac.dm"
 #include "modular_causticcove\code\modules\extra_virtue\prefs.dm"
+#include "modular_ochrevalley\code\modules\clothing\rogueclothes\armor\regenerating.dm"
 #include "modular_causticcove\code\modules\grazer\stomach.dm"
 #include "modular_ochrevalley\code\datums\loadout\loadout_triumph.dm"
 #include "modular_ochrevalley\code\datums\pollutants\foods.dm"


### PR DESCRIPTION
## About The Pull Request

Due to how natural armour breaks almost every update due to it directly touching damage code, it is now being replaced by a proper skin armour. These are currently identical in strength to existing natural armours.

* Natural armour is now a skin armour, this means that it will block the chest slot.
* This allows it to be examined for stats by other players and yourself.
* Whilst you can technically now layer it with other armours, wearing anything with an armour class on your legs, top, neck, mask or head will treat you like wearing armour you are not trained in, massively nerfing your dodge, parries, jumping, running and other effects.
* It works on the same regeneration code as other skin armours at about the same rate as them, so technically a bit of a buff here.
* The natural armour virtue has been removed.
* Wildsouls and domesticated wildsouls now also get a heavy mood debuff in town. Domesticated wildsouls do not get the stats debuff still though. This is intended to reinforce that people should hate being in town as a wildsoul and discourage people just casually playing them in there. Note that this only affects you if you keep moving, so if you are in a scene in town and staying still, the mood debuff will vanish after a bit.

As a note, this does not do anything to natural armour code at all. It still exists, it just isn't applied to anyone any more.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Tested and works as intended.

## Why It's Good For The Game

The way that natural armour is coded is rather unique and has caused endless problems for us since the opening of the server, requiring it to be fixed over and over. This brings it in line with other skin armours.
We also have a bit of a problem with wildsouls just casually hanging around in town and basically treating it as any other regular adventurer but stronger, we want to discourage that. This applies slightly to the domesticated wildsoul too, as we feel that for it's advantages as a warden over other wardens, it should really be more heavily encouraged to stay in the wilds where it is happiest. Being domesticated does not mean you are now a happy towner, it means that you are willing to work with the town on the roads.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Wearing anything with an armour class as a wildsoul will nerf you, excluding feet, wrists and hands.
balance: Wildsouls now get a big mood debuff in town.
refactor: Changed natural armour to be a normal skin armour.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
