### PR TITLE
Add topic logging to figure out why everyone keeps tripping the topic limiter

### DIFF
--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -107,6 +107,11 @@
 	///Used for limiting the rate of clicks sends by the client to avoid abuse
 	var/list/clicklimiter
 
+	///whether or not logging is turned on
+	var/logging_topic = FALSE
+	///last 10 topics
+	var/list/last_topics = list()
+
 	///goonchat chatoutput of the client
 	var/datum/chatOutput/chatOutput
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -48,6 +48,11 @@ GLOBAL_LIST_EMPTY(respawncounts)
 		return 0
 	// RATWOOD EDIT END
 
+	if(logging_topic)
+		LAZYADD(last_topics, html_encode(href))
+		if(LAZYLEN(last_topics) > 10)
+			popleft(last_topics)
+
 	if(href_list["statbrowser_calendar"])
 		open_calendar_ui()
 		return
@@ -73,9 +78,9 @@ GLOBAL_LIST_EMPTY(respawncounts)
 			if (minute != topiclimiter[ADMINSWARNED_AT]) //only one admin message per-minute. (if they spam the admins can just boot/ban them)
 				topiclimiter[ADMINSWARNED_AT] = minute
 				msg += " Administrators have been informed."
-				log_game("[key_name(src)] Has hit the per-minute topic limit of [mtl] topic calls in a given game minute")
-				message_admins("[ADMIN_LOOKUPFLW(usr)] [ADMIN_KICK(usr)] Has hit the per-minute topic limit of [mtl] topic calls in a given game minute")
-//			to_chat(src, span_danger("[msg]"))
+				log_game("[key_name(src)] Has hit the per-minute topic limit of [mtl] topic calls in a given game minute. Recent topics: [last_topics.Join(",")]")
+				message_admins("[ADMIN_LOOKUPFLW(usr)] [ADMIN_KICK(usr)] Has hit the per-minute topic limit of [mtl] topic calls in a given game minute.[span_details("Recent topics", last_topics.Join("\n"))]")
+			logging_topic = TRUE
 			return
 
 	var/stl = CONFIG_GET(number/second_topic_limit)


### PR DESCRIPTION
## About The Pull Request
We've been having people constantly trip the `minute_topic_limit` and it'd be really nice to know what many different people keep doing, because it's most likely a bug with a UI rather than intentional spam at this point.

DNM, this isn't fit for long term, just test merge until we find the problems.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [ ] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [ ] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence
<img width="1290" height="44" alt="image" src="https://github.com/user-attachments/assets/8eb99e29-3a79-4407-81af-4cb9a8045d8d" />

## Why It's Good For The Game
This will inform whether we can fix the problem or if we need to raise the `minute_topic_limit`.
Players should not be hitting this regularly as it interrupts their UI usage, and false positives cause alarm fatigue.
