### PR TITLE
lets lux be scraped with tool_sharp (knives)

### DIFF
--- a/code/modules/surgery/surgeries_hearth/extract_lux.dm
+++ b/code/modules/surgery/surgeries_hearth/extract_lux.dm
@@ -14,6 +14,7 @@
 	name = "Extract Lux"
 	implements = list(
 		TOOL_SCALPEL = 80,
+		TOOL_SHARP = 60,
 	)
 	target_mobtypes = list(/mob/living/carbon/human)
 	time = 8 SECONDS

--- a/code/modules/surgery/surgeries_hearth/extract_lux.dm
+++ b/code/modules/surgery/surgeries_hearth/extract_lux.dm
@@ -14,7 +14,7 @@
 	name = "Extract Lux"
 	implements = list(
 		TOOL_SCALPEL = 80,
-		TOOL_SHARP = 60,
+		TOOL_SHARP = 60, //OV change
 	)
 	target_mobtypes = list(/mob/living/carbon/human)
 	time = 8 SECONDS


### PR DESCRIPTION
very simple single line change (prior was only surgery needed a specific surgery tool all others have improv options) to allow knives to scrap lux, prior only scalpel worked, 20% more difficult to keep it in line with all other surgeries being better with right tools even tho a blades a blade...