### PR TITLE
Domesticate Wildsoul Warden Refactor

### DIFF
--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -51,7 +51,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(list(/area/rogue/indoors
 		guy.apply_status_effect(/datum/status_effect/buff/feraldebuff)
 		guy.add_stress(/datum/stressevent/feralintown)
 	if((src.town_area == TRUE) && HAS_TRAIT(guy, TRAIT_FERAL_MINOR)) //for domesticated wildsouls to discourage them being in town
-		guy.add_stress(/datum/stressevent/feralintown)
+		guy.add_stress(/datum/stressevent/feralintown_minor)
 	//OV edit end
 	if((src.town_area == TRUE) && HAS_TRAIT(guy, TRAIT_NECRAS_ABATEMENT) && !guy.has_status_effect(/datum/status_effect/buff/deadite_pacified)) //zombie pacification
 		guy.apply_status_effect(/datum/status_effect/buff/deadite_pacified)

--- a/code/modules/jobs/job_types/roguetown/garrison/warden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/warden.dm
@@ -36,7 +36,7 @@
 	neck = /obj/item/clothing/neck/roguetown/coif/padded
 	cloak = /obj/item/clothing/cloak/wardencloak
 	backr = /obj/item/storage/backpack/rogue/satchel
-	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden
+	//armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden //OV EDIT
 	//gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather //OV Edit
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/rogueweapon/stoneaxe/woodcut/wardenpick
@@ -89,6 +89,7 @@
 	..()
 	gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather //OV Add
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced //OV Add
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden //OV ADD
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/warden_machete = 1,
 		/obj/item/storage/keyring/warden = 1,

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -788,6 +788,7 @@
 			var/obj/item/clothing/CL = src.head
 			if(CL.armor_class >= ARMOR_CLASS_LIGHT)
 				return FALSE
+		/* Removed till it's reworked
 		if(istype(src.wear_neck, /obj/item/clothing)) //No gorgets etc
 			var/obj/item/clothing/CL = src.wear_neck
 			if(CL.armor)
@@ -796,6 +797,7 @@
 			var/obj/item/clothing/CL = src.wear_mask
 			if(CL.armor)
 				return FALSE
+		*/
 		return TRUE //No need to run the rest of the checks, we've already ensured there's nothing better than light armour on them
 	//OV edit end
 	if(istype(src.wear_armor, /obj/item/clothing))

--- a/modular_causticcove/code/modules/classes/domesticated_wildsoul.dm
+++ b/modular_causticcove/code/modules/classes/domesticated_wildsoul.dm
@@ -3,7 +3,7 @@
 	tutorial = "You were once upon a time part of the wild. Now you have taken up the duty to protecting it, whenever because of the safety and curiosity of the settlement that you now serve, longing for a purpose, or merely being part of something greater and a concentrated effort, the safety of the roads for these fragile towners and traders rest in your hands and claws. Keep your cradle safe and free of riff raffs, together with your more civilized allies."
 	outfit = /datum/outfit/job/roguetown/warden/wildsoul
 	category_tags = list(CTAG_WARDEN)
-	traits_applied = list(TRAIT_CRITICAL_RESISTANCE, TRAIT_CIVILIZEDBARBARIAN, TRAIT_STRONGBITE, TRAIT_ARMOR_AVERSE, TRAIT_FERAL_MINOR) // OV EDIT - Woodsman removed so it doesnt get applied twice. Feral removed, since theyre warden.
+	traits_applied = list(TRAIT_CRITICAL_RESISTANCE, TRAIT_CIVILIZEDBARBARIAN, TRAIT_STRONGBITE, TRAIT_FERAL_MINOR) // OV EDIT - Woodsman removed so it doesnt get applied twice. Feral removed, since theyre warden.
 	subclass_stats = list(
 		STATKEY_STR = 3,//7 points weighted, same as MAA. Direbear stats are kicked in the shins cause they get stat buffs in the woods instead of a debuff in the town.
 		STATKEY_CON = 2,
@@ -36,7 +36,7 @@
 	H.adjust_blindness(-3)
 	shoes = /obj/item/clothing/shoes/roguetown/boots/furlinedanklets
 	beltr = /obj/item/rogueweapon/huntingknife/stoneknife //OV Edit - Warden Sync
-	armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/wildsoul/dense //OV EDIT
+	armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/wildsoul/warden //OV EDIT
 	gloves = /obj/item/clothing/gloves/roguetown/knuckles //OV Edit added steel knuckles
 	//OV Add Start
 	backpack_contents = list(

--- a/modular_causticcove/code/modules/classes/wildsoul.dm
+++ b/modular_causticcove/code/modules/classes/wildsoul.dm
@@ -300,4 +300,9 @@
 	desc = "So many walls, no trees, no grass... I have to get out of here!!!"
 	stressadd = 15
 	timer = 5 MINUTES
+
+/datum/stressevent/feralintown_minor
+	desc = "So many walls, no trees, no grass... I'm still not used to this..."
+	stressadd = 3
+	timer = 2 MINUTES
 //OV edit end

--- a/modular_ochrevalley/code/modules/clothing/rogueclothes/armor/regenerating.dm
+++ b/modular_ochrevalley/code/modules/clothing/rogueclothes/armor/regenerating.dm
@@ -18,7 +18,7 @@
 /obj/item/clothing/suit/roguetown/armor/regenerating/skin/wildsoul/warden
 	name = "warden's natural armour"
 	desc = "The natural body of this person protects them from some amount of harm."
-	armor = ARMOR_LEATHER
+	armor = ARMOR_PADDED
 	body_parts_covered = COVERAGE_FULL_BODY_ACTUAL
 	body_parts_inherent = COVERAGE_FULL_BODY_ACTUAL
 	armor_class = ARMOR_CLASS_NONE

--- a/modular_ochrevalley/code/modules/clothing/rogueclothes/armor/regenerating.dm
+++ b/modular_ochrevalley/code/modules/clothing/rogueclothes/armor/regenerating.dm
@@ -14,3 +14,13 @@
 	name = "dense natural armour"
 	armor = ARMOR_PLATE
 	max_integrity = 400
+
+/obj/item/clothing/suit/roguetown/armor/regenerating/skin/wildsoul/warden
+	name = "warden's natural armour"
+	desc = "The natural body of this person protects them from some amount of harm."
+	armor = ARMOR_LEATHER
+	body_parts_covered = COVERAGE_FULL_BODY_ACTUAL
+	body_parts_inherent = COVERAGE_FULL_BODY_ACTUAL
+	armor_class = ARMOR_CLASS_NONE
+
+	max_integrity = 400


### PR DESCRIPTION
## About The Pull Request

Domesticated wildsoul warden subclass has been refactored to bring it more in-line with other garrison roles, without losing much of it's flavour.
* It now has a slightly higher overall strength compared to bailiffs, having a similar (but higher integ and head protection) skin armour. Overall, this is a pretty substantial drop in protection, compared to dense natural armour.
* It is no longer armour averse, meaning it can wear other armours like legs and helmets.
* The town mood debuff has been heavily reduced for domesticated wildsouls.
* They retain their crit resistance, so they're still pretty damn tanky even with their more vulnerable armour.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game

Balancing of wildsouls has always been a bit of an iffy subject, but most of them have no responsibilities and are expected to stay out of town. However, the warden one is always brought up as very ehhhhh, given that it's basically just clearly the strongest garrison subclass and compared to the other unarmed garrison member (the bailiff), it's just straight up better. I feel that these changes keep it strong, and it's still in my opinion just better than the bailiff, whilst bringing it closer to being in-line with the others.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Domesticated wildsouls now have a lower protection skin armour that allows them to layer armour.
balance: Domesticated wildsoul town mood debuff reduced from 15 to 3.
balance: Domesticated wildsouls are no longer debuffed by wearing light armour.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
