### PR TITLE
Discourage harvesting your own lux

### DIFF
--- a/code/modules/surgery/surgeries_hearth/extract_lux.dm
+++ b/code/modules/surgery/surgeries_hearth/extract_lux.dm
@@ -37,6 +37,10 @@
 	display_results(user, target, span_notice("I begin to scrape lux from [target]'s heart..."),
 		span_notice("[user] begins to scrape lux from [target]'s heart."),
 		span_notice("[user] begins to scrape lux from [target]'s heart."))
+	//OV edit
+	if(target == user)
+		to_chat(target, span_warningbig("Doing this to myself will likely kill me..."))
+	//OV edit end
 	return TRUE
 
 /datum/surgery_step/extract_lux/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)

--- a/code/modules/surgery/surgeries_hearth/extract_lux.dm
+++ b/code/modules/surgery/surgeries_hearth/extract_lux.dm
@@ -60,6 +60,12 @@
 			new /obj/item/reagent_containers/lux_moss(target.loc)
 		else
 			new /obj/item/reagent_containers/lux_impure(target.loc)
+		
+		//OV edit
+		if(target == user)
+			target.Stun(200)
+			to_chat(target, span_warningbig("THE AGONY! I should not have tried to harvest my own lux!"))
+		//OV edit end
 
 		SEND_SIGNAL(user, COMSIG_LUX_EXTRACTED, target)
 		//record_featured_stat(FEATURED_STATS_CRIMINALS, user)	- This.. isn't normally criminal.


### PR DESCRIPTION


## About The Pull Request

Attempting to literally scrape your own lux will now stun you for 20 seconds and tell you why. This will likely lead to your death.

Includes a warning as you start harvesting.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game

Harvesting your own lux is LRP as all hell. Literally ripping your own chest open and scraping material off of your heart is something people do just casually. It's just terrible.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Attempting to literally scrape your own lux will now stun you for 20 seconds and tell you why. This will likely lead to your death.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
