### PR TITLE
Undivided Sage Miracle fix

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -207,7 +207,7 @@
 
 	switch(H.patron?.type)
 		if(/datum/patron/divine/undivided)
-			var/list/heal = list("Greater Miracle (Miracle)", "Fortifying Vapors (Medical)")
+			var/list/heal = list("Greater Miracle (Divine)", "Fortifying Vapors (Secular)")
 			var/highheal_options = input(H, "Choose your healing training.", "Experientia Medica") as anything in heal
 			switch(highheal_options)
 				if("Greater Miracle (Divine)")


### PR DESCRIPTION
## About The Pull Request

Fixed Sage not getting Miracle or Fortifying Vapors after choosing one or the other if their Patron is Undivided.

<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->

## Developer's checklist

- [x] It compiles locally
- [x] Player gets to choose Greater Miracle and Fortifying Vapors 
- [x] Player gets either Greater Miracle or Fortifying Vapors after selecting the option


## Testing Evidence

Went into the game and selected both after choosing Mystic -> Sage as Undivided.


## Why It's Good For The Game

Fixes an issue where you select a healing option but do not get anything.


## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:

fix: fixed a line of code that looked for a string that did not exist 

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
