### PR TITLE
feycursed vice

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -330,6 +330,7 @@
 #define TRAIT_LYFE_DRINK "Hemovore"
 #define TRAIT_ARMOR_AVERSE "Armor Averse"
 #define TRAIT_FERAL_MINOR "Less Feral"
+#define TRAIT_FEYCURSED "Changeling"
 //OV File End
 
 // Economic Roles Traits
@@ -648,6 +649,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_SUNLIGHT_SENSITIVE = span_danger("Put on those shades and wave to yesterday, 'cause the sunlight hurts my eyes!"),
 	//OV Add Start
 	TRAIT_LYFE_DRINK = span_bloody("I hunger for fresh lyfe's blood."),
+	TRAIT_FEYCURSED = span_info("I was born, or rescued from certain death, under strange circumstances, unaided by the divine.")
 	//OV Add End
 ))
 

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -330,7 +330,7 @@
 #define TRAIT_LYFE_DRINK "Hemovore"
 #define TRAIT_ARMOR_AVERSE "Armor Averse"
 #define TRAIT_FERAL_MINOR "Less Feral"
-#define TRAIT_FEYCURSED "Changeling"
+#define TRAIT_FEYCURSED "Fey-Cursed Lux"
 //OV File End
 
 // Economic Roles Traits

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -50,6 +50,7 @@ GLOBAL_LIST_INIT(character_flaws, list(
 	/datum/charflaw/hemovore::name=/datum/charflaw/hemovore,
 	/datum/charflaw/dendor_touched::name=/datum/charflaw/dendor_touched,
 	/datum/charflaw/ravenous::name=/datum/charflaw/ravenous,
+	/datum/charflaw/changeling::name=/datum/charflaw/changeling,
 	//OV Add End
 	))
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag.dm
@@ -41,7 +41,9 @@
 		/datum/virtue/utility/feytouched, // They are already FAE
 		/datum/virtue/utility/riding, // Hags literally get a teleportation mechanic, it doesn't make much sense.
 		)
-	vice_restrictions = list(/datum/charflaw/hunted, /datum/charflaw/targeted, /datum/charflaw/wanted) // could you fucking imagine
+	//ov edit- add feycursed
+	vice_restrictions = list(/datum/charflaw/hunted, /datum/charflaw/targeted, /datum/charflaw/wanted, /datum/charflaw/changeling) // could you fucking imagine
+	//ov edit end
 	job_subclasses = list(
 		/datum/advclass/hag,
 	)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_component.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_component.dm
@@ -67,6 +67,16 @@
 			found_any = TRUE
 			to_chat(H, span_boldnotice("A familiar rhythm pulses in the roots... [hag_mob.real_name] is walking the lands this week."))
 			to_chat(hag_mob, span_boldnotice("A familiar rhythm pulses in the roots... [H.real_name] is walking the lands this week."))
+		//ov edit add- feycursed
+		if(HAS_TRAIT(H, TRAIT_FEYCURSED))
+			// The Hag mind learns about the vessel
+			hag_mob.mind.i_know_person(H)
+			found_any = TRUE
+			to_chat(hag_mob, span_boldnotice("The roots watch a dormant seedling... [H.real_name] is walking the lands this week."))
+			if(find_boon_by_type(H.real_name, /datum/hag_boon/changeling))
+				continue
+			grant_boon(H.real_name, /datum/hag_boon/changeling, 0)
+		//ov edit end
 	if(found_any)
 		to_chat(hag_mob, span_boldnotice("As your eyes adjust to the emerald gloom, the threads of the Mossmother's older puppets become visible to you..."))
 
@@ -254,7 +264,9 @@
 		var/has_real_boon = FALSE
 		for(var/datum/hag_boon/B in boon_registry[v_name])
 			// If they have a valid hag boon that IS NOT a curse and IS NOT a scar
-			if(B.hag_is_valid && !B.hag_curse && !istype(B, /datum/hag_boon/curse_scar))
+			//ov edit- add feycursed. Check feycursed here, but not below
+			if(B.hag_is_valid && !B.hag_curse && !istype(B, /datum/hag_boon/curse_scar) && !istype(B, /datum/hag_boon/changeling))
+			//ov edit end
 				has_real_boon = TRUE
 				break
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_component.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_component.dm
@@ -72,10 +72,10 @@
 			// The Hag mind learns about the vessel
 			hag_mob.mind.i_know_person(H)
 			found_any = TRUE
-			to_chat(hag_mob, span_boldnotice("The roots watch a dormant seedling... [H.real_name] is walking the lands this week."))
+			to_chat(hag_mob, span_boldnotice("The roots watch a dormant seedling... [H.real_name] is walking the lands this week. The hag may curse them, but cursing their Wyrd Lux will gain no spite"))
 			if(find_boon_by_type(H.real_name, /datum/hag_boon/changeling))
 				continue
-			grant_boon(H.real_name, /datum/hag_boon/changeling, 0)
+			grant_boon(H.real_name, /datum/hag_boon/changeling, 100)
 		//ov edit end
 	if(found_any)
 		to_chat(hag_mob, span_boldnotice("As your eyes adjust to the emerald gloom, the threads of the Mossmother's older puppets become visible to you..."))
@@ -194,7 +194,12 @@
 
 /datum/component/hag_curio_tracker/proc/transmute_boons_to_curse(true_name, list/boons, curse_path, points)
 	var/list/name_list = boon_registry[true_name]
+	//ov edit- changeling code
+	var/fakepoints = 0
 	for(var/datum/hag_boon/B in boons)
+		if(istype(B, /datum/hag_boon/changeling))
+			fakepoints += B.points
+	//ov edit end
 		name_list -= B
 		qdel(B)
 
@@ -203,11 +208,17 @@
 
 	var/datum/hag_boon/curse_scar/scar = find_boon_by_type(true_name, /datum/hag_boon/curse_scar)
 	if(scar)
-		scar.points += points
+	//ov edit- changeling code
+		scar.points += max(0, points-fakepoints)
+	//ov edit end
 	else
 		var/mob/living/victim = find_target(true_name)
 		if(victim)
 			ADD_TRAIT(victim, TRAIT_CURSE_SCAR, "hag_curse")
+		//ov edit- changeling code
+		if(fakepoints)
+			points = max(0, points-fakepoints)
+		//ov edit- changeling code
 		scar = new /datum/hag_boon/curse_scar(true_name, src, points)
 		name_list += scar
 	check_tier_upgrade()

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -905,7 +905,7 @@
 			else
 				. += span_danger("THE HOWL OF A MAD GOD SHAKES YOUR BONES! FLESH SHORN INTO VISCERA SPRAYS THE WALLS! RIP AND TEAR!") // Default 'npc' werewolf examine. Thought it seemed edgy enough.
 
-		if((HAS_TRAIT(user, TRAIT_ANCIENT_HAG) || HAS_TRAIT(user, TRAIT_FEYTOUCHED) || istype(user, /mob/living/simple_animal/pet/familiar/fae)) && HAS_TRAIT(src, TRAIT_FEYCURSED))
+		if((HAS_TRAIT(user, TRAIT_ANCIENT_HAG) || HAS_TRAIT(user, TRAIT_FEYTOUCHED) || istype(user, /mob/living/carbon/human/species/familiar/fae)) && HAS_TRAIT(src, TRAIT_FEYCURSED))
 			. += span_nicegreen("The tapestry of their lux has been altered by fey hands, but they have yet to truly embrace their nature.")
 // OV Edit End
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -904,6 +904,9 @@
 				. += examine_span_details(span_info("Werewolf Description"),span_info(werewolfplayer.wolfdesc_cached))
 			else
 				. += span_danger("THE HOWL OF A MAD GOD SHAKES YOUR BONES! FLESH SHORN INTO VISCERA SPRAYS THE WALLS! RIP AND TEAR!") // Default 'npc' werewolf examine. Thought it seemed edgy enough.
+
+		if((HAS_TRAIT(user, TRAIT_ANCIENT_HAG) || HAS_TRAIT(user, TRAIT_FEYTOUCHED) || istype(user, /mob/living/simple_animal/pet/familiar/fae)) && HAS_TRAIT(src, TRAIT_FEYCURSED))
+			. += span_nicegreen("The tapestry of their lux has been altered by fey hands, but they have yet to truly embrace their nature.")
 // OV Edit End
 
 		if((HAS_TRAIT(user, TRAIT_ANCIENT_HAG) || HAS_TRAIT(user, TRAIT_FEYTOUCHED) || istype(user, /mob/living/carbon/human/species/familiar/fae)) && HAS_TRAIT(src, TRAIT_FEYTOUCHED))

--- a/code/modules/surgery/surgeries_hearth/extract_lux.dm
+++ b/code/modules/surgery/surgeries_hearth/extract_lux.dm
@@ -69,8 +69,10 @@
 		if(isaasimar(target) && !(HAS_TRAIT(target, TRAIT_ANCIENT_HAG) || HAS_TRAIT(target, TRAIT_FEYTOUCHED)))
 			new /obj/item/reagent_containers/lux(target.loc)
 			apply_greater = TRUE
-		else if(HAS_TRAIT(target, TRAIT_ANCIENT_HAG) || HAS_TRAIT(target, TRAIT_FEYTOUCHED))
+		//ov edit, feycursed
+		else if(HAS_TRAIT(target, TRAIT_ANCIENT_HAG) || HAS_TRAIT(target, TRAIT_FEYTOUCHED) || HAS_TRAIT(target, TRAIT_FEYCURSED))
 			new /obj/item/reagent_containers/lux_moss(target.loc)
+		//ov edit end
 		else
 			new /obj/item/reagent_containers/lux_impure(target.loc)
 

--- a/modular_ochrevalley/code/datums/character_flaw/_character_flaw.dm
+++ b/modular_ochrevalley/code/datums/character_flaw/_character_flaw.dm
@@ -156,17 +156,17 @@ GLOBAL_LIST_INIT(dendor_touched_animals, list(
 		if(!hag_mind)
 			continue
 		hag_mind.i_know_person(user)
-		to_chat(hag_mind.current, span_boldnotice("The roots watch a dormant seedling... [user.real_name] is walking the lands this week."))
+		to_chat(hag_mind.current, span_boldnotice("The roots watch a dormant seedling... [user.real_name] is walking the lands this week. The hag may curse them, but cursing their Wyrd Lux will gain no spite"))
 		var/datum/component/hag_curio_tracker/HCT = hag_mob.GetComponent(/datum/component/hag_curio_tracker)
 		if(!HCT) 
 			continue
 		if(HCT.find_boon_by_type(user.real_name, /datum/hag_boon/changeling))
 			continue
-		HCT.grant_boon(user.real_name, /datum/hag_boon/changeling, 0)
+		HCT.grant_boon(user.real_name, /datum/hag_boon/changeling, 100)
 
 /datum/hag_boon/changeling
 	name = "Wyrd Lux"
-	desc = "The lux of one who bears this mark has been blessed with the mossmother's influence, whether to weave the first thread, or mend what was broken. They are as the mossmother's own offspring, and at the mercy of their discipline."
-	points = 0
+	desc = "The lux of one who bears this mark has been blessed with the mossmother's influence, whether to weave the first thread, or mend what was broken. They are as the mossmother's own offspring, and at the mercy of their discipline. Will not gain Spite when transmuted to a curse"
+	points = 100
 	transmutable = TRUE
 	hag_curse = FALSE

--- a/modular_ochrevalley/code/datums/character_flaw/_character_flaw.dm
+++ b/modular_ochrevalley/code/datums/character_flaw/_character_flaw.dm
@@ -143,3 +143,30 @@ GLOBAL_LIST_INIT(dendor_touched_animals, list(
 		to_chat(user, span_warning("I can feel my animal form being drawn out in the darkness..."))
 	countdown = countdown + 1
 	next_check = world.time + 5
+
+/datum/charflaw/changeling
+	name = "Fey Cursed"
+	desc = "You owe your life, through continuation or creation, to the fey. They know your true name, but you may not know of them, or of your nature. Unlike those who have embraced their fey heritage, you are unable to take advantage of it, and a hag may choose to curse you at their leisure" 
+	needs_extra_vice = TRUE
+
+/datum/charflaw/changeling/on_mob_creation(mob/user)
+	ADD_TRAIT(user, TRAIT_FEYCURSED, TRAIT_GENERIC)
+	for(var/mob/living/hag_mob in GLOB.active_hags)
+		var/datum/mind/hag_mind = hag_mob.mind
+		if(!hag_mind)
+			continue
+		hag_mind.i_know_person(user)
+		to_chat(hag_mind.current, span_boldnotice("The roots watch a dormant seedling... [user.real_name] is walking the lands this week."))
+		var/datum/component/hag_curio_tracker/HCT = hag_mob.GetComponent(/datum/component/hag_curio_tracker)
+		if(!HCT) 
+			continue
+		if(HCT.find_boon_by_type(user.real_name, /datum/hag_boon/changeling))
+			continue
+		HCT.grant_boon(user.real_name, /datum/hag_boon/changeling, 0)
+
+/datum/hag_boon/changeling
+	name = "Wyrd Lux"
+	desc = "The lux of one who bears this mark has been blessed with the mossmother's influence, whether to weave the first thread, or mend what was broken. They are as the mossmother's own offspring, and at the mercy of their discipline."
+	points = 0
+	transmutable = TRUE
+	hag_curse = FALSE

--- a/modular_ochrevalley/code/datums/character_flaw/_character_flaw.dm
+++ b/modular_ochrevalley/code/datums/character_flaw/_character_flaw.dm
@@ -37,7 +37,7 @@ GLOBAL_LIST_INIT(dendor_touched_animals, list(
 		if(target.cmode)
 			to_chat(user, span_warning("My meal is fighting back! I can't get a clean bite."))
 			return FALSE //target is actively fighting
-		if(ishuman(target)) //check if the target is human, so their armor can be checked. If the target is human, we get the best stab resist on this zone. 
+		if(ishuman(target)) //check if the target is human, so their armor can be checked. If the target is human, we get the best stab resist on this zone.
 			var/mob/living/carbon/human/humantarget = target
 			var/def_zone = limb_grabbed.body_zone
 			var/obj/item/clothing/prot = humantarget.get_best_worn_armor(def_zone, "stab")
@@ -71,7 +71,7 @@ GLOBAL_LIST_INIT(dendor_touched_animals, list(
 /datum/charflaw/dendor_touched/on_mob_creation(mob/user)
 	next_check = world.time + starting_leeway
 	last_transform = world.time
-	
+
 /datum/charflaw/dendor_touched/flaw_on_life(mob/user)
 	if(!user)
 		return
@@ -125,7 +125,7 @@ GLOBAL_LIST_INIT(dendor_touched_animals, list(
 			shape.name = "[animal_curse]"
 			shape.icon_state = "[animal_curse]"
 			shape.color = animal_colour
-			
+
 			for(var/obj/effect/proc_holder/spell/targeted/shapeshift/the_spell in shape.mind.spell_list)
 				the_spell.charge_counter = 0
 				the_spell.start_recharge()
@@ -146,10 +146,10 @@ GLOBAL_LIST_INIT(dendor_touched_animals, list(
 
 /datum/charflaw/changeling
 	name = "Fey Cursed"
-	desc = "You owe your life, through continuation or creation, to the fey. They know your true name, but you may not know of them, or of your nature. Unlike those who have embraced their fey heritage, you are unable to take advantage of it, and a hag may choose to curse you at their leisure" 
+	desc = "You owe your life, through continuation or creation, to the fey. They know your true name, but you may not know of them, or of your nature. Unlike those who have embraced their fey heritage, you are unable to take advantage of it, and a hag may choose to curse you at their leisure"
 	needs_extra_vice = TRUE
 
-/datum/charflaw/changeling/on_mob_creation(mob/user)
+/datum/charflaw/changeling/apply_post_equipment(mob/user)
 	ADD_TRAIT(user, TRAIT_FEYCURSED, TRAIT_GENERIC)
 	for(var/mob/living/hag_mob in GLOB.active_hags)
 		var/datum/mind/hag_mind = hag_mob.mind
@@ -158,7 +158,7 @@ GLOBAL_LIST_INIT(dendor_touched_animals, list(
 		hag_mind.i_know_person(user)
 		to_chat(hag_mind.current, span_boldnotice("The roots watch a dormant seedling... [user.real_name] is walking the lands this week. The hag may curse them, but cursing their Wyrd Lux will gain no spite"))
 		var/datum/component/hag_curio_tracker/HCT = hag_mob.GetComponent(/datum/component/hag_curio_tracker)
-		if(!HCT) 
+		if(!HCT)
 			continue
 		if(HCT.find_boon_by_type(user.real_name, /datum/hag_boon/changeling))
 			continue


### PR DESCRIPTION
## About The Pull Request
Adds the Feycursed vice, which cannot be your first vice. The effects are as follows
- the hag knows you. you do not know the hag
- feytouched, fey familiars, and the hag know you're feycursed on examine
- you have a 100-point hag boon which does nothing, and does not count against the hag's limit of influenced individuals. This means you can be cursed by the hag at their leisure. This boon also does not benefit the hag when they use it to curse you
- your lux is corrupted. 

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence
i did an oopsie and forgot to gather pictures again, but i did wholly test that
-feycursed joins before hags got the boon when the hag joined, and appeared in the hag mind
-feycursed joins after hags got the boon when joining, and appeared in the hag mind

## Why It's Good For The Game
a flaw for changeling sorts of characters, who want to be fey associated, but not necessarily debilitated by the feytouched virtue, nor open to any of its powers
## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Feycursed, an RP virtue which makes you more vulnerable to the hag due to some manner of fairy influence in your nature
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
