### PR TITLE
Naledi Option for Orators

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
@@ -111,4 +111,10 @@
 	//OV Edit: Let more classes test faith
 	add_verb(H, /mob/living/carbon/human/proc/faith_test)
 	add_verb(H, /mob/living/carbon/human/proc/torture_victim)
+	
+	var/origins = list("Otava", "Naledi")
+	var/origin_choice = input(H,"Choose your HERALDRY.", "TAKE UP PSYDON'S ARMS.") as anything in origins
+	if(origin_choice == "Naledi")
+		neck = /obj/item/clothing/neck/roguetown/psicross/naledi
+		id = /obj/item/clothing/ring/signet/psy/g
 	//OV Edit End

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
@@ -115,6 +115,6 @@
 	var/origins = list("Otava", "Naledi")
 	var/origin_choice = input(H,"Choose your HERALDRY.", "TAKE UP PSYDON'S ARMS.") as anything in origins
 	if(origin_choice == "Naledi")
-		neck = /obj/item/clothing/neck/roguetown/psicross/naledi
+		neck = /obj/item/clothing/neck/roguetown/psicross/silver/naledi
 		id = /obj/item/clothing/ring/signet/psy/g
 	//OV Edit End


### PR DESCRIPTION


## About The Pull Request

The orator subclass of orthodoxist was the only one that did not have a forced naledi or otava origin on spawn. Therefore, on request, I've made it so that you can now choose between spawning with otavan signet ring and cross, or the gold naledi wrist cross and naledi ring. Otherwise the class is unchanged.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<img width="297" height="542" alt="image" src="https://github.com/user-attachments/assets/9c1d24d1-8bd6-427e-bb91-4194ddf2a138" />

## Why It's Good For The Game

Someone wants to play her blackblood as this subclass, and would like the option to spawn with gold instead of silver items. This allows them that option, seeing as it was already not forced to go for one origin or the other.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: The option to spawn with gold instead of silver for the orator inquisitor subclass.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
