### PR TITLE
Loadout scrolls read faster

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -142,7 +142,7 @@
 	. = ..()
 	if(!user.mind)
 		return
-	
+
 	for(var/crafting_recipe_type in crafting_recipe_types)
 		var/datum/crafting_recipe/R = crafting_recipe_type
 		user.mind.teach_crafting_recipe(crafting_recipe_type)
@@ -275,8 +275,10 @@ UNDER NO CIRCUMSTANCE SHOULD ANY OF THE BOOKS BE GIVEN OUT INTO SPAWNERS OR TO B
 
 /obj/item/book/granter/spell/bonechill/sizespell/loadout // Loadout specific ones!
 	needLit = FALSE
+	pages_to_mastery = 0
 
 /obj/item/book/granter/spell/bonechill/mirror_transform/loadout // Mirror Transform Spell
-    needLit = FALSE
+	needLit = FALSE
+	pages_to_mastery = 0
 
 //Caustic Edit End

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -275,10 +275,10 @@ UNDER NO CIRCUMSTANCE SHOULD ANY OF THE BOOKS BE GIVEN OUT INTO SPAWNERS OR TO B
 
 /obj/item/book/granter/spell/bonechill/sizespell/loadout // Loadout specific ones!
 	needLit = FALSE
-	pages_to_mastery = 0
+	pages_to_mastery = 0 //OV Edit: reads faster
 
 /obj/item/book/granter/spell/bonechill/mirror_transform/loadout // Mirror Transform Spell
 	needLit = FALSE
-	pages_to_mastery = 0
+	pages_to_mastery = 0 //OV Edit: reads faster
 
 //Caustic Edit End


### PR DESCRIPTION
## About The Pull Request

Reduces the time it takes to read the loadout scrolls from 5 cycles to 1, making it far more tolerable.

## Testing Evidence

Ran it locally, ran good, not much to show for it.

## Why It's Good For The Game

Some characters have to use this every round, cutting down on the tedium of standing still is very good.

## Changelog

:cl:
qol: loadout scrolls read much faster
/:cl: