### PR TITLE
Many Needed Changes

### DIFF
--- a/code/controllers/subsystem/migrants.dm
+++ b/code/controllers/subsystem/migrants.dm
@@ -94,7 +94,7 @@ SUBSYSTEM_DEF(migrants)
 		wave_number++
 		return
 	log_game("Migrants: FAILED to spawn wave: [wave_type]")
-	message_admins("MIGRANTS: Wave '[wave.name]' failed to assemble on the [track] track.")
+	//message_admins("MIGRANTS: Wave '[wave.name]' failed to assemble on the [track] track.") // OV REMOVE - we do not need to know this
 	wave_cooldown[wave_type] = world.time + get_fail_cooldown(wave)
 	for(var/client/client as anything in get_wave_candidates(wave_type))
 		to_chat(client, span_boldwarning("The wave you queued for, [wave.name], failed to gather enough people and scattered into the mist. You have left the queue."))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -336,7 +336,7 @@
 		str += skin_armor.integrity_check() //not tied to 'smart' because wild souls aren't
 		. += str
 	//caustic edit end
-	
+
 	//arcyne ward
 	if(istype(skin_armor, /obj/item/clothing/suit/roguetown/armor/manual/arcyne_ward))
 		var/obj/item/clothing/suit/roguetown/armor/manual/arcyne_ward/ward = skin_armor
@@ -697,7 +697,7 @@
 		var/obj/item/organ/heart/heart = getorganslot(ORGAN_SLOT_HEART)
 		if(heart?.inscryption && (heart.inscryption_key in maniac.key_nums))
 			. += span_danger("[t_He] know[p_s()] [heart.inscryption_key], I AM SURE OF IT!")
-	
+
 	//Caustic Edit - Attempt to add a quick AFK tag to examine text!
 	if(client && away_from_keyboard && manual_afk)
 		. += span_warning("\[Away From Keyboard for [round((client.inactivity/10)/60)] minutes.\]")
@@ -799,7 +799,7 @@
 	var/pvp_pref = get_pvp_icon()
 	var/pvp_icon
 	if(pvp_pref && client.prefs.directory_pvp)
-		pvp_icon = "[SPAN_TOOLTIP("[client.prefs.directory_pvp]","[get_badge_span("[pvp_pref]")]")]"	
+		pvp_icon = "[SPAN_TOOLTIP("[client.prefs.directory_pvp]","[get_badge_span("[pvp_pref]")]")]"
 	//OV edit end
 
 	if(name in unknown_names)
@@ -1120,7 +1120,7 @@
 			. += span_redtext("[m3] strange glowing eyes and fangs!")
 
 		//Blackblood Inquisition trauma
-		if(HAS_TRAIT(src, TRAIT_INQUISITION) && HAS_TRAIT(user, TRAIT_BLACKBLOOD))
+		if(HAS_TRAIT(src, TRAIT_INQUISITION) && HAS_TRAIT(user, TRAIT_BLACKBLOOD) && src != user) // OV Edit - we can examine OURSELVES
 			var/mob/living/carbon/carbs = user
 			if(HAS_TRAIT(user, TRAIT_PSYDONIAN_GRIT) || HAS_TRAIT(user, TRAIT_NOMOOD))
 				return
@@ -1179,7 +1179,7 @@
 
 	. += medical_text
 
-	//OV edit 
+	//OV edit
 	// VORE BELLY EXAMINES
 	var/list/vorestrings = list()
 	vorestrings += formatted_vore_examine()

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -55,7 +55,7 @@
 	var/mob/living/carbon/follower = user
 	var/datum/patron/patron = follower.patron
 
-	var/prayer = tgui_input_text(follower, "All successfully sent prayers are heard by a higher power. Keep prayers SFW.", "Whisper your prayer", encode = TRUE, multiline = TRUE) // OV Edit: use TGUI input + adds prayer rules
+	var/prayer = tgui_input_text(follower, "All successfully sent prayers are heard by a higher power. Keep prayers SFW and in-character.", "Whisper your prayer", encode = TRUE, multiline = TRUE) // OV Edit: use TGUI input + adds prayer rules
 	if(!prayer)
 		return
 

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -55,7 +55,7 @@
 	var/mob/living/carbon/follower = user
 	var/datum/patron/patron = follower.patron
 
-	var/prayer = input("Whisper your prayer:", "Prayer") as text|null
+	var/prayer = tgui_input_text(follower, "All successfully sent prayers are heard by a higher power. Keep prayers SFW.", "Whisper your prayer", encode = TRUE, multiline = TRUE) // OV Edit: use TGUI input + adds prayer rules
 	if(!prayer)
 		return
 


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->

1. Hides failed migrant wave admin log
2. Blackbloods can examine themselves as inquisition roles without freaking out
3. Prayers now both use TGUI input and inform the player to that HIGHER POWERS see all prayers + tells them to keep prayers SFW and in-character
4. Re-enables the proper age vet checks.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [X] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [X] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [X] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->
<img width="325" height="251" alt="image" src="https://github.com/user-attachments/assets/59a319d3-c87a-418d-914b-4ba6ad73b12f" />

Joined as a blackblood inquisitor, examined myself. No freakout!

Age vetting tested ingame. Hard to test properly because it always returns true of the client is an admin, (which I am for the sake of testing.) I effectively reverted the CC commit commenting it out, it compiles, and debugging with code breaks reveals that the game is going through the proper channels for age vetting now.

## Why It's Good For The Game

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

1. Admins do not need to see this log. This serves no purpose for us except to spam us with even more logs we do not need to see.
2. A minor oversight for blackblood that is now fixed. Now blackblooded inquisition members can examine themselves without panicking.
3. We have been getting a lot of LRP prayers lately, perhaps because players do not know that yes, we can in fact see all of their prayers and smite them accordingly. This politely informs them of such.
4. Currently, we do not do age vetting. This makes that fact clearer to players, and opens the gates for us to properly do so in the future so we can indicate to players if a character's player has ACTUALLY been age vetted FOR REAL.

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
