### PR TITLE
Add 1 PQ minimum to wildsoul

### DIFF
--- a/modular_causticcove/code/modules/classes/wildsoul.dm
+++ b/modular_causticcove/code/modules/classes/wildsoul.dm
@@ -14,7 +14,7 @@
 	obsfuscated_job = TRUE
 
 	show_in_credits = FALSE
-	min_pq = null
+	min_pq = 1 //OV Edit - Trying to make this less of a newb trap by making you play literally anything else first before you try Vagabond+
 	max_pq = null
 	announce_latejoin = FALSE
 	wanderer_examine = TRUE


### PR DESCRIPTION
## About The Pull Request
Should be discussed by staff before PR is merged as this is a PQ related change.

Increases the minimum PQ to play wildsoul from 0 to 1, the same as acolyte and a few other basic roles a bit too strong to give to a total newbie but trusted after you get a few rounds in or a single commend.
<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [X] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [X] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [X] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence
<img width="181" height="79" alt="image" src="https://github.com/user-attachments/assets/bca080d2-0b94-4b65-84a4-f606729603be" />
<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game
Whenever I play necran actively I tend to be the first to show up to bodies, be they deadite or not. And shockingly often, it’s a new player wild soul. I’d guess maybe 30-40% of my revives? Which is a statistical anomaly worth thinking on, and this is the result of that thought.

Wild souls are powerful classes, arguably some being power classes in their own right, but they are horrendous roles to learn the game on. You are deprived of people to help and teach you, and unlike advents or towners you can’t just run to town to bleed out in the streets and get help. Being available right out of the gate is a newb trap because they *looks strong* and *sound appealing* but their nature as wilderness people makes this a trap.

1 PQ is comically easy to get but it does mean they have to play virtually any other class first to get it. Hopefully this results in more people learning the game first *then* picking the playstyle heavily reliant on self sufficiency and game knowledge.
<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added 1 PQ minimum to play wildsoul.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
