### PR TITLE
Adds ochre specific deadite text

### DIFF
--- a/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
@@ -265,6 +265,7 @@
 	zombie.vomit(1, blood = TRUE, stun = FALSE)
 	playsound(get_turf(zombie), 'sound/magic/woundheal_crunch.ogg', 80, FALSE, -1) //Horrible noises
 	to_chat(zombie, span_narsie("Death is not the end..."))
+	to_chat(zombie, span_warning("You are a deadite! You are a mindless beast inhabiting the shell of your body, with little to no remnant of your former self. The beast wants to bite and feed and infect, but it is truly mindless and you may just shamble about passively, too. A passive deadite is easier to cure, while an aggressive one may have to be put down by force before such a thing happens. Choose your actions wisely, and remember that the rules around PVP still apply as a deadite!")) //OV Edit
 	sleep(2 SECONDS) //now get them up to go fight and die
 	if(zombie.resting)
 		zombie.set_resting(FALSE, FALSE) //GET UP, KILL, CONSUME.


### PR DESCRIPTION
## About The Pull Request
Adds an Ochre specific line to the deadite text that tells people "yo heads up heres what we expect" so they know what is up.

Should be run by staff before merging.
<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [X] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [X] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [X] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence
<img width="813" height="438" alt="image" src="https://github.com/user-attachments/assets/49d09ccf-4e24-4a91-90c9-2d17da9fd3a0" />

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game
Mostly just setting expectations for players instead of just "ur zombie nao :3" like it has by default. Which does work well upstream I assume but we have different expectations for player behavior and apothecary/acolyte players probably do not want to have to robust deadites into the ground just to get people back into the round faster. So this should set new player expectations more appropriately for what they should do when they deadite. As few people join with intention to roleplay as a reanimated corpse.
<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Adds an Ochre specific text for new deadites telling them what the expectations are when playing this "antag".
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
