### PR TITLE
Emergency Become Deadite

### DIFF
--- a/modular_ochrevalley/code/modules/mob/living/become_deadite.dm
+++ b/modular_ochrevalley/code/modules/mob/living/become_deadite.dm
@@ -1,0 +1,104 @@
+/mob/living/carbon/human/verb/become_deadite()
+	set name = "Become Deadite"
+	set category = "IC"
+	set desc = "For use in an emergency where you can't be revived in town."
+
+	if(stat != DEAD)
+		to_chat(src, "You can only use this verb when dead in a place that prevents you from deaditing normally.")
+		return
+
+	var/area/A = get_area(src)
+	if(!istype(A, /area/rogue/indoors/town))
+		to_chat(src, "You can only use this verb when dead in a place that prevents you from deaditing normally.")
+		return
+
+	if(!(mob_biotypes & (MOB_ORGANIC|MOB_UNDEAD)))
+		to_chat(src, "You are not able to become a deadite.")
+		return
+
+	if(HAS_TRAIT(src, TRAIT_DNR) || HAS_TRAIT(src, TRAIT_ZOMBIE_IMMUNE))
+		to_chat(src, "You are not able to become a deadite.")
+		return
+
+	var/confirmation = tgui_alert(src, "This verb will turn you into a deadite after 3 minutes of not being interrupted. Do not use this if someone is actively working to revive you, this is intended for when you are stuck with nobody around to save you. Are you sure you want to do this?", "Become Deadite", list("Begin", "Cancel"))
+
+	if(confirmation != "Begin")
+		return
+
+	visible_message(span_warning("[src] begins steadily rotting once again, they will soon raise as a deadite if not interrupted."))
+	log_and_message_admins("[src] is forcing their deadite transformation")
+
+	if(!do_after_dead(src, 3 SECONDS, src))
+		to_chat(src, "Your raising from the dead was interrupted.")
+		return
+
+	if(stat != DEAD)
+		to_chat(src, "You can only use this verb when dead in a place that prevents you from deaditing normally.")
+		return
+
+	A = get_area(src)
+	if(!istype(A, /area/rogue/indoors/town))
+		to_chat(src, "You can only use this verb when dead in a place that prevents you from deaditing normally.")
+		return
+
+	zombie_check()
+	var/datum/antagonist/zombie/Z = mind.has_antag_datum(/datum/antagonist/zombie)
+	if(Z && !Z.has_turned && !Z.revived && stat == DEAD)
+		infected = TRUE
+		log_and_message_admins("[src] has successfully used Become Deadite")
+		Z.wake_zombie(TRUE)
+	else
+		to_chat(src, "Something went wrong and you weren't able to become a deadite.")
+
+/proc/do_after_dead(mob/user, delay, atom/target = null, progress = TRUE, datum/callback/extra_checks = null, same_direction = FALSE, no_interrupt = FALSE, allow_movement = FALSE)
+	if(!user)
+		return FALSE
+
+	if(user.doing)
+		if(no_interrupt)
+			return
+		return FALSE
+
+	user.doing = TRUE
+	SEND_SIGNAL(user, COMSIG_DO_AFTER_BEGAN)
+
+	var/atom/Tloc = null
+	if(target && !isturf(target))
+		Tloc = target.loc
+
+	var/atom/Uloc = user.loc
+	var/original_dir = user.dir
+
+	var/drifting = FALSE
+
+	delay *= user.do_after_coefficent()
+
+	var/datum/progressbar/progbar
+	if (progress)
+		progbar = new(user, delay, user)
+
+	var/endtime = world.time + delay
+	var/starttime = world.time
+	. = TRUE
+	while (world.time < endtime)
+		stoplag(1)
+		if (progress)
+			progbar.update(world.time - starttime)
+
+		if(QDELETED(user) || (!drifting && !allow_movement && user.loc != Uloc) || (extra_checks && !extra_checks.Invoke()) || (same_direction && user.dir != original_dir))
+			. = FALSE
+			break
+
+		if(!user.doing)
+			. = FALSE
+			break
+
+		if(!QDELETED(Tloc) && (QDELETED(target) || Tloc != target.loc))
+			if((Uloc != Tloc || Tloc != user) && !drifting)
+				. = FALSE
+				break
+
+	user.doing = FALSE
+	SEND_SIGNAL(user, COMSIG_DO_AFTER_ENDED)
+	if (progress)
+		qdel(progbar)

--- a/modular_ochrevalley/code/modules/mob/living/become_deadite.dm
+++ b/modular_ochrevalley/code/modules/mob/living/become_deadite.dm
@@ -28,7 +28,7 @@
 	visible_message(span_warning("[src] begins steadily rotting once again, they will soon raise as a deadite if not interrupted."))
 	log_and_message_admins("[src] is forcing their deadite transformation")
 
-	if(!do_after_dead(src, 3 SECONDS, src))
+	if(!do_after_dead(src, 3 MINUTES, src))
 		to_chat(src, "Your raising from the dead was interrupted.")
 		return
 

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3680,6 +3680,7 @@
 #include "modular_causticcove\code\game\objects\items\weapons\ranged\arquebus.dm"
 #include "modular_causticcove\code\modules\accessability\epilepsy.dm"
 #include "modular_causticcove\code\modules\accessability\epilepsy_prefs.dm"
+#include "modular_ochrevalley\code\modules\mob\living\become_deadite.dm"
 #include "modular_causticcove\code\modules\antagonists\roguetown\villains\werewolf\werewolf_transformation_resist.dm"
 #include "modular_causticcove\code\modules\baycode_port_helpers\baycode_port_helpers.dm"
 #include "modular_causticcove\code\modules\baycode_port_helpers\chemcolour.dm"


### PR DESCRIPTION


## About The Pull Request

Adds a new IC verb to become a deadite when you are unable to be revived in town.

The verb is intended specifically for cases where somebody has been brought into town and there is nobody around to revive them, and they would have been better off left rotting in the woods. Therefore, it has these features:

- It can only be used when dead and if you are actually allowed to become a deadite in the first place.
- It can ONLY be used in town locations where becoming a deadite is normally blocked, no using it to cheese deadite transformations in the woods.
- It takes 3 minutes, and can be interrupted by somebody moving you.
- It includes a message specifically about the intent of this verb, that you should never use it when someone is actually intending to revive you properly.
- It logs the use of this verb and messages the admins when activated and completed.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Tested on a test server and seems to work as intended.

## Why It's Good For The Game

There is a major disconnect between lore and mechanics here. Players that find a body understandably grab it and save it, bringing it to the church or clinic. Unfortunately, if there is nobody there to revive them, this is effectively a round removal until they are dragged back out into the streets.

This feels really terribly LRP to have to do, and it feels like breaking character to either ignore bodies or drag them out of the church, but as it is it feels compulsory. There's not even a lore reason for them not rotting in town, it's just there to protect people upstream from zombies coming to life where they're more aggressive.

The main advantage of this is that it is now perfectly reasonable to bring someone into the church or clinic when you found them dead. Because even if there are no acolytes, you can just leave them there and they have the choice to deadite and self revive anyway.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added a new Become Deadite verb for emergencies where nobody can revive you and you're stuck dead in town.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
