### PR TITLE
Adds a non-people drinking/eating way for hemovores to get nutrition

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -284,6 +284,11 @@ All foods are distributed among various categories. Use common sense.
 				else
 					eater.apply_status_effect(/datum/status_effect/buff/foodhealing, faretype, faretype)
 
+		//OV edit - if they are a hemovore, just skip them because they shouldn't be getting buffs from normal food
+		if(HAS_TRAIT(human_eater, TRAIT_LYFE_DRINK))
+			return
+		//OV edit end
+
 		if(faretype >= FAVORITE_FOOD_MINFARE && ((cuisine & human_eater.favorite_cuisine) || (dish_type & human_eater.favorite_dish)))
 			if(human_eater.add_stress(/datum/stressevent/favourite_food))
 				new /obj/effect/temp_visual/heart(get_turf(human_eater))

--- a/modular_ochrevalley/code/datums/loadout/loadout_miscellaneous.dm
+++ b/modular_ochrevalley/code/datums/loadout/loadout_miscellaneous.dm
@@ -12,3 +12,8 @@
 	name = "Consolidation Chalk"
 	path = /obj/item/item_tf_chalk
 	sort_category = "Misc"
+
+/datum/loadout_item/bloodslop
+	name = "Vial of Bloody Slop"
+	path = /obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/poor
+	sort_category = "Misc"

--- a/modular_ochrevalley/code/datums/loadout/loadout_miscellaneous.dm
+++ b/modular_ochrevalley/code/datums/loadout/loadout_miscellaneous.dm
@@ -14,6 +14,6 @@
 	sort_category = "Misc"
 
 /datum/loadout_item/bloodslop
-	name = "Vial of Bloody Slop"
-	path = /obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/poor
-	sort_category = "Misc"
+    name = "Vial of Bloody Slop"
+    path = /obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/poor
+    sort_category = "Misc"

--- a/modular_ochrevalley/code/datums/loadout/loadout_miscellaneous.dm
+++ b/modular_ochrevalley/code/datums/loadout/loadout_miscellaneous.dm
@@ -10,7 +10,7 @@
 
 /datum/loadout_item/item_tf_chalk
 	name = "Consolidation Chalk"
-	path = /obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/poor
+	path = /obj/item/item_tf_chalk
 	sort_category = "Misc"
 
 /datum/loadout_item/bloodslop

--- a/modular_ochrevalley/code/datums/loadout/loadout_miscellaneous.dm
+++ b/modular_ochrevalley/code/datums/loadout/loadout_miscellaneous.dm
@@ -10,7 +10,7 @@
 
 /datum/loadout_item/item_tf_chalk
 	name = "Consolidation Chalk"
-	path = /obj/item/item_tf_chalk
+	path = /obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/poor
 	sort_category = "Misc"
 
 /datum/loadout_item/bloodslop

--- a/modular_ochrevalley/code/datums/loadout/loadout_miscellaneous.dm
+++ b/modular_ochrevalley/code/datums/loadout/loadout_miscellaneous.dm
@@ -9,11 +9,6 @@
     sort_category = "Misc"
 
 /datum/loadout_item/item_tf_chalk
-	name = "Consolidation Chalk"
-	path = /obj/item/item_tf_chalk
-	sort_category = "Misc"
-
-/datum/loadout_item/bloodslop
-    name = "Vial of Bloody Slop"
-    path = /obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/poor
+    name = "Consolidation Chalk"
+    path = /obj/item/item_tf_chalk
     sort_category = "Misc"

--- a/modular_ochrevalley/code/datums/stress/negative_events.dm
+++ b/modular_ochrevalley/code/datums/stress/negative_events.dm
@@ -2,3 +2,13 @@
 	timer = 2 MINUTES
 	stressadd = 1
 	desc = span_red("Bleh! This drink was almost unbearably bitter!")
+
+/datum/stressevent/bloodslop
+	timer = 2 MINUTES
+	stressadd = 3
+	desc = span_red("Oh that was HORRENDOUS, why would anyone drink this!?")
+
+/datum/stressevent/bloodslop/hemo
+	stressadd = 1
+	desc = span_red("This is terrible, but it's better than nothing at least...")
+

--- a/modular_ochrevalley/code/datums/stress/negative_events.dm
+++ b/modular_ochrevalley/code/datums/stress/negative_events.dm
@@ -12,3 +12,8 @@
 	stressadd = 1
 	desc = span_red("This is terrible, but it's better than nothing at least...")
 
+/datum/stressevent/badjuiceforvampires
+	timer = 2 MINUTES
+	stressadd = 5 //worse than eating without a table
+	desc = span_red("GUHHGBG- This wretched imitation is not food! It is poison!")
+

--- a/modular_ochrevalley/code/datums/stress/negative_events.dm
+++ b/modular_ochrevalley/code/datums/stress/negative_events.dm
@@ -6,14 +6,13 @@
 /datum/stressevent/bloodslop
 	timer = 2 MINUTES
 	stressadd = 3
-	desc = span_red("Oh that was HORRENDOUS, why would anyone drink this!?")
+	desc = span_red("It's just a horrid slop of bloody meat.")
 
 /datum/stressevent/bloodslop/hemo
 	stressadd = 1
-	desc = span_red("This is terrible, but it's better than nothing at least...")
+	desc = span_red("A bloody mess of a meal but close enough to lyfesblood.")
 
 /datum/stressevent/badjuiceforvampires
 	timer = 2 MINUTES
 	stressadd = 5 //worse than eating without a table
-	desc = span_red("GUHHGBG- This wretched imitation is not food! It is poison!")
-
+	desc = span_red("This vile concoction is an affront to my tongue!")

--- a/modular_ochrevalley/code/modules/reagents/hemovore_snacks.dm
+++ b/modular_ochrevalley/code/modules/reagents/hemovore_snacks.dm
@@ -6,12 +6,18 @@
 // all are revolting to non-hemovores, the noble one specifically is hazardous to actual lyckers/vampires.
 
 /obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/poor
+	name = "bloody slop"
+	desc = "A horrible mix of water, salt, and viscera, even a prisoner would at least get hardtack. For those who drink lyfeblood, this may yet be useful."
 	list_reagents = list(/datum/reagent/hemosnack/poor = 30)
 
 /obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/mid
+	name = "alchemical vitae"
+	desc = "A carefully considered mix of reagents brewed by a trained alchemist for those who drink lyfeblood. Ostensibly still disgusting for anyone who does not drink lyfeblood, and only tolerable for those who do."
 	list_reagents = list(/datum/reagent/hemosnack/mid = 30)
 
 /obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/good
+	name = "bloodwine stew"
+	desc = "A refined alchemical solution created by an expert alchemist, it combines the staples of a fine dining experience while satiating the need for lyfesblood. A luxurious meal, for those who drink lyfesblood at least."
 	list_reagents = list(/datum/reagent/hemosnack/good = 30)
 
 /datum/reagent/hemosnack

--- a/modular_ochrevalley/code/modules/reagents/hemovore_snacks.dm
+++ b/modular_ochrevalley/code/modules/reagents/hemovore_snacks.dm
@@ -3,7 +3,7 @@
 //- peasant tier: made with alchemy skilldif 0 on any table using improvised ingredients, gives a little bit of nutrition and a small mood debuff for 5 minutes
 //- burgher tier: made with apprentice alch at an alchemy table using mostly alchemy and raw food ingredients, gives nutrition and no buffs/debuffs
 //- noble tier: made with expert alch at an alchemy table but uses a lot of ingredients found in lavish foods, fills nutrition completely and gives a good snack buff (good meal is still people exclusive)
-// all are revolting to non-hemovores, the noble one specifically is hazardous to actual lyckers/vampires.
+// all are revolting to non-hemovores, the noble one specifically is hazardous to actual lyckers/vampyres.
 
 /obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/poor
 	name = "bloody slop"

--- a/modular_ochrevalley/code/modules/reagents/hemovore_snacks.dm
+++ b/modular_ochrevalley/code/modules/reagents/hemovore_snacks.dm
@@ -1,0 +1,67 @@
+//Snacks for Hemovore vice havers, does not work on vampires bcuz of their vitae weirdness
+//has 3 tiers
+//- peasant tier: made with alchemy skilldif 0 on any table using improvised ingredients, gives a little bit of nutrition and a small mood debuff for 5 minutes
+//- burgher tier: made with apprentice alch at an alchemy table using mostly alchemy and raw food ingredients, gives nutrition and no buffs/debuffs
+//- noble tier: made with expert alch at an alchemy table but uses a lot of ingredients found in lavish foods, fills nutrition completely and gives a good snack buff (good meal is still people exclusive)
+// all are revolting to non-hemovores, the noble one specifically is hazardous to actual lyckers/vampires.
+
+/obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/poor
+	list_reagents = list(/datum/reagent/hemosnack/poor = 30)
+
+/obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/mid
+	list_reagents = list(/datum/reagent/hemosnack/mid = 30)
+
+/obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/good
+	list_reagents = list(/datum/reagent/hemosnack/good = 30)
+
+/datum/reagent/hemosnack
+	name = "hemosnack base reagent"
+	description = "u should not see this"
+	color = "#0adf7b"
+	taste_description = "coder mistakes"
+	metabolization_rate = 1 //30 per vial, meaning adjust nutrition/hydration * 30 for resulting change
+
+/datum/reagent/hemosnack/poor
+	name = "bloody slop"
+	description = "A horrible mix of water, salt, and viscera, even a prisoner would at least get hardtack. For those who drink lyfeblood, this may yet be useful."
+	color = "#3d2b2b"
+	taste_description = "salty giblets"
+
+/datum/reagent/hemosnack/poor/on_mob_life(mob/living/carbon/M)
+	if(!M.has_stress_event(/datum/stressevent/bloodslop) && !HAS_TRAIT(M, TRAIT_LYFE_DRINK))
+		M.add_stress(/datum/stressevent/bloodslop)
+	if(!M.has_stress_event(/datum/stressevent/bloodslop/hemo) && HAS_TRAIT(M, TRAIT_LYFE_DRINK))
+		M.add_stress(/datum/stressevent/bloodslop/hemo)
+	if(HAS_TRAIT(M, TRAIT_LYFE_DRINK))
+		M.adjust_nutrition(10)
+		M.adjust_hydration(10)
+	..()
+
+/datum/reagent/hemosnack/mid
+	name = "alchemical vitae"
+	description = "A carefully considered mix of reagents brewed by a trained alchemist for those who drink lyfeblood. Ostensibly still disgusting for anyone who does not drink lyfeblood, and only tolerable for those who do."
+	color = "#4b2b2b"
+	taste_description = "salted steak"
+
+/datum/reagent/hemosnack/mid/on_mob_life(mob/living/carbon/M)
+	if(!M.has_stress_event(/datum/stressevent/bloodslop) && !HAS_TRAIT(M, TRAIT_LYFE_DRINK))
+		M.add_stress(/datum/stressevent/bloodslop)
+	if(HAS_TRAIT(M, TRAIT_LYFE_DRINK))
+		M.adjust_nutrition(20)
+		M.adjust_hydration(20)
+	..()
+
+/datum/reagent/hemosnack/good
+	name = "bloodwine stew"
+	description = "A refined alchemical solution created by an expert alchemist, it combines the staples of a fine dining experience while satiating the need for lyfesblood. A luxurious meal, for those who drink lyfesblood at least."
+	color = "#641b1b"
+	taste_description = "berry sauce drizzled steak with garlic accents"
+
+/datum/reagent/hemosnack/good/on_mob_life(mob/living/carbon/M)
+	if(!M.has_stress_event(/datum/stressevent/bloodslop) && !HAS_TRAIT(M, TRAIT_LYFE_DRINK))
+		M.add_stress(/datum/stressevent/bloodslop)
+	if(HAS_TRAIT(M, TRAIT_LYFE_DRINK))
+		M.adjust_nutrition(30)
+		M.adjust_hydration(30)
+		M.apply_status_effect(/datum/status_effect/buff/snackbuff)
+	..()

--- a/modular_ochrevalley/code/modules/reagents/hemovore_snacks.dm
+++ b/modular_ochrevalley/code/modules/reagents/hemovore_snacks.dm
@@ -5,17 +5,17 @@
 //- noble tier: made with expert alch at an alchemy table but uses a lot of ingredients found in lavish foods, fills nutrition completely and gives a good snack buff (good meal is still people exclusive)
 // all are revolting to non-hemovores, the noble one specifically is hazardous to actual lyckers/vampyres.
 
-/obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/poor
+/obj/item/reagent_containers/glass/bottle/alchemical/hemosnack/poor
 	name = "bloody slop"
 	desc = "A horrible mix of water, salt, and viscera, even a prisoner would at least get hardtack. For those who drink lyfeblood, this may yet be useful."
 	list_reagents = list(/datum/reagent/hemosnack/poor = 30)
 
-/obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/mid
+/obj/item/reagent_containers/glass/bottle/alchemical/hemosnack/mid
 	name = "alchemical vitae"
 	desc = "A carefully considered mix of reagents brewed by a trained alchemist for those who drink lyfeblood. Ostensibly still disgusting for anyone who does not drink lyfeblood, and only tolerable for those who do."
 	list_reagents = list(/datum/reagent/hemosnack/mid = 30)
 
-/obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/good
+/obj/item/reagent_containers/glass/bottle/alchemical/hemosnack/good
 	name = "bloodwine stew"
 	desc = "A refined alchemical solution created by an expert alchemist, it combines the staples of a fine dining experience while satiating the need for lyfesblood. A luxurious meal, for those who drink lyfesblood at least."
 	list_reagents = list(/datum/reagent/hemosnack/good = 30)

--- a/modular_ochrevalley/code/modules/reagents/hemovore_snacks.dm
+++ b/modular_ochrevalley/code/modules/reagents/hemovore_snacks.dm
@@ -29,9 +29,9 @@
 
 /datum/reagent/hemosnack/poor/on_mob_life(mob/living/carbon/M)
 	if(!M.has_stress_event(/datum/stressevent/bloodslop) && !HAS_TRAIT(M, TRAIT_LYFE_DRINK))
-		M.add_stress(/datum/stressevent/bloodslop)
+		M.add_stress(/datum/stressevent/bloodslop) //wow this viscera and salt in a vial is terrible tasting
 	if(!M.has_stress_event(/datum/stressevent/bloodslop/hemo) && HAS_TRAIT(M, TRAIT_LYFE_DRINK))
-		M.add_stress(/datum/stressevent/bloodslop/hemo)
+		M.add_stress(/datum/stressevent/bloodslop/hemo) //hemovores hate it slightly less
 	if(HAS_TRAIT(M, TRAIT_LYFE_DRINK))
 		M.adjust_nutrition(10)
 		M.adjust_hydration(10)
@@ -60,8 +60,10 @@
 /datum/reagent/hemosnack/good/on_mob_life(mob/living/carbon/M)
 	if(!M.has_stress_event(/datum/stressevent/bloodslop) && !HAS_TRAIT(M, TRAIT_LYFE_DRINK))
 		M.add_stress(/datum/stressevent/bloodslop)
+	if(HAS_TRAIT(M, TRAIT_VAMPBITE) && !HAS_TRAIT(M, TRAIT_LYFE_DRINK))
+		M.add_stress(/datum/stressevent/badjuiceforvampires) //get garlicked, idiot
 	if(HAS_TRAIT(M, TRAIT_LYFE_DRINK))
 		M.adjust_nutrition(30)
 		M.adjust_hydration(30)
-		M.apply_status_effect(/datum/status_effect/buff/snackbuff)
+		M.apply_status_effect(/datum/status_effect/buff/snackbuff) //still worse than drinking a person
 	..()

--- a/modular_ochrevalley/code/modules/reagents/hemovore_snacks.dm
+++ b/modular_ochrevalley/code/modules/reagents/hemovore_snacks.dm
@@ -34,11 +34,11 @@
 	taste_description = "salty giblets"
 
 /datum/reagent/hemosnack/poor/on_mob_life(mob/living/carbon/M)
-	if(!M.has_stress_event(/datum/stressevent/bloodslop) && !HAS_TRAIT(M, TRAIT_LYFE_DRINK))
+	if(!M.has_stress_event(/datum/stressevent/bloodslop) && !HAS_TRAIT(M, TRAIT_LYFE_DRINK) && !HAS_TRAIT(M, TRAIT_ORGAN_EATER))
 		M.add_stress(/datum/stressevent/bloodslop) //wow this viscera and salt in a vial is terrible tasting
-	if(!M.has_stress_event(/datum/stressevent/bloodslop/hemo) && HAS_TRAIT(M, TRAIT_LYFE_DRINK))
+	if(!M.has_stress_event(/datum/stressevent/bloodslop/hemo) && HAS_TRAIT(M, TRAIT_LYFE_DRINK)) //i dont think someone who eats actual raw organs will care much about taste here
 		M.add_stress(/datum/stressevent/bloodslop/hemo) //hemovores hate it slightly less
-	if(HAS_TRAIT(M, TRAIT_LYFE_DRINK))
+	if(HAS_TRAIT(M, TRAIT_LYFE_DRINK) || HAS_TRAIT(M, TRAIT_ORGAN_EATER)) //organ eaters are weirdos who will also probably enjoy this slop
 		M.adjust_nutrition(10)
 		M.adjust_hydration(10)
 	..()
@@ -50,9 +50,9 @@
 	taste_description = "salted steak"
 
 /datum/reagent/hemosnack/mid/on_mob_life(mob/living/carbon/M)
-	if(!M.has_stress_event(/datum/stressevent/bloodslop) && !HAS_TRAIT(M, TRAIT_LYFE_DRINK))
+	if(!M.has_stress_event(/datum/stressevent/bloodslop) && !HAS_TRAIT(M, TRAIT_LYFE_DRINK) && !HAS_TRAIT(M, TRAIT_ORGAN_EATER))
 		M.add_stress(/datum/stressevent/bloodslop)
-	if(HAS_TRAIT(M, TRAIT_LYFE_DRINK))
+	if(HAS_TRAIT(M, TRAIT_LYFE_DRINK) || HAS_TRAIT(M, TRAIT_ORGAN_EATER))
 		M.adjust_nutrition(20)
 		M.adjust_hydration(20)
 	..()
@@ -64,11 +64,11 @@
 	taste_description = "berry sauce drizzled steak with garlic accents"
 
 /datum/reagent/hemosnack/good/on_mob_life(mob/living/carbon/M)
-	if(!M.has_stress_event(/datum/stressevent/bloodslop) && !HAS_TRAIT(M, TRAIT_LYFE_DRINK))
+	if(!M.has_stress_event(/datum/stressevent/bloodslop) && !HAS_TRAIT(M, TRAIT_LYFE_DRINK) && !HAS_TRAIT(M, TRAIT_ORGAN_EATER))
 		M.add_stress(/datum/stressevent/bloodslop)
 	if(HAS_TRAIT(M, TRAIT_VAMPBITE) && !HAS_TRAIT(M, TRAIT_LYFE_DRINK))
 		M.add_stress(/datum/stressevent/badjuiceforvampires) //get garlicked, idiot
-	if(HAS_TRAIT(M, TRAIT_LYFE_DRINK))
+	if(HAS_TRAIT(M, TRAIT_LYFE_DRINK) || HAS_TRAIT(M, TRAIT_ORGAN_EATER))
 		M.adjust_nutrition(30)
 		M.adjust_hydration(30)
 		M.apply_status_effect(/datum/status_effect/buff/snackbuff) //still worse than drinking a person

--- a/modular_ochrevalley/code/modules/roguetown/roguecrafting/alchemy/alchemy.dm
+++ b/modular_ochrevalley/code/modules/roguetown/roguecrafting/alchemy/alchemy.dm
@@ -1,0 +1,22 @@
+/datum/crafting_recipe/roguetown/alchemy/hemosnack_poor
+	name = "bloody slop"
+	category = "Table"
+	result = list(/obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/poor = 1)
+	reqs = list(/obj/item/reagent_containers/glass/bottle/alchemical = 1, /datum/reagent/water = 30, /obj/item/alch/viscera = 2, /obj/item/reagent_containers/powder/salt = 1)
+	craftdiff = 0	//made on a table by the desperate
+
+/datum/crafting_recipe/roguetown/alchemy/hemosnack_mid
+	name = "alchemical vitae"
+	category = "Table"
+	req_table = FALSE
+	result = list(/obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/mid = 1)
+	reqs = list(/obj/item/reagent_containers/glass/bottle/alchemical = 1, /datum/reagent/medicine/healthpot = 30, /obj/item/reagent_containers/food/snacks/rogue/meat/steak = 2, /obj/item/alch/puresalt = 1)
+	craftdiff = 2	//made at an alchemy table by the knowing
+
+/datum/crafting_recipe/roguetown/alchemy/hemosnack_good
+	name = "bloodwine stew"
+	category = "Table"
+	req_table = FALSE
+	result = list(/obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/good = 1)
+	reqs = list(/obj/item/reagent_containers/glass/bottle/alchemical = 1, /datum/reagent/consumable/ethanol/jackberrywine = 30, /obj/item/reagent_containers/food/snacks/rogue/peppersteak/ducal = 2, /obj/item/alch/puresalt = 1)
+	craftdiff = 4	//made on an alchemy table by the experts

--- a/modular_ochrevalley/code/modules/roguetown/roguecrafting/alchemy/alchemy.dm
+++ b/modular_ochrevalley/code/modules/roguetown/roguecrafting/alchemy/alchemy.dm
@@ -1,6 +1,6 @@
-/datum/crafting_recipe/roguetown/alchemy/hemosnack_poor
+/datum/crafting_recipe/roguetown/survival/hemosnack_poor
 	name = "bloody slop"
-	category = "Table"
+	structurecraft = /obj/structure/table
 	result = list(/obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/poor = 1)
 	reqs = list(/obj/item/reagent_containers/glass/bottle/alchemical = 1, /datum/reagent/water = 30, /obj/item/alch/viscera = 2, /obj/item/reagent_containers/powder/salt = 1)
 	craftdiff = 0	//made on a table by the desperate
@@ -8,7 +8,6 @@
 /datum/crafting_recipe/roguetown/alchemy/hemosnack_mid
 	name = "alchemical vitae"
 	category = "Table"
-	req_table = FALSE
 	result = list(/obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/mid = 1)
 	reqs = list(/obj/item/reagent_containers/glass/bottle/alchemical = 1, /datum/reagent/medicine/healthpot = 30, /obj/item/reagent_containers/food/snacks/rogue/meat/steak = 2, /obj/item/alch/puresalt = 1)
 	craftdiff = 2	//made at an alchemy table by the knowing
@@ -16,7 +15,6 @@
 /datum/crafting_recipe/roguetown/alchemy/hemosnack_good
 	name = "bloodwine stew"
 	category = "Table"
-	req_table = FALSE
 	result = list(/obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/good = 1)
 	reqs = list(/obj/item/reagent_containers/glass/bottle/alchemical = 1, /datum/reagent/consumable/ethanol/jackberrywine = 30, /obj/item/reagent_containers/food/snacks/rogue/peppersteak/ducal = 2, /obj/item/alch/puresalt = 1)
 	craftdiff = 4	//made on an alchemy table by the experts

--- a/modular_ochrevalley/code/modules/roguetown/roguecrafting/alchemy/alchemy.dm
+++ b/modular_ochrevalley/code/modules/roguetown/roguecrafting/alchemy/alchemy.dm
@@ -1,20 +1,20 @@
 /datum/crafting_recipe/roguetown/survival/hemosnack_poor
 	name = "bloody slop"
 	structurecraft = /obj/structure/table
-	result = list(/obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/poor = 1)
+	result = list(/obj/item/reagent_containers/glass/bottle/alchemical/hemosnack/poor = 1)
 	reqs = list(/obj/item/reagent_containers/glass/bottle/alchemical = 1, /datum/reagent/water = 30, /obj/item/alch/viscera = 2, /obj/item/reagent_containers/powder/salt = 1)
 	craftdiff = 0	//made on a table by the desperate
 
 /datum/crafting_recipe/roguetown/alchemy/hemosnack_mid
 	name = "alchemical vitae"
 	category = "Table"
-	result = list(/obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/mid = 1)
+	result = list(/obj/item/reagent_containers/glass/bottle/alchemical/hemosnack/mid = 1)
 	reqs = list(/obj/item/reagent_containers/glass/bottle/alchemical = 1, /datum/reagent/medicine/healthpot = 30, /obj/item/reagent_containers/food/snacks/rogue/meat/steak = 2, /obj/item/alch/puresalt = 1)
 	craftdiff = 2	//made at an alchemy table by the knowing
 
 /datum/crafting_recipe/roguetown/alchemy/hemosnack_good
 	name = "bloodwine stew"
 	category = "Table"
-	result = list(/obj/item/reagent_containers/glass/bottle/alchemical/rogue/hemosnack/good = 1)
+	result = list(/obj/item/reagent_containers/glass/bottle/alchemical/hemosnack/good = 1)
 	reqs = list(/obj/item/reagent_containers/glass/bottle/alchemical = 1, /datum/reagent/consumable/ethanol/jackberrywine = 30, /obj/item/reagent_containers/food/snacks/rogue/peppersteak/ducal = 2, /obj/item/alch/puresalt = 1)
 	craftdiff = 4	//made on an alchemy table by the experts

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3715,6 +3715,8 @@
 #include "modular_causticcove\code\modules\dcbot\topichandlers\fetchmanifest.dm"
 #include "modular_causticcove\code\modules\dcbot\topichandlers\fetchplayers.dm"
 #include "modular_causticcove\code\modules\deadite_pac\deadite_pac.dm"
+#include "modular_ochrevalley\code\modules\reagents\hemovore_snacks.dm"
+#include "modular_ochrevalley\code\modules\roguetown\roguecrafting\alchemy\alchemy.dm"
 #include "modular_causticcove\code\modules\extra_virtue\prefs.dm"
 #include "modular_ochrevalley\code\modules\clothing\rogueclothes\armor\regenerating.dm"
 #include "modular_causticcove\code\modules\grazer\stomach.dm"


### PR DESCRIPTION
## About The Pull Request
Adds three new crafts for 3 new reagents to sate the nutrition needs of hemovores:
- Bloody slop: 10 nutrition and 10 hydration per dram, mood debuff for drinking it (even as a hemovore), crafted with 0 crafting skill at a table with things you can probably find laying around.
- Alchemical Vitae: twice as nutritious and hydrating as the slop, no mood debuff for hemovores, requires actual meat to be used and refined salt + health potion, crafted using apprentice alchemy at an alchemy table
- Bloodwine Stew: thrice as nutritious as the slop, gives the good snack buff, requires ducal steaks + jacksberry wine + salt, needs expert level alchemy and an alchemy table, especially revolting to lickers

These reagents will only provide the nutritious/buffs aspects to hemovores, regular people get no nutritional value and a minor mood debuff. Lickers also get no nutrition and either the regular debuff or a special one if they drink the bloodwine stew.

Removes the food buffs you get from regular food and drink if you are a hemovore. This was kinda unintentional from the getgo but that's being removed now since there are other ways to get said buffs (and hey, it is a vice after all).

Oh also TRAIT_ORGAN_EATER allows you to drink the slop with no problems because if you eat organs I assume you really don't care about how you get your nutrition.
<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [X] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [X] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [X] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence
That would be a lot of screenshots so here is the test results summary:
- All three reagents spawn and work as intended for hemovores, non-hemovores, and lickers
- All three items are craftable using the described crafting options
- the fact that the jacksberry wine has to be actively made in game because none of the debug items actually spawn in the reagent is supremely annoying. As a heads up for anyone testing this too.
- Hemovores do not benefit from food buffs anymore when eating, regular people still do
- cuisine system is not impacted so you do still get the lil heart and stuff there even as a hemovore
- organ eaters can drink the slop just fine. Organ eater hemovores can too
<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game
Mostly just enables people to not drink *just* living things. Maybe animal blood was how they got by. Maybe they lose control when they drink real people. The drinks themselves only work for this one specific vice and the ones that don't give a mood debuff require alchemy and some preparation to make. The highest tier one practically requires making two whole meals and a brew of wine just to make it. So hopefully the difficulty is about where it should be there.
<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: 3 new crafting recipes and 3 new reagents for hemovores, now they have a non-living person alternative for food. The better ones require alchemy though.
add: bloody slop is in the loadout for one loadout point
remove: hemovores benefiting from buffs from conventional food items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
