### PR TITLE
[DNM] Reworks Shrine Priest/Guardian to be adventurer classes

### DIFF
--- a/code/game/objects/items/rogueitems/waterskin.dm
+++ b/code/game/objects/items/rogueitems/waterskin.dm
@@ -37,7 +37,7 @@
 	icon_state = "waterpurifier"
 	volume = 150 //doubling the amount due to the cost
 	desc_uncorked = "Bronze tubes spiral about from the mouth of this waterskin in complex, dizzying patterns. The cap on the mouth is off."
-	var/filtered_reagents = list(/datum/reagent/water/gross, 
+	var/filtered_reagents = list(/datum/reagent/water/gross,
 								 /datum/reagent/water/bathwater,
 								 /datum/reagent/water/salty) // List of liquids it turns into drinkable water
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -74,7 +74,11 @@ GLOBAL_VAR_INIT(adventurer_hugbox_duration_still, 3 MINUTES)
 		/datum/advclass/rogue/buccaneer,
 		/datum/advclass/rogue/tinkerer,
 		///Caustic edit end
-		/datum/advclass/true_random, //OV ADD
+		// OV Edit
+		/datum/advclass/true_random,
+		/datum/advclass/foreigner/shrine_priest,
+		/datum/advclass/foreigner/shrine_guardian,
+		// OV Edit End
 		/datum/advclass/foreigner/shepherd,
 		/datum/advclass/foreigner/fencerguy,
 		/datum/advclass/foreigner/bronzeclad,

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary.dm
@@ -50,10 +50,6 @@
 		/datum/advclass/mercenary/hangyaku,
 		/datum/advclass/mercenary/chonin,
 		/datum/advclass/mercenary/seonjang,
-		//Caustic add start
-		/datum/advclass/mercenary/shrine_priest,
-		/datum/advclass/mercenary/shrine_guardian,
-		//Caustic add end
 		/datum/advclass/mercenary/steppesman,
 		/datum/advclass/mercenary/warscholar,
 		/datum/advclass/mercenary/warscholar_pontifex,

--- a/modular_causticcove/code/modules/classes/shrine_priest/shrine_guardian.dm
+++ b/modular_causticcove/code/modules/classes/shrine_priest/shrine_guardian.dm
@@ -8,14 +8,14 @@
 	outfit = /datum/outfit/job/roguetown/mercenary/shrine_guardian
 	subclass_languages = list(/datum/language/kazengunese)
 	category_tags = list(CTAG_ADVENTURER)
-	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_CRITICAL_RESISTANCE) // NO dodge expert. Hit fast, hit hard, but survive attacks by sheer grit and avoidance. You have spacing tools to avoid getting whacked - use 'em!
+	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_DODGEEXPERT) // Hit fast, hit hard, but survive attacks by  avoidance. You have spacing tools to avoid getting whacked - use 'em!
 	cmode_music = 'sound/music/combat_kazengite.ogg'
 	//OV edit
 	subclass_stats = list(
 		STATKEY_WIL = 1,
 		STATKEY_STR = 1,
 		STATKEY_SPD = 1,
-		// 5 stat weight. Unlike the advent Paladin (7 stat weight), these guys don't even have medium armor, but they do have crit resistance. A more lightweight, mobility-focused, Kazengunese paladin of sorts.
+		// 5 stat weight. Unlike the advent Paladin (7 stat weight), these guys don't even have medium armor, but they do have dodge expert. Aoh more lightweight, mobility-focused, Kazengunese paladin of sorts.
 	)
 	//OV edit end
 	subclass_skills = list(

--- a/modular_causticcove/code/modules/classes/shrine_priest/shrine_guardian.dm
+++ b/modular_causticcove/code/modules/classes/shrine_priest/shrine_guardian.dm
@@ -15,7 +15,7 @@
 		STATKEY_WIL = 1,
 		STATKEY_STR = 1,
 		STATKEY_SPD = 1,
-		// 5 stat weight. Unlike the advent Paladin (7 stat weight), these guys don't even have medium armor, but they do have dodge expert. Aoh more lightweight, mobility-focused, Kazengunese paladin of sorts.
+		// 5 stat weight. Unlike the advent Paladin (7 stat weight), these guys don't even have medium armor, but they do have dodge expert. A more lightweight, mobility-focused, Kazengunese paladin of sorts.
 	)
 	//OV edit end
 	subclass_skills = list(

--- a/modular_causticcove/code/modules/classes/shrine_priest/shrine_guardian.dm
+++ b/modular_causticcove/code/modules/classes/shrine_priest/shrine_guardian.dm
@@ -1,25 +1,27 @@
-/datum/advclass/mercenary/shrine_guardian
+# define SHRINEGUARDIAN_TUTORIAL "You were once a guardian of a shrine in the far eastern lands of Kazengun. For one reason or another you have departed from your homeland and sailed far across the seas to these western lands. Perhaps you were forced out by marauding ronin or beasts. Or maybe you have an unusual desire to spread the word of Aisata and Saidon's Twelve Children to the west. These foreign lands are lethal indeed, but you will be more so."
+
+/datum/advclass/foreigner/shrine_guardian
 	name = "Shrine Guardian"
-	tutorial = "You were once a guardian of your shrine in Kazengun. Something has forced you out, if it be maurauding ronin, or too many beasts for you to handle. You are skilled in polearms and bows, using an awkward battle style for hit and run tactics."
+	tutorial = SHRINEGUARDIAN_TUTORIAL
 	allowed_sexes = list(MALE, FEMALE)
-	forbidden_races = list(RACES_SMALL) //no dwarf sprites
 	allowed_patrons = ALL_KAZENGUN_PATRONS //guardian of the twelve... and saidon but no undivided
 	outfit = /datum/outfit/job/roguetown/mercenary/shrine_guardian
 	subclass_languages = list(/datum/language/kazengunese)
 	class_select_category = CLASS_CAT_KAZENGUN
-	category_tags = list(CTAG_MERCENARY)
-	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_CRITICAL_RESISTANCE)
+	category_tags = list(CTAG_ADVENTURER)
+	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_CRITICAL_RESISTANCE) // NO dodge expert. Hit fast, hit hard, but survive attacks by sheer grit and avoidance. You have spacing tools to avoid getting whacked - use 'em!
 	cmode_music = 'sound/music/combat_kazengite.ogg'
 	//OV edit
 	subclass_stats = list(
-		STATKEY_WIL = 2,
+		STATKEY_WIL = 1,
 		STATKEY_STR = 1,
-		STATKEY_SPD = 2,
+		STATKEY_SPD = 1,
 		STATKEY_PER = 1
+		// 6 stat weight. Unlike the advent Paladin (5 stat weight), these guys don't even have medium armor. A more lightweight, mobility-focused, Kazengunese paladin of sorts.
 	)
 	//OV edit end
 	subclass_skills = list(
-		/datum/skill/magic/holy = SKILL_LEVEL_NOVICE,
+		/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/bows = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/tracking = SKILL_LEVEL_JOURNEYMAN,
@@ -33,9 +35,9 @@
 
 /datum/outfit/job/roguetown/mercenary/shrine_guardian/pre_equip(mob/living/carbon/human/H)
 	..()
-	to_chat(H, span_warning("You were once a guardian of your shrine in Kazengun. Something has forced you out, if it be maurauding ronin, or too many beasts for you to handle. You are skilled in polearms and bows, using an awkward battle style for hit and run tactics."))
+	to_chat(H, span_warning(SHRINEGUARDIAN_TUTORIAL))
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_1)
+	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_1) //Capped to T1 miracles.
 	head = /obj/item/clothing/head/roguetown/mentorhat
 	cloak = /obj/item/clothing/cloak/kazengun //OV Add: Added Kazengun Drip to Kazengun Class
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants2
@@ -77,3 +79,5 @@
 				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve //OV Edit: Adjusted for spawn
 				l_hand = /obj/item/rogueweapon/spear/naginata //OV Edit: Adjusted for spawn
 				beltr = /obj/item/quiver/arrows
+
+#undef SHRINEGUARDIAN_TUTORIAL

--- a/modular_causticcove/code/modules/classes/shrine_priest/shrine_guardian.dm
+++ b/modular_causticcove/code/modules/classes/shrine_priest/shrine_guardian.dm
@@ -7,7 +7,6 @@
 	allowed_patrons = ALL_KAZENGUN_PATRONS //guardian of the twelve... and saidon but no undivided
 	outfit = /datum/outfit/job/roguetown/mercenary/shrine_guardian
 	subclass_languages = list(/datum/language/kazengunese)
-	class_select_category = CLASS_CAT_KAZENGUN
 	category_tags = list(CTAG_ADVENTURER)
 	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_CRITICAL_RESISTANCE) // NO dodge expert. Hit fast, hit hard, but survive attacks by sheer grit and avoidance. You have spacing tools to avoid getting whacked - use 'em!
 	cmode_music = 'sound/music/combat_kazengite.ogg'

--- a/modular_causticcove/code/modules/classes/shrine_priest/shrine_guardian.dm
+++ b/modular_causticcove/code/modules/classes/shrine_priest/shrine_guardian.dm
@@ -27,6 +27,7 @@
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN
 	)
+	extra_context = "This subclass has access to tier 1 miracles, and has a choice of naginata, eagle's beak, recurve bow, and short bows."
 
 /*/datum/outfit/job/roguetown/mercenary/shrine_guardian //OV Edit - All Kazengun Patrons Unlocked
 	allowed_patrons = list(/datum/patron/divine/astrata)*/
@@ -50,6 +51,7 @@
 		/obj/item/flashlight/flare/torch/lantern,
 		/obj/item/needle,
 		/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+		/obj/item/storage/belt/rogue/pouch/coins/poor,
 		)
 	var/weapons = list("Eagle's Beak + Shortbow","Naginata + Shortbow","Naginata + Recurve Bow") //OV Edit: Added Naginata + Shortbow
 	if(H.mind)

--- a/modular_causticcove/code/modules/classes/shrine_priest/shrine_guardian.dm
+++ b/modular_causticcove/code/modules/classes/shrine_priest/shrine_guardian.dm
@@ -15,8 +15,7 @@
 		STATKEY_WIL = 1,
 		STATKEY_STR = 1,
 		STATKEY_SPD = 1,
-		STATKEY_PER = 1
-		// 6 stat weight. Unlike the advent Paladin (5 stat weight), these guys don't even have medium armor. A more lightweight, mobility-focused, Kazengunese paladin of sorts.
+		// 5 stat weight. Unlike the advent Paladin (7 stat weight), these guys don't even have medium armor, but they do have crit resistance. A more lightweight, mobility-focused, Kazengunese paladin of sorts.
 	)
 	//OV edit end
 	subclass_skills = list(

--- a/modular_causticcove/code/modules/classes/shrine_priest/shrine_guardian.dm
+++ b/modular_causticcove/code/modules/classes/shrine_priest/shrine_guardian.dm
@@ -34,7 +34,7 @@
 
 /datum/outfit/job/roguetown/mercenary/shrine_guardian/pre_equip(mob/living/carbon/human/H)
 	..()
-	to_chat(H, span_warning(SHRINEGUARDIAN_TUTORIAL))
+	to_chat(H, span_notice(SHRINEGUARDIAN_TUTORIAL))
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_1) //Capped to T1 miracles.
 	head = /obj/item/clothing/head/roguetown/mentorhat

--- a/modular_causticcove/code/modules/classes/shrine_priest/shrine_guardian.dm
+++ b/modular_causticcove/code/modules/classes/shrine_priest/shrine_guardian.dm
@@ -1,4 +1,4 @@
-# define SHRINEGUARDIAN_TUTORIAL "You were once a guardian of a shrine in the far eastern lands of Kazengun. For one reason or another you have departed from your homeland and sailed far across the seas to these western lands. Perhaps you were forced out by marauding ronin or beasts. Or maybe you have an unusual desire to spread the word of Aisata and Saidon's Twelve Children to the west. These foreign lands are lethal indeed, but you will be more so."
+# define SHRINEGUARDIAN_TUTORIAL "You were once a guardian of a shrine in the far eastern lands of Kazengun. For one reason or another you have departed from your homeland and sailed far across the seas to these western lands. Perhaps you were forced out by marauding ronin or beasts. Regardless of the cause, these foreign lands are lethal indeed... but you will be even more so."
 
 /datum/advclass/foreigner/shrine_guardian
 	name = "Shrine Guardian"
@@ -51,7 +51,6 @@
 		/obj/item/flashlight/flare/torch/lantern,
 		/obj/item/needle,
 		/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-		/obj/item/roguekey/mercenary
 		)
 	var/weapons = list("Eagle's Beak + Shortbow","Naginata + Shortbow","Naginata + Recurve Bow") //OV Edit: Added Naginata + Shortbow
 	if(H.mind)
@@ -78,5 +77,43 @@
 				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve //OV Edit: Adjusted for spawn
 				l_hand = /obj/item/rogueweapon/spear/naginata //OV Edit: Adjusted for spawn
 				beltr = /obj/item/quiver/arrows
+
+	switch(H.patron?.type)
+		if(/datum/patron/old_god)
+			neck = /obj/item/clothing/neck/roguetown/psicross
+		if(/datum/patron/divine/astrata)
+			neck = /obj/item/clothing/neck/roguetown/psicross/astrata
+			H.cmode_music = 'sound/music/cmode/church/combat_astrata.ogg'
+		if(/datum/patron/divine/noc)
+			neck = /obj/item/clothing/neck/roguetown/psicross/noc
+		if(/datum/patron/divine/abyssor)
+			neck = /obj/item/clothing/neck/roguetown/psicross/abyssor
+		if(/datum/patron/divine/dendor)
+			neck = /obj/item/clothing/neck/roguetown/psicross/dendor
+			H.cmode_music = 'sound/music/cmode/garrison/combat_warden.ogg' // see: druid.dm
+		if(/datum/patron/divine/necra)
+			neck = /obj/item/clothing/neck/roguetown/psicross/necra
+			H.cmode_music = 'sound/music/cmode/church/combat_necra.ogg'
+		if(/datum/patron/divine/pestra)
+			neck = /obj/item/clothing/neck/roguetown/psicross/pestra
+		if(/datum/patron/divine/ravox)
+			neck = /obj/item/clothing/neck/roguetown/psicross/ravox
+		if(/datum/patron/divine/malum)
+			neck = /obj/item/clothing/neck/roguetown/psicross/malum
+		if(/datum/patron/divine/eora)
+			neck = /obj/item/clothing/neck/roguetown/psicross/eora
+			H.cmode_music = 'sound/music/cmode/church/combat_eora.ogg'
+		// Kazengun considers Matoko and Baosumi to be benevolent and a part of the holy pantheon with the rest of the Ten. We therefore do not give them TRAIT_HERESIARCH. However the character no doubt knows how heretical they are in these lands, so we put their cross in their stash.
+		if(/datum/patron/inhumen/matthios)
+			neck = /obj/item/clothing/neck/roguetown/psicross
+			H.cmode_music = 'sound/music/combat_matthios.ogg'
+			H.mind?.special_items["Amulet of Matoko"] = /obj/item/clothing/neck/roguetown/psicross/inhumen/matthios
+		if(/datum/patron/inhumen/baotha)
+			neck = /obj/item/clothing/neck/roguetown/psicross
+			H.cmode_music = 'sound/music/combat_baotha.ogg'
+			H.mind?.special_items["Amulet of Baosumi"] = /obj/item/clothing/neck/roguetown/psicross/inhumen/baotha
+		if(/datum/patron/divine/xylix)
+			neck = /obj/item/clothing/neck/roguetown/luckcharm
+			H.cmode_music = 'sound/music/combat_jester.ogg'
 
 #undef SHRINEGUARDIAN_TUTORIAL

--- a/modular_causticcove/code/modules/classes/shrine_priest/shrine_priest.dm
+++ b/modular_causticcove/code/modules/classes/shrine_priest/shrine_priest.dm
@@ -2,7 +2,7 @@
 #define SHRINEPRIEST_CHOICE_MIRACLES "Holy Arts (T3 Miracles + Medicine skill)" // OV Add
 #define SHRINEPRIEST_CHOICE_BLADE "Swordsmanship (T2 Miracles + Hwando)" // OV Add
 
-/datum/advclass/mercenary/shrine_priest
+/datum/advclass/foreigner/shrine_priest
 	name = "Shrine Priest"
 	tutorial = SHRINEPRIEST_TUTORIAL // OV Edit
 	allowed_sexes = list(MALE, FEMALE)
@@ -10,8 +10,7 @@
 	allowed_patrons = ALL_KAZENGUN_PATRONS //guardian of the twelve... and saidon but no undivided
 	outfit = /datum/outfit/job/roguetown/mercenary/shrine_priest
 	subclass_languages = list(/datum/language/kazengunese)
-	class_select_category = CLASS_CAT_KAZENGUN
-	category_tags = list(CTAG_MERCENARY)
+	category_tags = list(CTAG_ADVENTURER)
 	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_CRITICAL_RESISTANCE, TRAIT_RITUALIST)
 	cmode_music = 'sound/music/combat_kazengite.ogg'
 	subclass_stats = list(
@@ -22,7 +21,6 @@
 	)
 	subclass_skills = list(
 		/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/tracking = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,

--- a/modular_causticcove/code/modules/classes/shrine_priest/shrine_priest.dm
+++ b/modular_causticcove/code/modules/classes/shrine_priest/shrine_priest.dm
@@ -4,7 +4,6 @@
 	name = "Shrine Priest"
 	tutorial = SHRINEPRIEST_TUTORIAL // OV Edit
 	allowed_sexes = list(MALE, FEMALE)
-	forbidden_races = list(RACES_SMALL) //no dwarf sprites
 	allowed_patrons = ALL_KAZENGUN_PATRONS //guardian of the twelve... and saidon but no undivided
 	outfit = /datum/outfit/job/roguetown/mercenary/shrine_priest
 	subclass_languages = list(/datum/language/kazengunese)
@@ -14,7 +13,7 @@
 		STATKEY_WIL = 1,
 		STATKEY_INT = 2,
 		STATKEY_SPD = 1,
-		// 5 stat weight. Compared to Missionary (stat weight 7,) we start with slightly nicer gear, and we do have crit resistance, so we dock 2 comparative stat weight.
+		// 5 stat weight. Compared to Missionary (stat weight 7,) we start with fairly nicer gear, so we dock 2 comparative stat weight.
 	)
 	subclass_skills = list(
 		/datum/skill/magic/holy = SKILL_LEVEL_EXPERT,
@@ -29,7 +28,7 @@
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 	)
-	extra_context = "This subclass regenerates Devotion far quicker, and has access to Tier 3 miracles. It also starts with slightly better gear than Missionary, such as "
+	extra_context = "This subclass regenerates Devotion far quicker, and has access to Tier 3 miracles. It also starts with slightly better gear than Missionary, including better food and a belt full of throwing stars."
 
 /*/datum/outfit/job/roguetown/mercenary/shrine_priest //OV Edit - All Kazengun Patrons Unlocked
 	allowed_patrons = list(/datum/patron/divine/astrata)*/
@@ -46,9 +45,12 @@
 	belt = /obj/item/storage/belt/rogue/leather/knifebelt/black/kazengun
 	backl = /obj/item/storage/backpack/rogue/satchel
 	beltr = /obj/item/flashlight/flare/torch/lantern
+	beltl = /obj/item/reagent_containers/glass/bottle/waterskin // If only we had drinking gourds... This'll have to do
 	backpack_contents = list(
-		/obj/item/needle,
-		/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+		/obj/item/reagent_containers/glass/bottle/rogue/healthpot = 1,
+		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+		/obj/item/reagent_containers/food/snacks/rogue/meat/salami = 2, // We don't really have any Eastern travel food at the moment, so double down on the SLOMMI
+		/obj/item/needle = 1,
 		)
 
 	H.adjust_skillrank_up_to(/datum/skill/misc/medicine, SKILL_LEVEL_JOURNEYMAN)
@@ -179,5 +181,3 @@
 	H.set_blindness(0)
 
 #undef SHRINEPRIEST_TUTORIAL
-#undef SHRINEPRIEST_CHOICE_MIRACLES
-#undef SHRINEPRIEST_CHOICE_BLADE

--- a/modular_causticcove/code/modules/classes/shrine_priest/shrine_priest.dm
+++ b/modular_causticcove/code/modules/classes/shrine_priest/shrine_priest.dm
@@ -1,6 +1,6 @@
 #define SHRINEPRIEST_TUTORIAL "You are a shrine priest from the far eastern lands of Kazengun, trained in the holy arts of your homeland. You have a history, however vast or small, of performing rituals, communing with the spirits, laying those spirits to rest, and more such holy services at shrine that was your charge. For one reason or another you have departed from both your shrine and Kazengun, and have traveled far across the seas to the west." // OV Add
 #define SHRINEPRIEST_CHOICE_MIRACLES "Holy Arts (T3 Miracles + Medicine skill)" // OV Add
-#define SHRINEPRIEST_CHOICE_BLADE "Swordsmanship (T2 Miracles + Hwando)" // OV Add
+#define SHRINEPRIEST_CHOICE_BLADE "Swordsmanship (T2 Miracles + Hwando) (-1 STR)" // OV Add
 
 /datum/advclass/foreigner/shrine_priest
 	name = "Shrine Priest"
@@ -14,16 +14,19 @@
 	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_CRITICAL_RESISTANCE, TRAIT_RITUALIST)
 	cmode_music = 'sound/music/combat_kazengite.ogg'
 	subclass_stats = list(
-		STATKEY_CON = 2,
 		STATKEY_WIL = 2,
-		STATKEY_LCK = 2, //OV Edit: Fixing stat issue while fixing sandals
-		STATKEY_STR = -1
+		STATKEY_LCK = 1, //OV Edit: Fixing stat issue while fixing sandals
+		STATKEY_INT = 2,
+		STATKEY_SPD = 1,
+		// 7 stat weight. Compared to Missionary (stat weight 8,) we start with slightly nicer gear.
 	)
 	subclass_skills = list(
 		/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/tracking = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/medicine = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/shields = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT
 	)
@@ -39,16 +42,13 @@
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants2
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt2
 	shoes = /obj/item/clothing/shoes/roguetown/gladiator //OV Edit: Fixed pathing for sandals
-	neck = /obj/item/clothing/neck/roguetown/psicross/astrata
 	gloves = /obj/item/clothing/gloves/roguetown/plate/kote //OV Edit: Removed unused glove spawn call above
 	belt = /obj/item/storage/belt/rogue/leather/knifebelt/black/kazengun
 	backl = /obj/item/storage/backpack/rogue/satchel
+	beltr = /obj/item/flashlight/flare/torch/lantern
 	backpack_contents = list(
-		/obj/item/flashlight/flare/torch/lantern,
 		/obj/item/needle,
 		/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-		/obj/item/roguekey/mercenary,
-		/obj/item/ritechalk
 		)
 	// OV Edit Start - Choose between regular shrine priest (w/ sword) or focus more on miracles
 	var/options = list(SHRINEPRIEST_CHOICE_BLADE, SHRINEPRIEST_CHOICE_MIRACLES)
@@ -60,9 +60,10 @@
 	switch(choice)
 		if(SHRINEPRIEST_CHOICE_BLADE)
 			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN)
-			beltl = /obj/item/rogueweapon/sword/sabre/mulyeog
+			r_hand = /obj/item/rogueweapon/sword/sabre/mulyeog
 			beltr = /obj/item/rogueweapon/scabbard/sword/kazengun
 			C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_2)
+			H.change_stat(STATKEY_STR, -1) // Cuts down our stat weight to 5. You will pay the stat price if you want the cool sword AND T2 miracles!
 			to_chat(H, span_notice(SHRINEPRIEST_TUTORIAL + " Although dedicated to the holy arts, you are not defenseless - your blade will see to that."))
 		// Sacrifice your neat sword for better holy magic and medicine! Kazengunese missionary, essentially.
 		if(SHRINEPRIEST_CHOICE_MIRACLES)
@@ -70,6 +71,45 @@
 			C.grant_miracles(H, cleric_tier = CLERIC_T3, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_3)
 			to_chat(H, span_notice(SHRINEPRIEST_TUTORIAL + " Your single-minded devotion to the holy arts will prove useful in these violent lands."))
 
+	switch(H.patron?.type)
+		if(/datum/patron/old_god)
+			neck = /obj/item/clothing/neck/roguetown/psicross
+		if(/datum/patron/divine/astrata)
+			neck = /obj/item/clothing/neck/roguetown/psicross/astrata
+			H.cmode_music = 'sound/music/cmode/church/combat_astrata.ogg'
+		if(/datum/patron/divine/noc)
+			neck = /obj/item/clothing/neck/roguetown/psicross/noc
+		if(/datum/patron/divine/abyssor)
+			neck = /obj/item/clothing/neck/roguetown/psicross/abyssor
+			H.grant_language(/datum/language/abyssal)
+		if(/datum/patron/divine/dendor)
+			H.grant_language (/datum/language/beast)
+			neck = /obj/item/clothing/neck/roguetown/psicross/dendor
+			H.cmode_music = 'sound/music/cmode/garrison/combat_warden.ogg' // see: druid.dm
+		if(/datum/patron/divine/necra)
+			neck = /obj/item/clothing/neck/roguetown/psicross/necra
+			H.cmode_music = 'sound/music/cmode/church/combat_necra.ogg'
+		if(/datum/patron/divine/pestra)
+			neck = /obj/item/clothing/neck/roguetown/psicross/pestra
+		if(/datum/patron/divine/ravox)
+			neck = /obj/item/clothing/neck/roguetown/psicross/ravox
+		if(/datum/patron/divine/malum)
+			neck = /obj/item/clothing/neck/roguetown/psicross/malum
+		if(/datum/patron/divine/eora)
+			neck = /obj/item/clothing/neck/roguetown/psicross/eora
+			H.cmode_music = 'sound/music/cmode/church/combat_eora.ogg'
+		// Kazengun considers Matoko and Baosumi to be benevolent and a part of the holy pantheon with the rest of the Ten. We therefore do not give them TRAIT_HERESIARCH. However the character no doubt knows how heretical they are in these lands, so we put their cross in their stash.
+		if(/datum/patron/inhumen/matthios)
+			neck = /obj/item/clothing/neck/roguetown/psicross
+			H.cmode_music = 'sound/music/combat_matthios.ogg'
+			H.mind?.special_items["Amulet of Matoko"] = /obj/item/clothing/neck/roguetown/psicross/inhumen/matthios
+		if(/datum/patron/inhumen/baotha)
+			neck = /obj/item/clothing/neck/roguetown/psicross
+			H.cmode_music = 'sound/music/combat_baotha.ogg'
+			H.mind?.special_items["Amulet of Baosumi"] = /obj/item/clothing/neck/roguetown/psicross/inhumen/baotha
+		if(/datum/patron/divine/xylix)
+			neck = /obj/item/clothing/neck/roguetown/luckcharm
+			H.cmode_music = 'sound/music/combat_jester.ogg'
 	// OV Edit End
 	H.set_blindness(0)
 

--- a/modular_causticcove/code/modules/classes/shrine_priest/shrine_priest.dm
+++ b/modular_causticcove/code/modules/classes/shrine_priest/shrine_priest.dm
@@ -18,7 +18,7 @@
 		STATKEY_LCK = 1, //OV Edit: Fixing stat issue while fixing sandals
 		STATKEY_INT = 2,
 		STATKEY_SPD = 1,
-		// 7 stat weight. Compared to Missionary (stat weight 8,) we start with slightly nicer gear.
+		// 7 stat weight. Compared to Missionary (stat weight 8,) we start with slightly nicer gear, so we dock a comparative stat weight.
 	)
 	subclass_skills = list(
 		/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE,
@@ -64,11 +64,11 @@
 			beltr = /obj/item/rogueweapon/scabbard/sword/kazengun
 			C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_2)
 			H.change_stat(STATKEY_STR, -1) // Cuts down our stat weight to 5. You will pay the stat price if you want the cool sword AND T2 miracles!
-			to_chat(H, span_notice(SHRINEPRIEST_TUTORIAL + " Although dedicated to the holy arts, you are not defenseless - your blade will see to that."))
+			to_chat(H, span_notice(SHRINEPRIEST_TUTORIAL + " Although you are dedicated to the holy arts, you are not defenseless - your blade will see to that."))
 		// Sacrifice your neat sword for better holy magic and medicine! Kazengunese missionary, essentially.
 		if(SHRINEPRIEST_CHOICE_MIRACLES)
 			H.adjust_skillrank_up_to(/datum/skill/misc/medicine, SKILL_LEVEL_JOURNEYMAN)
-			C.grant_miracles(H, cleric_tier = CLERIC_T3, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_3)
+			C.grant_miracles(H, cleric_tier = CLERIC_T3, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_3)//Minor regen, capped to T3, parity with other Holy and/or Arcyne caster - no others spend 15 minutes idling only to unlock their entire potencial.
 			to_chat(H, span_notice(SHRINEPRIEST_TUTORIAL + " Your single-minded devotion to the holy arts will prove useful in these violent lands."))
 
 	switch(H.patron?.type)

--- a/modular_causticcove/code/modules/classes/shrine_priest/shrine_priest.dm
+++ b/modular_causticcove/code/modules/classes/shrine_priest/shrine_priest.dm
@@ -26,7 +26,6 @@
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/medicine = SKILL_LEVEL_NOVICE,
-		/datum/skill/combat/shields = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT
 	)
 

--- a/modular_causticcove/code/modules/classes/shrine_priest/shrine_priest.dm
+++ b/modular_causticcove/code/modules/classes/shrine_priest/shrine_priest.dm
@@ -58,30 +58,78 @@
 	switch(H.patron?.type)
 		if(/datum/patron/old_god)
 			neck = /obj/item/clothing/neck/roguetown/psicross
+			ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 		if(/datum/patron/divine/astrata)
 			neck = /obj/item/clothing/neck/roguetown/psicross/astrata
 			H.cmode_music = 'sound/music/cmode/church/combat_astrata.ogg'
+			ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 		if(/datum/patron/divine/noc)
 			neck = /obj/item/clothing/neck/roguetown/psicross/noc
+			H.adjust_skillrank(/datum/skill/craft/alchemy, SKILL_LEVEL_APPRENTICE, TRUE)
+			ADD_TRAIT(H, TRAIT_ALCHEMY_EXPERT, TRAIT_GENERIC) // we keep this one since adventuring cleric doesnt get it like the regular acolyte.
+			H.adjust_skillrank(/datum/skill/magic/arcane, SKILL_LEVEL_APPRENTICE, TRUE) // for their arcane spells, very little CDR and cast speed.
+			if(H.mind)
+				H.mind.AddSpell(new /datum/action/cooldown/spell/touch/prestidigitation)
+			ADD_TRAIT(H, TRAIT_ARCYNE, TRAIT_GENERIC) // So that they can take arcyne potential and not break.
 		if(/datum/patron/divine/abyssor)
 			neck = /obj/item/clothing/neck/roguetown/psicross/abyssor
+			H.adjust_skillrank(/datum/skill/labor/fishing, SKILL_LEVEL_JOURNEYMAN, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/swimming, SKILL_LEVEL_JOURNEYMAN, TRUE)
+			ADD_TRAIT(H, TRAIT_WATERBREATHING, TRAIT_GENERIC)
 			H.grant_language(/datum/language/abyssal)
 		if(/datum/patron/divine/dendor)
 			H.grant_language (/datum/language/beast)
 			neck = /obj/item/clothing/neck/roguetown/psicross/dendor
-			H.cmode_music = 'sound/music/cmode/garrison/combat_warden.ogg' // see: druid.dm
+			H.adjust_skillrank(/datum/skill/labor/farming, SKILL_LEVEL_APPRENTICE, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/hunting, SKILL_LEVEL_NOVICE, TRUE)
+			ADD_TRAIT(H, TRAIT_EXPERT_HUNTER, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_WOODWALKER, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_OUTDOORSMAN, TRAIT_GENERIC)
 		if(/datum/patron/divine/necra)
 			neck = /obj/item/clothing/neck/roguetown/psicross/necra
+			ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_SOUL_EXAMINE, TRAIT_GENERIC)
+			H.adjust_skillrank(/datum/skill/misc/athletics, SKILL_LEVEL_APPRENTICE, TRUE) // digging graves and carrying bodies builds muscles probably.
 			H.cmode_music = 'sound/music/cmode/church/combat_necra.ogg'
+			var/list/necra_tools = list("Shovel", "Scythe")
+			var/tool_choice = input(H, "A reaper, or a digger?", "HOW WILL YOU APPEASE NERIKO?") as anything in necra_tools
+			switch(tool_choice) // choose wisely... larp or effectiveness?
+				if("Shovel")
+					l_hand = /obj/item/rogueweapon/shovel
+				if("Scythe") // o lawd we farmin
+					backr = /obj/item/rogueweapon/scabbard/gwstrap
+					l_hand = /obj/item/rogueweapon/scythe
+					H.adjust_skillrank(/datum/skill/labor/farming, SKILL_LEVEL_APPRENTICE, TRUE) // We get a bit of skill for farmin as part of our "slightly better gear than Missionary" upside
 		if(/datum/patron/divine/pestra)
 			neck = /obj/item/clothing/neck/roguetown/psicross/pestra
+			H.adjust_skillrank(/datum/skill/misc/medicine, SKILL_LEVEL_NOVICE, TRUE)
+			H.adjust_skillrank(/datum/skill/craft/alchemy, SKILL_LEVEL_NOVICE, TRUE)
+			ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
 		if(/datum/patron/divine/ravox)
 			neck = /obj/item/clothing/neck/roguetown/psicross/ravox
+			H.adjust_skillrank(/datum/skill/misc/athletics, SKILL_LEVEL_JOURNEYMAN, TRUE)
+			// We have no staff, so we instead get even BETTER unarmed skill! (up to Journeyman)
+			H.adjust_skillrank(/datum/skill/combat/unarmed, SKILL_LEVEL_NOVICE, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/wrestling, SKILL_LEVEL_NOVICE, TRUE)
+			ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 		if(/datum/patron/divine/malum)
 			neck = /obj/item/clothing/neck/roguetown/psicross/malum
+			ADD_TRAIT(H, TRAIT_SMITHING_EXPERT, TRAIT_GENERIC)
+			H.adjust_skillrank(/datum/skill/craft/blacksmithing, SKILL_LEVEL_APPRENTICE, TRUE)
+			H.adjust_skillrank(/datum/skill/craft/armorsmithing, SKILL_LEVEL_APPRENTICE, TRUE)
+			H.adjust_skillrank(/datum/skill/craft/weaponsmithing, SKILL_LEVEL_APPRENTICE, TRUE)
+			H.adjust_skillrank(/datum/skill/craft/smelting, SKILL_LEVEL_APPRENTICE, TRUE)
+			H.adjust_skillrank(/datum/skill/labor/lumberjacking, SKILL_LEVEL_APPRENTICE, TRUE)
 		if(/datum/patron/divine/eora)
 			neck = /obj/item/clothing/neck/roguetown/psicross/eora
 			H.cmode_music = 'sound/music/cmode/church/combat_eora.ogg'
+			backpack_contents[/obj/item/reagent_containers/eoran_seed] = 1
+			r_hand = /obj/item/rogueweapon/huntingknife/scissors
+			ADD_TRAIT(H, TRAIT_BEAUTIFUL, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)
+			H.adjust_skillrank(/datum/skill/craft/sewing, SKILL_LEVEL_NOVICE, TRUE)
+			H.adjust_skillrank(/datum/skill/labor/farming, SKILL_LEVEL_NOVICE, TRUE)
+			H.adjust_skillrank(/datum/skill/craft/cooking, SKILL_LEVEL_APPRENTICE, TRUE)
 		// Kazengun considers Matoko and Baosumi to be benevolent and a part of the holy pantheon with the rest of the Ten. We therefore do not give them TRAIT_HERESIARCH. However the character no doubt knows how heretical they are in these lands, so we put their cross in their stash.
 		if(/datum/patron/inhumen/matthios)
 			neck = /obj/item/clothing/neck/roguetown/psicross
@@ -94,6 +142,39 @@
 		if(/datum/patron/divine/xylix)
 			neck = /obj/item/clothing/neck/roguetown/luckcharm
 			H.cmode_music = 'sound/music/combat_jester.ogg'
+			H.adjust_skillrank(/datum/skill/misc/climbing, SKILL_LEVEL_JOURNEYMAN, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/lockpicking, SKILL_LEVEL_NOVICE, TRUE)
+			H.adjust_skillrank_up_to(/datum/skill/misc/music, SKILL_LEVEL_EXPERT, TRUE)
+			H.cmode_music = 'sound/music/combat_jester.ogg'
+			var/datum/inspiration/I = new /datum/inspiration(H)
+			I.grant_inspiration(H, bard_tier = BARD_T2)
+			if(H.mind)
+				var/instruments = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman", "Psyaltery", "Flute", "Drum", "Shamisen")
+				var/instrument_choice = tgui_input_list(H, "Choose your instrument.", "TAKE UP ARMS", instruments)
+				H.set_blindness(0)
+				switch(instrument_choice)
+					if("Harp")
+						l_hand = /obj/item/rogue/instrument/harp
+					if("Lute")
+						l_hand = /obj/item/rogue/instrument/lute
+					if("Accordion")
+						l_hand = /obj/item/rogue/instrument/accord
+					if("Guitar")
+						l_hand = /obj/item/rogue/instrument/guitar
+					if("Hurdy-Gurdy")
+						l_hand = /obj/item/rogue/instrument/hurdygurdy
+					if("Viola")
+						l_hand = /obj/item/rogue/instrument/viola
+					if("Vocal Talisman")
+						l_hand = /obj/item/rogue/instrument/vocals
+					if("Psyaltery")
+						l_hand = /obj/item/rogue/instrument/psyaltery
+					if("Flute")
+						l_hand = /obj/item/rogue/instrument/flute
+					if("Drum")
+						l_hand = /obj/item/rogue/instrument/drum
+					if("Shamisen")
+						l_hand = /obj/item/rogue/instrument/shamisen
 	// OV Edit End
 	H.set_blindness(0)
 

--- a/modular_causticcove/code/modules/classes/shrine_priest/shrine_priest.dm
+++ b/modular_causticcove/code/modules/classes/shrine_priest/shrine_priest.dm
@@ -14,11 +14,10 @@
 	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_CRITICAL_RESISTANCE, TRAIT_RITUALIST)
 	cmode_music = 'sound/music/combat_kazengite.ogg'
 	subclass_stats = list(
-		STATKEY_WIL = 2,
-		STATKEY_LCK = 1, //OV Edit: Fixing stat issue while fixing sandals
+		STATKEY_WIL = 1,
 		STATKEY_INT = 2,
 		STATKEY_SPD = 1,
-		// 7 stat weight. Compared to Missionary (stat weight 8,) we start with slightly nicer gear, so we dock a comparative stat weight.
+		// 5 stat weight. Compared to Missionary (stat weight 7,) we start with slightly nicer gear, and we do have crit resistance, so we dock 2 comparative stat weight.
 	)
 	subclass_skills = list(
 		/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE,
@@ -63,7 +62,7 @@
 			r_hand = /obj/item/rogueweapon/sword/sabre/mulyeog
 			beltr = /obj/item/rogueweapon/scabbard/sword/kazengun
 			C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_2)
-			H.change_stat(STATKEY_STR, -1) // Cuts down our stat weight to 5. You will pay the stat price if you want the cool sword AND T2 miracles!
+			H.change_stat(STATKEY_STR, -1) // Cuts down our stat weight to 3. You will pay the stat price if you want the cool sword AND T2 miracles AND crit resist on an adventurer!
 			to_chat(H, span_notice(SHRINEPRIEST_TUTORIAL + " Although you are dedicated to the holy arts, you are not defenseless - your blade will see to that."))
 		// Sacrifice your neat sword for better holy magic and medicine! Kazengunese missionary, essentially.
 		if(SHRINEPRIEST_CHOICE_MIRACLES)

--- a/modular_causticcove/code/modules/classes/shrine_priest/shrine_priest.dm
+++ b/modular_causticcove/code/modules/classes/shrine_priest/shrine_priest.dm
@@ -1,6 +1,4 @@
-#define SHRINEPRIEST_TUTORIAL "You are a shrine priest from the far eastern lands of Kazengun, trained in the holy arts of your homeland. You have a history, however vast or small, of performing rituals, communing with the spirits, laying those spirits to rest, and more such holy services at shrine that was your charge. For one reason or another you have departed from both your shrine and Kazengun, and have traveled far across the seas to the west." // OV Add
-#define SHRINEPRIEST_CHOICE_MIRACLES "Holy Arts (T3 Miracles + Medicine skill)" // OV Add
-#define SHRINEPRIEST_CHOICE_BLADE "Swordsmanship (T2 Miracles + Hwando) (-1 STR)" // OV Add
+#define SHRINEPRIEST_TUTORIAL "You are a shrine priest from the far eastern lands of Kazengun, trained in the holy arts of your homeland. You have a history, however vast or small, of performing rituals, communing with the spirits, laying those spirits to rest, and more such holy services at shrine that was your charge. For one reason or another you have departed from both your shrine and Kazengun, and have traveled far across the seas to the west. Your single-minded devotion to the holy arts will prove useful in these violent lands." // OV Add
 
 /datum/advclass/foreigner/shrine_priest
 	name = "Shrine Priest"
@@ -11,7 +9,6 @@
 	outfit = /datum/outfit/job/roguetown/mercenary/shrine_priest
 	subclass_languages = list(/datum/language/kazengunese)
 	category_tags = list(CTAG_ADVENTURER)
-	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_CRITICAL_RESISTANCE)
 	cmode_music = 'sound/music/combat_kazengite.ogg'
 	subclass_stats = list(
 		STATKEY_WIL = 1,
@@ -20,14 +17,19 @@
 		// 5 stat weight. Compared to Missionary (stat weight 7,) we start with slightly nicer gear, and we do have crit resistance, so we dock 2 comparative stat weight.
 	)
 	subclass_skills = list(
-		/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/magic/holy = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/tracking = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/medicine = SKILL_LEVEL_NOVICE,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT
+		/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 	)
+	extra_context = "This subclass regenerates Devotion far quicker, and has access to Tier 3 miracles. It also starts with slightly better gear than Missionary, such as "
 
 /*/datum/outfit/job/roguetown/mercenary/shrine_priest //OV Edit - All Kazengun Patrons Unlocked
 	allowed_patrons = list(/datum/patron/divine/astrata)*/
@@ -48,26 +50,10 @@
 		/obj/item/needle,
 		/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 		)
-	// OV Edit Start - Choose between regular shrine priest (w/ sword) or focus more on miracles
-	var/options = list(SHRINEPRIEST_CHOICE_BLADE, SHRINEPRIEST_CHOICE_MIRACLES)
-	var/choice = tgui_input_list(H, "What was my dedication while I served my shrine?", "CHOOSE YOUR ARTS", options, default = SHRINEPRIEST_CHOICE_BLADE)
-	// If for whatever reason they closed the choice menu or cancelled, fall back to the default
-	if(!choice)
-		choice = SHRINEPRIEST_CHOICE_BLADE
 
-	switch(choice)
-		if(SHRINEPRIEST_CHOICE_BLADE)
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN)
-			r_hand = /obj/item/rogueweapon/sword/sabre/mulyeog
-			beltr = /obj/item/rogueweapon/scabbard/sword/kazengun
-			C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_2)
-			H.change_stat(STATKEY_STR, -1) // Cuts down our stat weight to 3. You will pay the stat price if you want the cool sword AND T2 miracles AND crit resist on an adventurer!
-			to_chat(H, span_notice(SHRINEPRIEST_TUTORIAL + " Although you are dedicated to the holy arts, you are not defenseless - your blade will see to that."))
-		// Sacrifice your neat sword for better holy magic and medicine! Kazengunese missionary, essentially.
-		if(SHRINEPRIEST_CHOICE_MIRACLES)
-			H.adjust_skillrank_up_to(/datum/skill/misc/medicine, SKILL_LEVEL_JOURNEYMAN)
-			C.grant_miracles(H, cleric_tier = CLERIC_T3, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_3)//Minor regen, capped to T3, parity with other Holy and/or Arcyne caster - no others spend 15 minutes idling only to unlock their entire potencial.
-			to_chat(H, span_notice(SHRINEPRIEST_TUTORIAL + " Your single-minded devotion to the holy arts will prove useful in these violent lands."))
+	H.adjust_skillrank_up_to(/datum/skill/misc/medicine, SKILL_LEVEL_JOURNEYMAN)
+	C.grant_miracles(H, cleric_tier = CLERIC_T3, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_3)//Minor regen, capped to T3, parity with other Holy and/or Arcyne caster - no others spend 15 minutes idling only to unlock their entire potential.
+	to_chat(H, span_notice(SHRINEPRIEST_TUTORIAL))
 
 	switch(H.patron?.type)
 		if(/datum/patron/old_god)

--- a/modular_causticcove/code/modules/classes/shrine_priest/shrine_priest.dm
+++ b/modular_causticcove/code/modules/classes/shrine_priest/shrine_priest.dm
@@ -11,7 +11,7 @@
 	outfit = /datum/outfit/job/roguetown/mercenary/shrine_priest
 	subclass_languages = list(/datum/language/kazengunese)
 	category_tags = list(CTAG_ADVENTURER)
-	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_CRITICAL_RESISTANCE, TRAIT_RITUALIST)
+	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_CRITICAL_RESISTANCE)
 	cmode_music = 'sound/music/combat_kazengite.ogg'
 	subclass_stats = list(
 		STATKEY_WIL = 1,

--- a/modular_causticcove/code/modules/classes/shrine_priest/shrine_priest.dm
+++ b/modular_causticcove/code/modules/classes/shrine_priest/shrine_priest.dm
@@ -1,6 +1,10 @@
+#define SHRINEPRIEST_TUTORIAL "You are a shrine priest from the far eastern lands of Kazengun, trained in the holy arts of your homeland. You have a history, however vast or small, of performing rituals, communing with the spirits, laying those spirits to rest, and more such holy services at shrine that was your charge. For one reason or another you have departed from both your shrine and Kazengun, and have traveled far across the seas to the west." // OV Add
+#define SHRINEPRIEST_CHOICE_MIRACLES "Holy Arts (T3 Miracles + Medicine skill)" // OV Add
+#define SHRINEPRIEST_CHOICE_BLADE "Swordsmanship (T2 Miracles + Hwando)" // OV Add
+
 /datum/advclass/mercenary/shrine_priest
 	name = "Shrine Priest"
-	tutorial = "Your a Shrine Priest someone trained in the mystical arts of Kazegun not a farmer or commonfolk, the rituals you preform to comune with spirits or lay them to rest. Weither it be through prayer, or a dance of miracles and blade. For one reason or another you have left Kazegun wether to pursue a better life, coin or just seeking a fresh start."
+	tutorial = SHRINEPRIEST_TUTORIAL // OV Edit
 	allowed_sexes = list(MALE, FEMALE)
 	forbidden_races = list(RACES_SMALL) //no dwarf sprites
 	allowed_patrons = ALL_KAZENGUN_PATRONS //guardian of the twelve... and saidon but no undivided
@@ -31,9 +35,7 @@
 
 /datum/outfit/job/roguetown/mercenary/shrine_priest/pre_equip(mob/living/carbon/human/H)
 	..()
-	to_chat(H, span_warning("Your a Shrine Priest someone trained in the mystical arts of Kazegun not a farmer or commonfolk, the rituals you preform to comune with spirits or lay them to rest. Weither it be through prayer, or a dance of miracles and blade. For one reason or another you have left Kazegun wether to pursue a better life, coin or just seeking a fresh start."))
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_2)
 	head = /obj/item/clothing/head/roguetown/mentorhat
 	cloak = /obj/item/clothing/cloak/kazengun
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants2
@@ -50,6 +52,29 @@
 		/obj/item/roguekey/mercenary,
 		/obj/item/ritechalk
 		)
+	// OV Edit Start - Choose between regular shrine priest (w/ sword) or focus more on miracles
+	var/options = list(SHRINEPRIEST_CHOICE_BLADE, SHRINEPRIEST_CHOICE_MIRACLES)
+	var/choice = tgui_input_list(H, "What was my dedication while I served my shrine?", "CHOOSE YOUR ARTS", options, default = SHRINEPRIEST_CHOICE_BLADE)
+	// If for whatever reason they closed the choice menu or cancelled, fall back to the default
+	if(!choice)
+		choice = SHRINEPRIEST_CHOICE_BLADE
+
+	switch(choice)
+		if(SHRINEPRIEST_CHOICE_BLADE)
+			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN)
+			beltl = /obj/item/rogueweapon/sword/sabre/mulyeog
+			beltr = /obj/item/rogueweapon/scabbard/sword/kazengun
+			C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_2)
+			to_chat(H, span_notice(SHRINEPRIEST_TUTORIAL + " Although dedicated to the holy arts, you are not defenseless - your blade will see to that."))
+		// Sacrifice your neat sword for better holy magic and medicine! Kazengunese missionary, essentially.
+		if(SHRINEPRIEST_CHOICE_MIRACLES)
+			H.adjust_skillrank_up_to(/datum/skill/misc/medicine, SKILL_LEVEL_JOURNEYMAN)
+			C.grant_miracles(H, cleric_tier = CLERIC_T3, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_3)
+			to_chat(H, span_notice(SHRINEPRIEST_TUTORIAL + " Your single-minded devotion to the holy arts will prove useful in these violent lands."))
+
+	// OV Edit End
 	H.set_blindness(0)
-	beltl = /obj/item/rogueweapon/sword/sabre/mulyeog
-	beltr = /obj/item/rogueweapon/scabbard/sword/kazengun
+
+#undef SHRINEPRIEST_TUTORIAL
+#undef SHRINEPRIEST_CHOICE_MIRACLES
+#undef SHRINEPRIEST_CHOICE_BLADE


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->
- Shrine Priest and Shrine Guardian have been made into nomad adventurer classes, with their skills and stats adjusted to be on parity with other adventurer classes.
- Both classes now are given the proper amulets based on your patron, and Priest gets additional items / skills / etc. based on their patron. Pretty much the same things missionary gets, minus the outfit changes as we lack Kazengun equivalents of patron-specific gear.
- Now allow short races to play them (because there are now sprites for their clothes!)
- Shrine Priest no longer has a sword or crit resist, and instead T3 miracles + better starting items than Missionary to make it a side-grade to it.
- Shrine Guardian now has dodge expert instead of crit resist to emphasize their new "lightweight paladin" niche. Again, meant to be a side-grade to their adventurer equivalent in terms of design.
- Rewrote Shrine Priest's description completely.
- Rewrote most of Shrine Guardian's description.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [X] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [X] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [X] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

<img width="550" height="700" alt="2026-08-13_01-45-17" src="https://github.com/user-attachments/assets/0c64dc1f-e96b-4a01-a6ca-52b967ce1012" />

<img width="400" height="356" alt="2026-08-13_02-16-42" src="https://github.com/user-attachments/assets/7749be59-f7f8-49ef-a6a3-01ee17cf5ef9" />

Both classes show in the proper spots, and spawn properly ingame, stats and all!



## Why It's Good For The Game

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

It made little sense for these to be exclusive to mercenary. Shrine maidens are a bit more than sellswords, and a holy warrior from the East fits a similar bill. These classes would be in my opinion more interesting (and appropriate) as thematically different side-grades to pre-existing cleric classes. Shrine Guardians fit a neat niche as a fast-moving T1 miracle casting paladin that depends on spacing and careful movement instead of armor. I also thought that a shrine priest should have the option to have the same level of holy power as a Western missionary, with a natural cost of not having a weapon, (although they still have their belt throwing stars so they aren't completely defenseless!)

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
