### PR TITLE
Fixes Fruktte granules being invisible

### DIFF
--- a/modular_ochrevalley/code/game/items/teablends.dm
+++ b/modular_ochrevalley/code/game/items/teablends.dm
@@ -88,7 +88,7 @@
 
 /obj/item/reagent_containers/food/snacks/grown/rogue/baothablend
 	name = "Void Blend"
-	desc = "Perform the rite. Atropa, for her sickly sweet smile. Defiled lux, for her anguish of betrayal. This is the drink… Forget and sleep. Forget. Outrun your pain, if you dare." 
+	desc = "Perform the rite. Atropa, for her sickly sweet smile. Defiled lux, for her anguish of betrayal. This is the drink… Forget and sleep. Forget. Outrun your pain, if you dare."
 	icon = 'modular_ochrevalley/icons/roguetown/items/teablends.dmi'
 	icon_state = "baothablend"
 	tastes = list("sweet, sickly oblivion" = 1)
@@ -99,7 +99,7 @@
 
 /obj/item/reagent_containers/food/snacks/grown/rogue/forgottenlove
 	name = "The Sisters Blend"
-	desc = "An union of love and pain. Eorans and Baothans both fear this brew, for it promises the impossible. Or does it? " 
+	desc = "An union of love and pain. Eorans and Baothans both fear this brew, for it promises the impossible. Or does it? "
 	icon = 'modular_ochrevalley/icons/roguetown/items/teablends.dmi'
 	icon_state = "forgottenlove"
 	tastes = list("bitter, incomplete nostalgia" = 1)
@@ -110,7 +110,7 @@
 
 /obj/item/reagent_containers/food/snacks/grown/rogue/chai
 	name = "Chai Blend"
-	desc = "A spiced tea blend from the eastern lands. Kazengun and Lingyue both claim they have created it, while some western scholars say it is from eastern Raneshen. True esoterics claim it was actually invented by a foolish snake." 
+	desc = "A spiced tea blend from the eastern lands. Kazengun and Lingyue both claim they have created it, while some western scholars say it is from eastern Raneshen. True esoterics claim it was actually invented by a foolish snake."
 	icon = 'modular_ochrevalley/icons/roguetown/items/teablends.dmi'
 	icon_state = "chai"
 	tastes = list("bitterness" = 1, "a mouthful of cough-inducing powderiness" = 1)
@@ -121,7 +121,7 @@
 
 /obj/item/reagent_containers/food/snacks/grown/rogue/volfmilk
 	name = "Vargmjölk syrup"
-	desc = "A sticky, sugary granulate of chopped, dried and thickened blend of berries, predominantly the humble raspberry. Gronnites drink this in the cold nites of their homeland, to stay hardy and fend off the cold." 
+	desc = "A sticky, sugary granulate of chopped, dried and thickened blend of berries, predominantly the humble raspberry. Gronnites drink this in the cold nites of their homeland, to stay hardy and fend off the cold."
 	icon = 'modular_ochrevalley/icons/roguetown/items/teablends.dmi'
 	icon_state = "volfmilk"
 	tastes = list("syrupy fruitiness" = 1)
@@ -132,9 +132,9 @@
 
 /obj/item/reagent_containers/food/snacks/grown/rogue/frukkte
 	name = "Fruktte granules"
-	desc = "Fjallites carve glacier ice to cool down in their surprisingly hot summers and prepare Fruktte - dried and chopped berries, which are then cooked down to a thick syrup, which is diluted with melting ice. Invigorating and fresh." 
+	desc = "Fjallites carve glacier ice to cool down in their surprisingly hot summers and prepare Fruktte - dried and chopped berries, which are then cooked down to a thick syrup, which is diluted with melting ice. Invigorating and fresh."
 	icon = 'modular_ochrevalley/icons/roguetown/items/teablends.dmi'
-	icon_state = "frukkte"
+	icon_state = "fruktte"
 	tastes = list("syrupy fruitiness" = 1)
 	bitesize = 1
 	list_reagents = list(/datum/reagent/consumable/nutriment = 2)
@@ -143,7 +143,7 @@
 
 /obj/item/reagent_containers/food/snacks/grown/rogue/barleytea
 	name = "Prepared barley"
-	desc = "Toasted grains of barley mixed with clippings of artemisia, as bittering agents. Hammerhold dwarves swear by beers and ales, but they too recognize that sickness isn’t the time for drinking. So they simply made a non-alcoholic substitute." 
+	desc = "Toasted grains of barley mixed with clippings of artemisia, as bittering agents. Hammerhold dwarves swear by beers and ales, but they too recognize that sickness isn’t the time for drinking. So they simply made a non-alcoholic substitute."
 	icon = 'modular_ochrevalley/icons/roguetown/items/teablends.dmi'
 	icon_state = "barleytea"
 	tastes = list("astringent graininess" = 1)
@@ -154,7 +154,7 @@
 
 /obj/item/reagent_containers/food/snacks/grown/rogue/kvass
 	name = "Kvass Mixture"
-	desc = "Originally just a way to extend the shelf life of bread a little bit more, Kvass has become quite popular a summer (when cold) and winter (when warm) drink in Aavnr, making it synonymous with the steppes." 
+	desc = "Originally just a way to extend the shelf life of bread a little bit more, Kvass has become quite popular a summer (when cold) and winter (when warm) drink in Aavnr, making it synonymous with the steppes."
 	icon = 'modular_ochrevalley/icons/roguetown/items/teablends.dmi'
 	icon_state = "kvass"
 	tastes = list("fruity breadiness" = 1)
@@ -165,7 +165,7 @@
 
 /obj/item/reagent_containers/food/snacks/grown/rogue/avantare
 	name = "Avantare Blend"
-	desc = "Some ports make it illegal for sailors to not enter before they have consumed a quart of Avantare - a mixture of lemon juice and minthra, to fend off shipborne disease and bad breath." 
+	desc = "Some ports make it illegal for sailors to not enter before they have consumed a quart of Avantare - a mixture of lemon juice and minthra, to fend off shipborne disease and bad breath."
 	icon = 'modular_ochrevalley/icons/roguetown/items/teablends.dmi'
 	icon_state = "avantare"
 	tastes = list("fresh sourness" = 1)


### PR DESCRIPTION
## About The Pull Request
A simple one-line fix for fruktte's icon. Fruktte is known as "frukkte" internally, in every location except its icon name. The fruktte item was calling for "frukkte" rather than the proper fruktte, which makes sense considering everywhere else it's called "frukkte", except for this one weird outlier (and its proper, ingame name), but resulted in the granules appearing invisible. This should make the granules appear properly.

VSC also removed errant white spaces from the ends of the blend descriptions, it seems like. Probably fine, since it compiled and ran fine running the OV Dun World.
<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [*] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [N/A] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [*] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence
<img width="435" height="439" alt="Screenshot 2026-08-16 193316" src="https://github.com/user-attachments/assets/37a85458-c750-402b-8c0e-08cfe48a89ae" />

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game
Bug fixes good. Making drink blends visible and easier to brew good.
<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fruktte granules are no longer invisible. Fjallic fruit-drink enjoyers rejoice!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
