### PR TITLE
Tinkerer update, for realsies this time

### DIFF
--- a/modular_ochrevalley/code/game/items/contraption.dm
+++ b/modular_ochrevalley/code/game/items/contraption.dm
@@ -1,6 +1,7 @@
 /obj/item/rogueweapon/contraption/linker/mace
 	var/demomod = 0.05 //amount of a structure destroyed with a single hit
 	special = /datum/special_intent/dissassemble
+	associated_skill = /datum/skill/combat/maces
 
 /datum/intent/mace/demolish/lesser //defined downstream as I remove demolish from wrenches upstream.
 	desc = "A deliberate structure-breaking blow. Deals bonus damage equal to a percentage of a target structure's maximum integrity."

--- a/modular_ochrevalley/code/game/items/contraption.dm
+++ b/modular_ochrevalley/code/game/items/contraption.dm
@@ -20,12 +20,12 @@
 	post_icon_state = "aimwarn"
 	pre_icon_state = "trap"
 	respect_adjacency = TRUE
-	delay = 0.4 SECONDS //not a long delay, but perhaps too long. This can be countered easily by kicking the attacker
+	delay = 0.6 SECONDS //not a long delay, but perhaps too long. This can be countered easily by kicking the attacker
 	cooldown = 30 SECONDS
 	stamcost = 25
 	custom_skill = /datum/skill/craft/engineering
 	var/dam = 10 //applies this, and then this again, multiplied by five, through armor.
-	var/wrenchdelay = 1 SECONDS
+	var/wrenchdelay = 1.2 SECONDS
 
 /datum/special_intent/dissassemble/apply_hit(turf/T)
 	var/list/targets = list()

--- a/modular_ochrevalley/code/game/items/contraption.dm
+++ b/modular_ochrevalley/code/game/items/contraption.dm
@@ -169,3 +169,20 @@
 	T.take_damage(bonus_damage, BRUTE, d_type, 1)
 	to_chat(user, span_warning("Your blow expertly caves into [T]! (+[bonus_damage])"))
 	return TRUE
+
+/obj/item/rogueweapon/contraption/linker/mace/proc/demolish_obj(obj/O, mob/living/user)
+	if(QDELETED(O))
+		return FALSE
+
+	if(isnull(O.max_integrity))
+		return FALSE
+
+	if(O.max_integrity > 3000)
+		to_chat(user, "Too hard, sire!")
+		return FALSE
+
+	var/bonus_damage = round(O.max_integrity * demomod)
+
+	O.take_damage(bonus_damage, BRUTE, d_type, 1)
+	to_chat(user, span_warning("Your blow expertly caves into [O]! (+[bonus_damage])"))
+	return TRUE

--- a/modular_ochrevalley/code/game/items/contraption.dm
+++ b/modular_ochrevalley/code/game/items/contraption.dm
@@ -7,10 +7,6 @@
 	desc = "A deliberate structure-breaking blow. Deals bonus damage equal to a percentage of a target structure's maximum integrity."
 	demolition_mod = 2.5
 
-/obj/item/rogueweapon/contraption/linker/mace/big
-	gripped_intents = list(/datum/intent/use, /datum/intent/mace/strike, /datum/intent/mace/strike/dislocate, /datum/intent/mace/demolish/lesser)
-
-
 /obj/item/rogueweapon/contraption/linker/mace/preloaded
 	current_charge = 80
 

--- a/modular_ochrevalley/code/game/items/contraption.dm
+++ b/modular_ochrevalley/code/game/items/contraption.dm
@@ -139,3 +139,31 @@
 		else if(target.mob_biotypes & MOB_UNDEAD) //things that'd normally have easydismember as carbons take more damage
 			realdamage *= 1.5 //equivalent to dismember chance bonus from easydismember, and the damage boost recieved from hitting a torso dismember!
 		apply_generic_weapon_damage(target, realdamage, "blunt", target_zone, bclass = BCLASS_TWIST, full_pen = TRUE)
+
+
+/obj/item/rogueweapon/contraption/linker/mace/attack_turf(turf/T, mob/living/user, multiplier)
+	. = ..()
+	if(. && istype(user?.used_intent, /datum/intent/mace/demolish))
+		demolish_turf(T, user)
+
+/obj/item/rogueweapon/contraption/linker/mace/attack_obj(obj/O, mob/living/user)
+	. = ..()
+	if(. && istype(user?.used_intent, /datum/intent/mace/demolish))
+		demolish_obj(O, user)
+
+/obj/item/rogueweapon/contraption/linker/mace/proc/demolish_turf(turf/T, mob/living/user)
+	if(QDELETED(T))
+		return FALSE
+
+	if(isnull(T.max_integrity))
+		return FALSE
+
+	if(T.max_integrity > 3000)
+		to_chat(user, "Too hard, sire!")
+		return FALSE
+
+	var/bonus_damage = round(T.max_integrity * 0.15)
+
+	T.take_damage(bonus_damage, BRUTE, d_type, 1)
+	to_chat(user, span_warning("Your blow expertly caves into [T]! (+[bonus_damage])"))
+	return TRUE

--- a/modular_ochrevalley/code/game/items/contraption.dm
+++ b/modular_ochrevalley/code/game/items/contraption.dm
@@ -1,0 +1,141 @@
+/obj/item/rogueweapon/contraption/linker/mace
+	special = /datum/special_intent/dissassemble
+
+/datum/intent/mace/demolish/lesser //defined downstream as I remove demolish from wrenches upstream. For lovely upstream reasons
+	demolition_mod = 2.5
+
+/obj/item/rogueweapon/contraption/linker/mace/big
+	gripped_intents = list(/datum/intent/use, /datum/intent/mace/strike, /datum/intent/mace/strike/dislocate, /datum/intent/mace/demolish/lesser)
+
+
+/obj/item/rogueweapon/contraption/linker/mace/preloaded
+	current_charge = 80
+
+/obj/item/rogueweapon/contraption/linker/mace/big/preloaded
+	current_charge = 80
+
+/datum/special_intent/dissassemble
+	name = "Dissassemble"
+	desc = "Try to catch one of the target's limbs with your weapons, immobilizing both of you. After a mote of work, use your engineering skill to attempt to twist the limb- removing mechanical or otherwise loose limbs from vulnerable or unarmored targets, and attempting to dislocate otherwise."
+	tile_coordinates = list(list(0,0))
+	post_icon_state = "aimwarn"
+	pre_icon_state = "trap"
+	respect_adjacency = TRUE
+	delay = 0.4 SECONDS //not a long delay, but perhaps too long. This can be countered easily by kicking the attacker
+	cooldown = 30 SECONDS
+	stamcost = 25
+	custom_skill = /datum/skill/craft/engineering
+	var/dam = 10 //applies this, and then this again, multiplied by five, through armor.
+	var/wrenchdelay = 1 SECONDS
+
+/datum/special_intent/dissassemble/apply_hit(turf/T)
+	var/list/targets = list()
+	var/target_zone = get_aimed_zone(howner)
+	var/vulnerableto = FALSE
+	for(var/mob/living/L in get_hearers_in_view(0, T)) //prioritize based on what mobs we'll hurt the most, as we'll choose one target in the end
+		var/priority = 1
+		if(L == howner)
+			continue
+		if(ishuman(L))
+			var/mob/living/carbon/human/H = L
+			if(HAS_TRAIT(L, TRAIT_IRONMAN))
+				priority = 5
+			else
+				var/obj/item/bodypart/bodypart = H.get_bodypart(target_zone)
+				if(bodypart && !QDELETED(bodypart))
+					if(bodypart.rotted || bodypart.skeletonized || HAS_TRAIT(L, TRAIT_EASYDISMEMBER))
+						priority = 3
+					if(bodypart.status == BODYPART_ROBOTIC)
+						priority = 5
+		else if(L.mob_biotypes & MOB_ROBOTIC)
+			priority = 2
+		if(L.stat)
+			priority = min(0, priority - 3)
+		else if(!(L.mobility_flags & MOBILITY_STAND))
+			priority = min(0, priority - 1)
+		targets[L] = priority
+	targets = sortTim(targets, GLOBAL_PROC_REF(cmp_numeric_dsc), TRUE)
+	var/mob/living/finaltarget
+	if(targets.len)
+		finaltarget = targets[1]
+	if(finaltarget)
+		if(finaltarget.has_status_effect(/datum/status_effect/debuff/exposed) || finaltarget.has_status_effect(/datum/status_effect/debuff/vulnerable))
+			vulnerableto = TRUE
+		apply_generic_weapon_damage(finaltarget, dam, "blunt", target_zone, bclass = BCLASS_TWIST, no_pen = TRUE)
+		playsound(finaltarget.loc, 'sound/items/bsmithfail.ogg', 100, TRUE)
+		howner.Immobilize(wrenchdelay)
+		finaltarget.Immobilize(wrenchdelay)
+		howner.changeNext_move(wrenchdelay) //you don't get to do anything until you finish the move
+		addtimer(CALLBACK(src, PROC_REF(wrenchlimb), finaltarget, target_zone, vulnerableto), wrenchdelay)
+		if(ishuman(finaltarget))
+			var/mob/living/carbon/human/humantarget = finaltarget
+			var/obj/item/bodypart/bodyparttarget = humantarget.get_bodypart(target_zone)
+			if(bodyparttarget && !QDELETED(bodyparttarget))
+				finaltarget.visible_message(span_warning("[howner] clamps [iparent] around [humantarget]'s [bodyparttarget]!"), span_userdanger("[howner] clamps [iparent] around your [bodyparttarget]!"))
+				var/obj/item/clothing/prot = humantarget.get_best_worn_armor(target_zone, "blunt")
+				if(prot)
+					var/armoramount = prot.armor.getRating("blunt")
+					if(armoramount >= DR_LIGHT) //nearly any blunt protection. This wrenches plate as good as it does robots, though
+						vulnerableto = TRUE
+					else if(armoramount <= DR_SUPER) //good, padded armor nosells the vulnerability completely
+						vulnerableto = FALSE
+			else
+				finaltarget.visible_message(span_warning("[howner] clamps [iparent] around [humantarget]!"), span_userdanger("[howner] clamps [iparent] around you!"))
+		else
+			finaltarget.visible_message(span_warning("[howner] clamps [iparent] around [finaltarget]!"), span_userdanger("[howner] clamps [iparent] around you!"))
+	..()
+
+/datum/special_intent/dissassemble/proc/wrenchlimb(var/mob/living/target, target_zone, vulnerable = FALSE)
+	var/userstrength = max(0, howner.STASTR - 10)
+	var/robottarget = FALSE
+	var/trydismember = FALSE
+	var/realdamage = dam
+	if(get_dist(howner, target) > 1)//keep close to the target
+		howner.visible_message(span_warning("[howner] lost their grip on [target]!"), span_userdanger("You've lost your grip on [target]!"))
+		return FALSE
+	if(howner.stat != CONSCIOUS || howner.IsParalyzed() || howner.IsStun() || QDELETED(howner) || !isturf(howner.loc) || !(howner.mobility_flags & MOBILITY_STAND))
+		howner.visible_message(span_warning("[howner] lost their grip on [target]!"), span_userdanger("You've lost your grip on [target]!"))
+		return FALSE //don't lose your sight of the target
+	if(isitem(iparent))
+		var/obj/item/I = iparent
+		if(!locate(I) in howner.held_items)
+			howner.visible_message(span_warning("[howner] lost their grip on [I]!"), span_userdanger("You've lost your grip on [I]!"))
+			return
+		if(I.gripped_intents && I.wielded)
+			userstrength += 2 //the big wrench is more effective at this attack, it gets more leverage when wielded
+		realdamage = get_complex_damage(I, howner)
+	if(ishuman(target))
+		var/mob/living/carbon/H = target
+		apply_generic_weapon_damage(H, realdamage * 2, "blunt", target_zone, bclass = BCLASS_TWIST, full_pen = TRUE)//simple, really. this is all that's applied
+		var/obj/item/bodypart/bodypart = H.get_bodypart(target_zone)
+		if(bodypart && !QDELETED(bodypart))
+			if(bodypart.status == BODYPART_ROBOTIC || HAS_TRAIT(target, TRAIT_IRONMAN))
+				robottarget = TRUE
+				trydismember = TRUE
+			if(bodypart.rotted || bodypart.skeletonized || HAS_TRAIT(target, TRAIT_EASYDISMEMBER))
+				trydismember = TRUE
+			if(trydismember)
+				if(robottarget)
+					userstrength += howner.get_skill_level(/datum/skill/craft/engineering)
+				if(!vulnerable)
+					userstrength = min(5, userstrength / 2)
+				var/attemptforce = realdamage * min(userstrength, 10)
+				if(prob(bodypart.dismemberment_chance_from_force(attemptforce)))
+					if(istype(bodypart, /obj/item/bodypart/head) || istype(bodypart, /obj/item/bodypart/chest)) //we don't decap or disembowel.
+						apply_generic_weapon_damage(H, realdamage, "blunt", target_zone, bclass = BCLASS_TWIST, full_pen = TRUE) //instead, just do another damage proc
+					else if(bodypart.dismember(BRUTE, BCLASS_TWIST, howner, damage = attemptforce))
+						if(robottarget)
+							playsound(howner.loc, 'sound/items/beartrap2.ogg', 100, FALSE)
+						else
+							playsound(howner.loc, 'sound/items/beartrap.ogg', 100, FALSE)
+						H.visible_message(span_warning("[howner] twists [H]'s [bodypart] clean off!"), span_userdanger("[howner] tears [bodypart] from your body!"))
+						return TRUE
+			playsound(howner.loc, 'sound/items/garrotebreak.ogg', 100, FALSE)
+			H.visible_message(span_warning("[howner] twists [H]'s [bodypart] with [iparent]!"), span_userdanger("[howner] painfully twists your [bodypart] with [iparent]!"))
+	else  //simplemob! we deal double damage, with a bonus against equivalent biotypes
+		realdamage *= 2
+		if(target.mob_biotypes & MOB_ROBOTIC) //theoretically, very powerful. In practice, there are no robotic simplemobs.
+			realdamage *= howner.get_skill_level(/datum/skill/craft/engineering)
+		else if(target.mob_biotypes & MOB_UNDEAD) //things that'd normally have easydismember as carbons take more damage
+			realdamage *= 1.5 //equivalent to dismember chance bonus from easydismember, and the damage boost recieved from hitting a torso dismember!
+		apply_generic_weapon_damage(target, realdamage, "blunt", target_zone, bclass = BCLASS_TWIST, full_pen = TRUE)

--- a/modular_ochrevalley/code/game/items/contraption.dm
+++ b/modular_ochrevalley/code/game/items/contraption.dm
@@ -1,7 +1,9 @@
 /obj/item/rogueweapon/contraption/linker/mace
+	var/demomod = 0.05 //amount of a structure destroyed with a single hit
 	special = /datum/special_intent/dissassemble
 
 /datum/intent/mace/demolish/lesser //defined downstream as I remove demolish from wrenches upstream.
+	desc = "A deliberate structure-breaking blow. Deals bonus damage equal to a percentage of a target structure's maximum integrity."
 	demolition_mod = 2.5
 
 /obj/item/rogueweapon/contraption/linker/mace/big
@@ -162,7 +164,7 @@
 		to_chat(user, "Too hard, sire!")
 		return FALSE
 
-	var/bonus_damage = round(T.max_integrity * 0.15)
+	var/bonus_damage = round(T.max_integrity * demomod)
 
 	T.take_damage(bonus_damage, BRUTE, d_type, 1)
 	to_chat(user, span_warning("Your blow expertly caves into [T]! (+[bonus_damage])"))

--- a/modular_ochrevalley/code/game/items/contraption.dm
+++ b/modular_ochrevalley/code/game/items/contraption.dm
@@ -105,7 +105,7 @@
 		realdamage = get_complex_damage(I, howner)
 	if(ishuman(target))
 		var/mob/living/carbon/H = target
-		apply_generic_weapon_damage(H, realdamage, "blunt", target_zone, bclass = BCLASS_TWIST, full_pen = TRUE)//simple, really. this is all that's applied
+		apply_generic_weapon_damage(H, realdamage * 2.5, "blunt", target_zone, bclass = BCLASS_TWIST)
 		var/obj/item/bodypart/bodypart = H.get_bodypart(target_zone)
 		if(bodypart && !QDELETED(bodypart))
 			if(bodypart.status == BODYPART_ROBOTIC || HAS_TRAIT(target, TRAIT_IRONMAN))
@@ -121,7 +121,7 @@
 				var/attemptforce = realdamage * min(userstrength, 10)
 				if(prob(bodypart.dismemberment_chance_from_force(attemptforce))) //checks chance to dismember.
 					if(istype(bodypart, /obj/item/bodypart/head) || istype(bodypart, /obj/item/bodypart/chest)) //we don't decap or disembowel.
-						apply_generic_weapon_damage(H, realdamage, "blunt", target_zone, bclass = BCLASS_TWIST, full_pen = TRUE) //instead, just do another damage proc
+						apply_generic_weapon_damage(H, realdamage, "blunt", target_zone, bclass = BCLASS_BLUNT, full_pen = TRUE) //instead, just do another damage proc
 					else if(bodypart.dismember(BRUTE, BCLASS_TWIST, howner, damage = attemptforce))//armor is checked in this proc. if there's armor, we don't get the dismember. this can, however, deal particularly nasty damage to armor with poor blunt protection
 						if(robottarget)
 							playsound(howner.loc, 'sound/items/beartrap2.ogg', 100, FALSE)
@@ -132,12 +132,12 @@
 			playsound(howner.loc, 'sound/items/garrotebreak.ogg', 100, FALSE)
 			H.visible_message(span_warning("[howner] twists [H]'s [bodypart] with [iparent]!"), span_userdanger("[howner] painfully twists your [bodypart] with [iparent]!"))
 	else  //simplemob! we deal double damage, with a bonus against equivalent biotypes
-		realdamage *= 2
+		realdamage *= 2.5
 		if(target.mob_biotypes & MOB_ROBOTIC) //theoretically, very powerful. In practice, there are no robotic simplemobs.
 			realdamage *= howner.get_skill_level(/datum/skill/craft/engineering)
 		else if(target.mob_biotypes & MOB_UNDEAD) //things that'd normally have easydismember as carbons take more damage
 			realdamage *= 1.5 //equivalent to dismember chance bonus from easydismember, and the damage boost recieved from hitting a torso dismember!
-		apply_generic_weapon_damage(target, realdamage, "blunt", target_zone, bclass = BCLASS_TWIST, full_pen = TRUE)
+		apply_generic_weapon_damage(target, realdamage, "blunt", target_zone, bclass = BCLASS_BLUNT, full_pen = TRUE)
 
 
 /obj/item/rogueweapon/contraption/linker/mace/attack_turf(turf/T, mob/living/user, multiplier)

--- a/modular_ochrevalley/code/game/items/contraption.dm
+++ b/modular_ochrevalley/code/game/items/contraption.dm
@@ -20,12 +20,12 @@
 	post_icon_state = "aimwarn"
 	pre_icon_state = "trap"
 	respect_adjacency = TRUE
-	delay = 0.6 SECONDS //not a long delay, but perhaps too long. This can be countered easily by kicking the attacker
-	cooldown = 30 SECONDS
+	delay = 0.5 SECONDS //not a long delay, but perhaps too long. This can be countered easily by kicking the attacker
+	cooldown = 20 SECONDS
 	stamcost = 25
 	custom_skill = /datum/skill/craft/engineering
-	var/dam = 10 //applies this, and then this again, multiplied by five, through armor.
-	var/wrenchdelay = 1.2 SECONDS
+	var/dam = 10
+	var/wrenchdelay = 1 SECONDS
 
 /datum/special_intent/dissassemble/apply_hit(turf/T)
 	var/list/targets = list()
@@ -60,7 +60,7 @@
 	if(finaltarget)
 		if(finaltarget.has_status_effect(/datum/status_effect/debuff/exposed) || finaltarget.has_status_effect(/datum/status_effect/debuff/vulnerable))
 			vulnerableto = TRUE
-		apply_generic_weapon_damage(finaltarget, dam, "blunt", target_zone, bclass = BCLASS_TWIST, no_pen = TRUE)
+		apply_generic_weapon_damage(finaltarget, dam, "blunt", target_zone, bclass = BCLASS_TWIST)
 		playsound(finaltarget.loc, 'sound/items/bsmithfail.ogg', 100, TRUE)
 		howner.Immobilize(wrenchdelay)
 		finaltarget.Immobilize(wrenchdelay)
@@ -105,7 +105,7 @@
 		realdamage = get_complex_damage(I, howner)
 	if(ishuman(target))
 		var/mob/living/carbon/H = target
-		apply_generic_weapon_damage(H, realdamage * 2, "blunt", target_zone, bclass = BCLASS_TWIST, full_pen = TRUE)//simple, really. this is all that's applied
+		apply_generic_weapon_damage(H, realdamage, "blunt", target_zone, bclass = BCLASS_TWIST, full_pen = TRUE)//simple, really. this is all that's applied
 		var/obj/item/bodypart/bodypart = H.get_bodypart(target_zone)
 		if(bodypart && !QDELETED(bodypart))
 			if(bodypart.status == BODYPART_ROBOTIC || HAS_TRAIT(target, TRAIT_IRONMAN))

--- a/modular_ochrevalley/code/game/items/contraption.dm
+++ b/modular_ochrevalley/code/game/items/contraption.dm
@@ -1,7 +1,7 @@
 /obj/item/rogueweapon/contraption/linker/mace
 	special = /datum/special_intent/dissassemble
 
-/datum/intent/mace/demolish/lesser //defined downstream as I remove demolish from wrenches upstream. For lovely upstream reasons
+/datum/intent/mace/demolish/lesser //defined downstream as I remove demolish from wrenches upstream.
 	demolition_mod = 2.5
 
 /obj/item/rogueweapon/contraption/linker/mace/big

--- a/modular_ochrevalley/code/game/items/contraption.dm
+++ b/modular_ochrevalley/code/game/items/contraption.dm
@@ -122,10 +122,10 @@
 				if(!vulnerable)
 					userstrength = min(5, userstrength / 2)
 				var/attemptforce = realdamage * min(userstrength, 10)
-				if(prob(bodypart.dismemberment_chance_from_force(attemptforce)))
+				if(prob(bodypart.dismemberment_chance_from_force(attemptforce))) //checks chance to dismember.
 					if(istype(bodypart, /obj/item/bodypart/head) || istype(bodypart, /obj/item/bodypart/chest)) //we don't decap or disembowel.
 						apply_generic_weapon_damage(H, realdamage, "blunt", target_zone, bclass = BCLASS_TWIST, full_pen = TRUE) //instead, just do another damage proc
-					else if(bodypart.dismember(BRUTE, BCLASS_TWIST, howner, damage = attemptforce))
+					else if(bodypart.dismember(BRUTE, BCLASS_TWIST, howner, damage = attemptforce))//armor is checked in this proc. if there's armor, we don't get the dismember. this can, however, deal particularly nasty damage to armor with poor blunt protection
 						if(robottarget)
 							playsound(howner.loc, 'sound/items/beartrap2.ogg', 100, FALSE)
 						else

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -64,6 +64,16 @@
 /datum/outfit/job/roguetown/adventurer/tinkerer/pre_equip(mob/living/carbon/human/H)
 	..()
 	to_chat(H, span_warning("In another life, your intellect, connections, and aptitude for blending well-worked bronze with Arcyne mysteries would have made for a fine guildsman. Whilst unnaccustomed to combat, your cleverness and inventions offer you a novel edge."))
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/jacket/artijacket
+	head = /obj/item/clothing/mask/rogue/spectacles/golden //DRIP
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+	backl = /obj/item/storage/backpack/rogue/backpack
+	pants = /obj/item/clothing/under/roguetown/trou/leather
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
+	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
+	belt = /obj/item/storage/belt/rogue/leather
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+	gloves = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves/blacksmith
 	if(H.mind)
 		var/gadgets = list("Pistol", "Rifle", "Crossbow", "Grappling Hook", "Clockwork Drill", "Voltic Gauntlets", "Bronze Limbs")
 		var/gadget_choice = input(H, "Choose a gadget.", "YOUR LATEST CREATION") as anything in gadgets
@@ -122,16 +132,6 @@
 				beltr = /obj/item/rogueweapon/contraption/linker/mace/preloaded
 			if("Massive Wrench")
 				beltr = /obj/item/rogueweapon/contraption/linker/mace/big/preloaded
-	armor = /obj/item/clothing/suit/roguetown/armor/leather/jacket/artijacket
-	head = /obj/item/clothing/mask/rogue/spectacles/golden //DRIP
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
-	backl = /obj/item/storage/backpack/rogue/backpack
-	pants = /obj/item/clothing/under/roguetown/trou/leather
-	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
-	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
-	belt = /obj/item/storage/belt/rogue/leather
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-	gloves = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves/blacksmith
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1,

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -116,7 +116,7 @@
 					var/obj/item/bodypart/l_leg/prosthetic/bronzeleft/leftbleg = new()
 					leftbleg.attach_limb(H)
 		var/wrenches = list("Compact Wrench", "Massive Wrench")
-		var/wrench_choice = input(H, "Choose your tool.", "TINKERER'S PRIDE") as anything in wrenches
+		var/wrench_choice = input(H, "Choose your tool!", "TINKERER'S PRIDE") as anything in wrenches
 		switch(wrench_choice)
 			if("Compact Wrench")
 				beltr = /obj/item/rogueweapon/contraption/linker/mace/preloaded

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -29,67 +29,66 @@
 	name = "Itinerant Tinkerer"
 	tutorial = "In another life, your intellect, connections, and aptitude for blending well-worked bronze with Arcyne mysteries would have made for a fine guildsman. Whilst unnaccustomed to combat, your cleverness and inventions offer you a novel edge."
 	outfit = /datum/outfit/job/roguetown/adventurer/tinkerer
-	cmode_music = 'sound/music/cmode/adventurer/combat_outlander3.ogg'
-	traits_applied = list(TRAIT_SEEPRICES, TRAIT_INTELLECTUAL, TRAIT_ARCYNE, TRAIT_SMITHING_EXPERT, TRAIT_LEYLINE_ATTUNEMENT)
+	cmode_music = 'sound/music/combat_dungeoneer.ogg'
+	traits_applied = list(TRAIT_TRAINED_SMITH, TRAIT_INTELLECTUAL, TRAIT_ARCYNE, TRAIT_SMITHING_EXPERT)
 	subclass_stats = list(
 		STATKEY_INT = 3,
 		STATKEY_PER = 2,
-		STATKEY_SPD = 2,
-		STATKEY_STR = -1,
+		STATKEY_SPD = 1,
 	)
+	subclass_mage_aspects = list("mastery" = FALSE, "major" = 0, "minor" = 1, "utilities" = 4, "locked_aspects" = list(/datum/magic_aspect/artifice), "ward" = TRUE)
 	subclass_skills = list(
 		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_NOVICE,
-		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/knives = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/firearms = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/crossbows = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/sneaking = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/craft/traps = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/traps = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/crafting = SKILL_LEVEL_NOVICE,//besides engineering, they have the bare minimum to maintain most equipment. Meant to run a repair-support role in most parties
 		/datum/skill/craft/weaponsmithing = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/armorsmithing = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/blacksmithing = SKILL_LEVEL_NOVICE,
-		/datum/skill/craft/sewing = SKILL_LEVEL_NOVICE,
-		/datum/skill/craft/tanning = SKILL_LEVEL_NOVICE,
-		/datum/skill/craft/smelting = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/engineering = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/engineering = SKILL_LEVEL_EXPERT,
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE
 	)
-	extra_context = "Chooses between a Pistol, a Grappler, a Clockwork Drill, Voltic Gauntlets (+2 STR, -2 SPD), Bronze Arms(+2 STR, -2 SPD), or Bronze Legs."
+	extra_context = "Chooses between a Pistol, a Rifle, a Grappler, a Clockwork Drill, Voltic Gauntlets, or Bronze Limbs. May have a big wrench, or a small wrench."
 
 /datum/outfit/job/roguetown/adventurer/tinkerer/pre_equip(mob/living/carbon/human/H)
 	..()
 	to_chat(H, span_warning("In another life, your intellect, connections, and aptitude for blending well-worked bronze with Arcyne mysteries would have made for a fine guildsman. Whilst unnaccustomed to combat, your cleverness and inventions offer you a novel edge."))
 	if(H.mind)
-		var/gadgets = list("Pistol", "Grappling Hook", "Clockwork Drill", "Voltic Gauntlets", "Bronze Arms", "Bronze Legs")
-		var/gadget_choice = input(H, "Choose a gadget.", "YOUR LATEST MASTERPIECE") as anything in gadgets
+		var/gadgets = list("Pistol", "Rifle", "Crossbow", "Grappling Hook", "Clockwork Drill", "Voltic Gauntlets", "Bronze Limbs")
+		var/gadget_choice = input(H, "Choose a gadget.", "YOUR LATEST CREATION") as anything in gadgets
 		H.set_blindness(0)
 		switch(gadget_choice)
 			if("Pistol")
-				H.adjust_skillrank_up_to(/datum/skill/combat/firearms, SKILL_LEVEL_APPRENTICE, TRUE)
 				beltl = /obj/item/quiver/bulletpouch/iron
-				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/arquebus/pistol
+				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/arquebus/pistol
 				l_hand = /obj/item/powderflask
+			if("Rifle")
+				beltl = /obj/item/quiver/bulletpouch/iron
+				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/arquebus
+				l_hand = /obj/item/powderflask
+			if("Crossbow")
+				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+				beltl = /obj/item/quiver/bolt/standard
 			if("Grappling Hook")
 				H.adjust_skillrank_up_to(/datum/skill/misc/climbing, SKILL_LEVEL_EXPERT, TRUE)
 				r_hand = /obj/item/grapplinghook
 			if("Clockwork Drill")
 				H.adjust_skillrank_up_to(/datum/skill/labor/mining, SKILL_LEVEL_APPRENTICE, TRUE)
-				r_hand = /obj/item/rogueweapon/contraption/pick/drill/precharged
+				backr = /obj/item/rogueweapon/contraption/pick/drill/precharged
 			if("Voltic Gauntlets")
 				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_APPRENTICE, TRUE)
 				gloves = /obj/item/clothing/gloves/roguetown/chain/contraption/voltic/precharged
-				H.change_stat(STATKEY_STR, 2) //we're gonna make the gauntlet tinkerers punchier and slower. trust me, they'll want this. This changes them from a +2 spd, -1 str class, to a +1 str class
-				H.change_stat(STATKEY_SPD, -2)
-				to_chat(H, span_warning("Compared to your average Tinkerer, I'm a bit burly (+2 Strength, -2 Speed)"))
-			if("Bronze Arms")
-				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_APPRENTICE, TRUE)
-				H.change_stat(STATKEY_STR, 2) //Tinkerers with big buff metal arms *also* get to feel kinda buff. for a rogue.
-				H.change_stat(STATKEY_SPD, -2)
-				to_chat(H, span_warning("Compared to your average Tinkerer, I'm a bit burly (+2 Strength, -2 Speed)"))
+			if("Bronze Limbs")
 				var/obj/item/bodypart/rightarm = H.get_bodypart(BODY_ZONE_R_ARM)
 				if(rightarm)
 					rightarm.drop_limb()
@@ -104,8 +103,6 @@
 				if(H.charflaws.len)
 					var/obj/item/bodypart/l_arm/prosthetic/bronzeleft/leftbarm = new()
 					leftbarm.attach_limb(H)
-			if("Bronze Legs")
-				H.adjust_skillrank_up_to(/datum/skill/misc/athletics, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				var/obj/item/bodypart/rightleg = H.get_bodypart(BODY_ZONE_R_LEG)
 				if(rightleg)
 					rightleg.drop_limb()
@@ -120,30 +117,29 @@
 				if(H.charflaws.len)
 					var/obj/item/bodypart/l_leg/prosthetic/bronzeleft/leftbleg = new()
 					leftbleg.attach_limb(H)
+		var/wrenches = list("Compact Wrench", "Massive Wrench")
+		var/wrench_choice = input(H, "Choose your tool.", "TINKERER'S PRIDE") as anything in wrenches
+		switch(wrench_choice)
+			if("Compact Wrench")
+				beltr = /obj/item/rogueweapon/contraption/linker/mace/preloaded
+			if("Massive Wrench")
+				beltr = /obj/item/rogueweapon/contraption/linker/mace/big/preloaded
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/jacket/artijacket
+	head = /obj/item/clothing/mask/rogue/spectacles/golden //DRIP
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 	backl = /obj/item/storage/backpack/rogue/backpack
-	backr = /obj/item/rogueweapon/scabbard/sheath
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-	beltr = /obj/item/flashlight/flare/torch/lantern
 	belt = /obj/item/storage/belt/rogue/leather
 	backpack_contents = list(
-		/obj/item/rogueweapon/huntingknife/idagger/steel/parrying = 1,
-		/obj/item/recipe_book/survival = 1,
+		/obj/item/rogueweapon/huntingknife = 1,
+		/obj/item/rogueweapon/scabbard/sheath = 1,
 		/obj/item/chalk = 1,
-		/obj/item/rogueweapon/handsaw = 1,
-		/obj/item/rogueweapon/hammer/iron,
-		/obj/item/clothing/mask/rogue/spectacles/golden = 1// a good tinkerer needs a pair of sickass looking goggles. In backpack so vices won't replace 'em
+		/obj/item/rogueweapon/hammer/iron = 1,
+		/obj/item/rogueweapon/tongs = 1,
+		/obj/item/flashlight/flare/torch/lantern = 1,
 		)
-	H.mind.AddSpell(new /datum/action/cooldown/spell/matthios/barter_secular) //They have the Connections like an antiquarian does, but none of the alchemical tricks
-	H.mind.AddSpell(new /datum/action/cooldown/spell/touch/prestidigitation)//A tinkerer is a bit magical, but one of their spells has to be mending
-	H.mind.AddSpell(new /datum/action/cooldown/spell/mending)
-	if(!LAZYLEN(H.mind.mage_aspect_config))
-		H.mind.setup_mage_aspects(list("mastery" = FALSE, "major" = 0, "minor" = 0, "utilities" = 2))
-		H.mind.check_learnspell()
 
 /obj/item/clothing/gloves/roguetown/chain/contraption/voltic/precharged
 	current_charge = 20

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -130,6 +130,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 	belt = /obj/item/storage/belt/rogue/leather
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	gloves = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves/blacksmith
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife = 1,

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -46,7 +46,7 @@
 		/datum/skill/combat/crossbows = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/sneaking = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/sneaking = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_JOURNEYMAN,

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -74,7 +74,7 @@
 				l_hand = /obj/item/powderflask
 			if("Rifle")
 				beltl = /obj/item/quiver/bulletpouch/iron
-				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/arquebus
+				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/arquebus
 				l_hand = /obj/item/powderflask
 			if("Crossbow")
 				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -56,7 +56,7 @@
 		/datum/skill/craft/armorsmithing = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/blacksmithing = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/engineering = SKILL_LEVEL_EXPERT,
-		/datum/skill/craft/smelting = SKILL_LEVEL_JOURNEYMAN
+		/datum/skill/craft/smelting = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE
 	)
 	extra_context = "Chooses between a Pistol, a Rifle, a Grappler, a Clockwork Drill, Voltic Gauntlets, or Bronze Limbs. May have a big wrench, or a small wrench."

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -70,7 +70,7 @@
 		switch(gadget_choice)
 			if("Pistol")
 				beltl = /obj/item/quiver/bulletpouch/iron
-				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/arquebus/pistol
+				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/arquebus/pistol
 				l_hand = /obj/item/powderflask
 			if("Rifle")
 				beltl = /obj/item/quiver/bulletpouch/iron
@@ -129,6 +129,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 	belt = /obj/item/storage/belt/rogue/leather
+	gloves = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves/blacksmith
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1,

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -56,6 +56,7 @@
 		/datum/skill/craft/armorsmithing = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/blacksmithing = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/engineering = SKILL_LEVEL_EXPERT,
+		/datum/skill/craft/smelting = SKILL_LEVEL_JOURNEYMAN
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE
 	)
 	extra_context = "Chooses between a Pistol, a Rifle, a Grappler, a Clockwork Drill, Voltic Gauntlets, or Bronze Limbs. May have a big wrench, or a small wrench."

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -80,13 +80,10 @@
 				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 				beltl = /obj/item/quiver/bolt/standard
 			if("Grappling Hook")
-				H.adjust_skillrank_up_to(/datum/skill/misc/climbing, SKILL_LEVEL_EXPERT, TRUE)
 				r_hand = /obj/item/grapplinghook
 			if("Clockwork Drill")
-				H.adjust_skillrank_up_to(/datum/skill/labor/mining, SKILL_LEVEL_APPRENTICE, TRUE)
 				backr = /obj/item/rogueweapon/contraption/pick/drill/precharged
 			if("Voltic Gauntlets")
-				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_APPRENTICE, TRUE)
 				gloves = /obj/item/clothing/gloves/roguetown/chain/contraption/voltic/precharged
 			if("Bronze Limbs")
 				var/obj/item/bodypart/rightarm = H.get_bodypart(BODY_ZONE_R_ARM)

--- a/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/modular_ochrevalley/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -30,13 +30,13 @@
 	tutorial = "In another life, your intellect, connections, and aptitude for blending well-worked bronze with Arcyne mysteries would have made for a fine guildsman. Whilst unnaccustomed to combat, your cleverness and inventions offer you a novel edge."
 	outfit = /datum/outfit/job/roguetown/adventurer/tinkerer
 	cmode_music = 'sound/music/combat_dungeoneer.ogg'
-	traits_applied = list(TRAIT_TRAINED_SMITH, TRAIT_INTELLECTUAL, TRAIT_ARCYNE, TRAIT_SMITHING_EXPERT)
+	traits_applied = list(TRAIT_SEEPRICES, TRAIT_INTELLECTUAL, TRAIT_ARCYNE, TRAIT_SMITHING_EXPERT)
 	subclass_stats = list(
 		STATKEY_INT = 3,
 		STATKEY_PER = 2,
 		STATKEY_SPD = 1,
 	)
-	subclass_mage_aspects = list("mastery" = FALSE, "major" = 0, "minor" = 1, "utilities" = 4, "locked_aspects" = list(/datum/magic_aspect/artifice), "ward" = TRUE)
+	subclass_mage_aspects = list("mastery" = FALSE, "major" = 0, "minor" = 1, "utilities" = 3, "locked_aspects" = list(/datum/magic_aspect/artifice))
 	subclass_skills = list(
 		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_NOVICE,

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3713,6 +3713,8 @@
 #include "modular_causticcove\code\modules\accessability\epilepsy.dm"
 #include "modular_causticcove\code\modules\accessability\epilepsy_prefs.dm"
 #include "modular_ochrevalley\code\modules\mob\living\become_deadite.dm"
+#include "modular_ochrevalley\code\game\items\livestockbait.dm"
+#include "modular_ochrevalley\code\game\items\contraption.dm"
 #include "modular_causticcove\code\modules\antagonists\roguetown\villains\werewolf\werewolf_transformation_resist.dm"
 #include "modular_causticcove\code\modules\baycode_port_helpers\baycode_port_helpers.dm"
 #include "modular_causticcove\code\modules\baycode_port_helpers\chemcolour.dm"

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3713,7 +3713,6 @@
 #include "modular_causticcove\code\modules\accessability\epilepsy.dm"
 #include "modular_causticcove\code\modules\accessability\epilepsy_prefs.dm"
 #include "modular_ochrevalley\code\modules\mob\living\become_deadite.dm"
-#include "modular_ochrevalley\code\game\items\livestockbait.dm"
 #include "modular_ochrevalley\code\game\items\contraption.dm"
 #include "modular_causticcove\code\modules\antagonists\roguetown\villains\werewolf\werewolf_transformation_resist.dm"
 #include "modular_causticcove\code\modules\baycode_port_helpers\baycode_port_helpers.dm"


### PR DESCRIPTION
## About The Pull Request
expected pr after awhile playtesting tinkerer. This brings them more in line as an advent version of Artificer-

- removes secular barter and skilled appraisal. it's a holdover from the antiquarian identity, and I find it really doesn't add much to the adventuring gameplay loop- especially slowing things down if you want to be efficient with it, after the nerf. We can leave the gold-gain niche to the antiquarian, sad as I am
- in place of skilled appraisal, gain Trained Smith, which allows them to automatically add nearby items to anvil recipes. Lower power trait, but it brings their trait list more in line with the artificer. 
- makes their spell kit more of an artificer-lite. Compared to before, they now have arcyne forge, and an two utility point. I've tentatively put ward on them to see how it plays out, but i'm not terribly attached to the idea. 
The extra utility points are also there to compensate for an upcoming removal of the Mending spell


- makes their statspread less specialized- removed strength penalty, and removed 1 speed. They're smiths, and ought not be weaker than average
- bronze limbs are a neat option, and, after earlier deliberation, gives them all of the limbs- on the virtue, these cost only 3 TRI for a full set, so we can see how it plays out and revert if necessary
- they may choose a rifle. Getting a feel for pistols and rifles in play, the two are clear sidegrades- the rifle is big, and slow to draw, but able to potshot from a range, whilst the pistol serves as a quick emergency sidearm in situations where a rifle is too big and slow. 
- They may now choose a Crossbow, again with apprentice skill. If they prefer a more pragmatic, viable armament, instead of a goofy contraption, and want an advent-artificer archetype otherwise, this is a workable option
- they gain apprentice firearms and crossbow skills by default, instead of when these options are chosen. These are the weapons which use engineering to craft, and are balanced on a relatively similar curve. I think this'll improve balance between the two by allowing tinkerers to choose whichever feels better amongst the two, and see where one might eclipse the other.
-  Exchanges their skill in Knives for apprentice skill with Maces. They'll have a hunting knife and novice, still, but their intended weapon is a wrench, with a choice of one or two handed options. They deal rather low damage- 20 for the small version, 25 for the two handed, and work off of mace skill. Both have Strike and Thresh (dislocate) intents. The larger version has Demolish intent when two-handed, intended to make it easier to build and modify structures by facilitating furniture removal. The wrench's special is a delayed TWIST damage attack, which can dismember easydismember and robot targets. it has a bonus against robots based on the user's engineering skill, as well as using engineering, rather than the weapon's skill, to determine whether the user can use it. Compare wrench damage and size to the blacksmith hammer, which is similarly sized but deals 21 damage
- brings their engineering to EXPERT. Engineering is the primary crafting/utility  skill amongst their list, and Jman doesn't hit breakpoints to use many contraptions. It feels weird that the bombardier gets expert engineering, whereas the tinkerer gets jman
- brings their traps and sneaking to JMAN to align with most rogue archetypes. Traps especially makes little sense to be lower.
- removes their skincrafting and leatherworking skills. these were added on suggestion, but in practice, makes them far too good at being a jack of all trades
- removes all skillbonuses for gadget choices

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] await battlewrenches from upstream pr https://github.com/Azure-Peak/Azure-Peak/pull/8234
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence
<img width="497" height="446" alt="{ADBA8324-D123-46C8-95CE-F472655A674A}" src="https://github.com/user-attachments/assets/a4840b52-5ee5-435c-be49-1906efe44073" />
<img width="247" height="327" alt="{86D3E076-5C02-4B2D-9C13-086ECFFA12CA}" src="https://github.com/user-attachments/assets/b61be241-e8c4-490f-8f48-bb1f7dfabe70" />
<img width="294" height="232" alt="{E57C9416-8C10-4E82-B180-D0AD4F80BA3D}" src="https://github.com/user-attachments/assets/d42d7972-f4b2-4957-9791-4415794b6805" />


## Why It's Good For The Game
changes to make the class more distinct, after getting good gamefeel
## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: misc tinkerer tweaks- reworked spells, gadget options and primary weapon choice
balance: adds Disassemble to battlewrenches
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
