### PR TITLE
Admin Far Travel and fix reform portals

### DIFF
--- a/modular_causticcove/code/modules/reformgem/reformportal.dm
+++ b/modular_causticcove/code/modules/reformgem/reformportal.dm
@@ -32,7 +32,7 @@ GLOBAL_LIST_EMPTY(reformation_portals)
 	qdel(src)
 
 /obj/structure/respawn_portal/Destroy()
-	soundloop.stop()
+//	soundloop.stop() //OV REMOVE
 	. = ..()
 
 /mob/dead/observer/proc/bring_body(var/turf/portal_loc) //OV EDIT

--- a/modular_ochrevalley/code/modules/admin/player_effects.dm
+++ b/modular_ochrevalley/code/modules/admin/player_effects.dm
@@ -130,7 +130,7 @@
 			direction = directions[direction]
 			var/target_tile = target.loc
 			for (var/i = 0; i < 10; i++)
-				var/turf/next_tile = get_step(target_tile, direction) 
+				var/turf/next_tile = get_step(target_tile, direction)
 				if (!next_tile)
 					break
 				target_tile = next_tile
@@ -199,7 +199,7 @@
 				return
 			target.overlay_fullscreen("scrolls", /atom/movable/screen/fullscreen/scrolls, 1)
 			addtimer(CALLBACK(target, TYPE_PROC_REF(/mob, clear_fullscreen), "scrolls"), 20 SECONDS)
-		
+
 		if("item_tf")
 			var/mob/living/M = target
 
@@ -208,7 +208,7 @@
 
 			if(!M.ckey)
 				return
-			
+
 			var/target_path = input(ui.user, "Enter typepath:", "Typepath", "/obj/structure/closet")
 			var/objholder = text2path(target_path)
 			if(!ispath(objholder))
@@ -233,7 +233,7 @@
 
 			spawned_obj.mob_possession = M
 			M.forceMove(spawned_obj)
-		
+
 		if("sun_strike")
 			var/turf/target_turf = get_turf(target)
 			to_chat(target, span_warning("Let there be light."))
@@ -494,7 +494,7 @@
 
 			M.tf_into(new_mob)
 
-		
+
 
 		if("elder_smite")
 			if(!target.ckey)
@@ -502,7 +502,7 @@
 			target.overlay_fullscreen("scrolls", /atom/movable/screen/fullscreen/scrolls, 1)
 			addtimer(CALLBACK(target, TYPE_PROC_REF(/mob, clear_fullscreen), "scrolls"), 20 SECONDS)
 
-		
+
 		*/
 
 
@@ -520,7 +520,7 @@
 			if(!istype(Tar))
 				return
 			Tar.reagents.clear_reagents()
-		
+
 		if("give_chem")
 			var/mob/living/carbon/human/Tar = target
 			if(!istype(Tar))
@@ -534,7 +534,7 @@
 			var/amount = tgui_input_number(ui.user, "How much of the chemical would you like to add?", "Amount", 5)
 			if(!amount)
 				return
-			
+
 			Tar.reagents.add_reagent(chemical, amount)
 
 		if("full_heal")
@@ -689,7 +689,7 @@
 			if(location == "Skin")
 				Tar.touching.add_reagent(chem, amount)
 
-		
+
 
 		if("medical_issue")
 			var/mob/living/carbon/human/Tar = target
@@ -711,31 +711,31 @@
 			if(!istype(Tar))
 				return
 			Tar.admin_buff(user, "spell")
-			
+
 		if("order_buffs")
 			var/mob/living/carbon/human/Tar = target
 			if(!istype(Tar))
 				return
 			Tar.admin_buff(user, "order")
-		
+
 		if("divine_buffs")
 			var/mob/living/carbon/human/Tar = target
 			if(!istype(Tar))
 				return
 			Tar.admin_buff(user, "divine")
-		
+
 		if("song_buffs")
 			var/mob/living/carbon/human/Tar = target
 			if(!istype(Tar))
 				return
 			Tar.admin_buff(user, "song")
-		
+
 		if("general_buffs")
 			var/mob/living/carbon/human/Tar = target
 			if(!istype(Tar))
 				return
 			Tar.admin_buff(user, "general")
-		
+
 		/* if("give_spell")
 			var/mob/living/carbon/human/Tar = target
 			if(!istype(Tar))
@@ -744,7 +744,7 @@
 			if(!new_spell)
 				return
 			Tar.AddSpell(new_spell) */
-		
+
 		if("remove_spell")
 			var/mob/living/carbon/human/Tar = target
 			if(!istype(Tar))
@@ -956,12 +956,12 @@
 				A = tgui_input_list(ui.user, "Pick an area to teleport [target] to:", "Jump to Area", GLOB.sortedAreas)
 				target.forceMove(pick(get_area_turfs(A)))
 				log_admin("[key_name(ui.user)] jumped [target] to [A]")
-		
+
 		if("gib")
 			var/death = tgui_alert(ui.user, "Are you sure you want to destroy [target]?", "Gib?", list("KILL", "Cancel"))
 			if(death == "KILL")
 				target.gib()
-		
+
 		if("dust")
 			var/death = tgui_alert(ui.user, "Are you sure you want to destroy [target]?", "Dust?", list("KILL", "Cancel"))
 			if(death == "KILL")
@@ -975,19 +975,19 @@
 
 		if("view_variables")
 			ui.user.client.debug_variables(target)
-		
+
 		if("orbit")
 			if(!ui.user.client.holder.marked_datum)
 				return
 			var/atom/movable/X = ui.user.client.holder.marked_datum
 			X.orbit(target)
-		
+
 		if("make_quest_item")
 			var/mob/living/Tar = target
 			if(!istype(Tar))
 				return
 			Tar.mob_gm_quest(ui.user)
-		
+
 		if("check_traits")
 			var/ht
 			var/mob/living/L = target
@@ -1021,6 +1021,12 @@
 			if(!ht)
 				to_chat(ui.user, "<span class='warning'>They have no special traits.</span>")
 			to_chat(ui.user, "*----*")
+
+		if("far_travel")
+			if(ishuman(target))
+				var/double_check = tgui_alert(ui.user, "Are you sure you want to remove them from the round?", "Far travel", list("Remove Them", "Cancel"))
+				if(double_check == "Remove Them")
+					safe_round_remove(target)
 
 		/*
 		if("quick_nif")
@@ -1168,7 +1174,7 @@
 		if("stop-orbits")
 			if(target.orbiters)
 				qdel(target.orbiters)
-		
+
 		if("clear_all_status")
 			var/mob/living/carbon/human/Tar = target
 			if(!istype(Tar))

--- a/tgui/packages/tgui/interfaces/PlayerEffects/PlayerEffectsTabs/ControlAdmin.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerEffects/PlayerEffectsTabs/ControlAdmin.tsx
@@ -34,6 +34,9 @@ export const ControlAdmin = (props) => {
       <Button fluid onClick={() => act('check_traits')}>
         Check Traits
       </Button>
+      <Button fluid onClick={() => act('far_travel')}>
+        Safely Far Travel
+      </Button>
     </Section>
   );
 };


### PR DESCRIPTION


## About The Pull Request

Added a "Safely Far Travel" button to the admin tab of the player effects menu that will remove someone safely from the round.

Fixed reform portals runtiming on being deleted.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game

Simply makes it easier for admins to despawn someone without having to spawn and delete a far travel zone.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added a "Safely Far Travel" button to the admin tab of the player effects menu that will remove someone safely from the round.
fix: Fixed reform portals runtiming on being deleted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
