### PR TITLE
Darkvision Adjustment & New Nite Eyes Virtue

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -95,10 +95,6 @@
 #define LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE 128
 #define LIGHTING_PLANE_ALPHA_INVISIBLE 0
 
-#define DARKVISION_ACCESSIBILITY_MIN -25
-#define DARKVISION_ACCESSIBILITY_MAX 25
-#define DARKVISION_BASE_POTENCY 0.65
-
 //lighting area defines
 /// dynamic lighting disabled (area stays at full brightness)
 #define DYNAMIC_LIGHTING_DISABLED 0

--- a/code/modules/antagonists/roguetown/villain/ascendant/ascendant_altar.dm
+++ b/code/modules/antagonists/roguetown/villain/ascendant/ascendant_altar.dm
@@ -75,9 +75,6 @@ GLOBAL_LIST_INIT(capstone_pool, list(
 	user.STAWIL += 2
 	user.STASPD += 2
 	user.STALUC += 2
-	// OV Edit Start
-	user.update_sight()
-	// OV Edit End
 
 	//check what ascendpoint they are on and add that trait
 	switch(ascendpoints)
@@ -147,9 +144,6 @@ GLOBAL_LIST_INIT(capstone_pool, list(
 	user.STAWIL += 2
 	user.STASPD += 2
 	user.STALUC += 2
-	// OV Edit Start
-	user.update_sight()
-	// OV Edit End
 
 	switch(ascend_stage)
 		if(1)
@@ -224,9 +218,6 @@ GLOBAL_LIST_INIT(capstone_pool, list(
 			user.STAWIL += 10
 			user.STASPD += 10
 			user.STALUC += 6
-			// OV Edit Start
-			user.update_sight()
-			// OV Edit End
 
 			heavensaysdanger() //Roger, our deal is honored; you will be rewarded in heaven.
 			addomen(ASCEND_ASCENDANT)

--- a/code/modules/antagonists/roguetown/villain/lich.dm
+++ b/code/modules/antagonists/roguetown/villain/lich.dm
@@ -87,7 +87,6 @@
 	STALUC = owner.current.STALUC
 
 /datum/antagonist/lich/proc/set_stats()
-	// OV Edit Start
 	owner.current.STASTR = src.STASTR
 	owner.current.STAPER = src.STAPER
 	owner.current.STACON = src.STACON
@@ -95,8 +94,6 @@
 	owner.current.STASPD = src.STASPD
 	owner.current.STAWIL = src.STAWIL
 	owner.current.STALUC = src.STALUC
-	owner.current.update_sight()
-	// OV Edit End
 
 /datum/antagonist/lich/proc/skele_look()
 	var/mob/living/carbon/human/L = owner.current

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -163,7 +163,6 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/no_redflash = FALSE
 	var/no_storyteller_events = FALSE
 	var/top_examine = FALSE
-	var/darkvision_accessibility = 0
 
 	var/lastclass
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -179,7 +179,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["no_language_icon"]	>> no_language_icon
 	S["no_redflash"]		>> no_redflash
 	S["top_examine"]		>> top_examine
-	S["darkvision_accessibility"] >> darkvision_accessibility
 	S["crt"]				>> crt
 	S["grain"]				>> grain
 	S["sexable"]			>> sexable
@@ -262,7 +261,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	auto_fit_viewport	= sanitize_integer(auto_fit_viewport, 0, 1, initial(auto_fit_viewport))
 	attack_blip_frequency = sanitize_integer(attack_blip_frequency, 0, 100, ATTACK_BLIP_PREF_DEFAULT)
 	widescreenpref	= sanitize_integer(widescreenpref, 0, 1, initial(widescreenpref))
-	darkvision_accessibility = sanitize_integer(darkvision_accessibility, DARKVISION_ACCESSIBILITY_MIN, DARKVISION_ACCESSIBILITY_MAX, initial(darkvision_accessibility))
 	ghost_form		= sanitize_inlist(ghost_form, GLOB.ghost_forms, initial(ghost_form))
 	ghost_orbit	= sanitize_inlist(ghost_orbit, GLOB.ghost_orbits, initial(ghost_orbit))
 	ghost_accs		= sanitize_inlist(ghost_accs, GLOB.ghost_accs_options, GHOST_ACCS_DEFAULT_OPTION)
@@ -338,7 +336,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["no_language_icon"], no_language_icon)
 	WRITE_FILE(S["no_redflash"], no_redflash)
 	WRITE_FILE(S["top_examine"], top_examine)
-	WRITE_FILE(S["darkvision_accessibility"], darkvision_accessibility)
 	WRITE_FILE(S["crt"], crt)
 	WRITE_FILE(S["sexable"], sexable)
 	WRITE_FILE(S["hide_pq"], hide_pq) //OV ADD

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -176,30 +176,6 @@
 		to_chat(src, "You [prefs.no_redflash ? "will not" : "will"] see the red flashing effect.")
 		//Caustic Edit End
 
-//OV ADD START - Darkvision
-/client/verb/darkvision_accessibility()
-	set category = "Preferences.Options"
-	set name = "Darkvision Accessibility"
-	if(!prefs)
-		return
-
-	var/new_darkvision_accessibility = tgui_input_number(
-		mob,
-		"Adjust Darksight potency from [DARKVISION_ACCESSIBILITY_MIN]% to +[DARKVISION_ACCESSIBILITY_MAX]%. 0% is the standard value.",
-		"Darkvision Accessibility",
-		prefs.darkvision_accessibility,
-		DARKVISION_ACCESSIBILITY_MAX,
-		DARKVISION_ACCESSIBILITY_MIN
-	)
-	if(isnull(new_darkvision_accessibility))
-		return
-
-	prefs.darkvision_accessibility = clamp(round(new_darkvision_accessibility), DARKVISION_ACCESSIBILITY_MIN, DARKVISION_ACCESSIBILITY_MAX)
-	prefs.save_preferences()
-	mob?.update_sight()
-	to_chat(src, "Darkvision accessibility set to [prefs.darkvision_accessibility]%.")
-//OV ADD END
-
 /client/verb/toggle_topexamine()
 	set category = "Preferences.Options"
 	set name = "Toggle Top Examine"

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -459,9 +459,6 @@
 			H.equipOutfit(outfit_override ? outfit_override : outfit, visualsOnly)
 
 	H.dna.species.after_equip_job(src, H, visualsOnly)
-	// OV Edit Start
-	H.update_sight()
-	// OV Edit End
 
 	if(!visualsOnly && announce)
 		announce(H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
@@ -161,11 +161,6 @@
 		apply_character_post_equipment(H)
 	H.set_advsetup(FALSE)
 	H.mind?.refresh_spell_buttons()
-
-	// OV Edit Start
-	H.update_sight()
-	// OV Edit End
-
 //======== Massive shitcode, that works at least.
 /datum/advclass/proc/get_vice_limits(mob/living/carbon/human/H)
 	if(length(vice_limits))

--- a/code/modules/jobs/job_types/roguetown/church/martyr.dm
+++ b/code/modules/jobs/job_types/roguetown/church/martyr.dm
@@ -321,9 +321,6 @@
 				current_holder.STAPER += stat_bonus_martyr
 				current_holder.STALUC += stat_bonus_martyr
 				H.energy_add(9999)
-				// OV Edit Start
-				H.update_sight()
-				// OV Edit End
 
 //This is called regardless of the activated state (safe or not)
 /datum/component/martyrweapon/proc/deactivate()
@@ -446,9 +443,6 @@
 				current_holder.STAINT = 20
 				current_holder.STAPER = 20
 				current_holder.STALUC = 20
-				// OV Edit Start
-				current_holder.update_sight()
-				// OV Edit End
 
 				current_holder.energy = current_holder.max_energy
 				current_holder.stamina = 0

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1,11 +1,6 @@
 /mob/living/carbon/Initialize(mapload)
 	..()
 
-	//OV Add Start
-	RegisterSignal(src, list(SIGNAL_ADDTRAIT(TRAIT_DARKVISION), SIGNAL_ADDTRAIT(TRAIT_ZIZOSIGHT)), PROC_REF(on_darkvision_trait_changed))
-	RegisterSignal(src, list(SIGNAL_REMOVETRAIT(TRAIT_DARKVISION), SIGNAL_REMOVETRAIT(TRAIT_ZIZOSIGHT)), PROC_REF(on_darkvision_trait_changed))
-	//OV Add End
-
 	recalculate_pain_threshold()
 
 	create_reagents(1000)
@@ -21,8 +16,6 @@
 	//This must be done first, so the mob ghosts correctly before DNA etc is nulled
 	. =	..()
 
-	UnregisterSignal(src, list(SIGNAL_ADDTRAIT(TRAIT_DARKVISION), SIGNAL_REMOVETRAIT(TRAIT_DARKVISION), SIGNAL_ADDTRAIT(TRAIT_ZIZOSIGHT), SIGNAL_REMOVETRAIT(TRAIT_ZIZOSIGHT)))
-
 	QDEL_LIST(hand_bodyparts)
 	QDEL_LIST(internal_organs)
 	QDEL_LIST(bodyparts)
@@ -30,11 +23,6 @@
 	QDEL_NULL(dna)
 	QDEL_NULL(underwear)
 	GLOB.carbon_list -= src
-
-/mob/living/carbon/proc/on_darkvision_trait_changed()
-	SIGNAL_HANDLER
-
-	update_sight()
 
 /mob/living/carbon/ZImpactDamage(turf/T, levels)
 	var/obj/item/bodypart/affecting
@@ -184,11 +172,7 @@
 			visible_message("<span class='danger'>[src] crashes into [victim]!",\
 				"<span class='danger'>I violently crash into [victim]!</span>")
 			playsound(src,"genblunt",100,TRUE)
-			/*var/nomprob //Caustic Edit - Commented this out, and it was added but never marked lol, but it was for the unfinished vore implementation
-			if(voremode)
-				nomprob = ((get_stat(STATKEY_LCK - 10) * 10) + ((get_stat(STATKEY_STR) - 10) * 10) + (get_stat(STATKEY_SPD)))
-				if(prob(nomprob))
-					spontaneous_vore_attackby(victim, src)*/
+
 
 
 //Throwing stuff
@@ -818,26 +802,9 @@
 		if(!isnull(G.lighting_alpha))
 			lighting_alpha = min(lighting_alpha, G.lighting_alpha)
 
-	// OV Edit Start
-	if(HAS_TRAIT(src, TRAIT_DARKVISION) || HAS_TRAIT(src, TRAIT_ZIZOSIGHT))
-		var/perception = clamp(get_stat(STATKEY_PER), 8, 15)
-		// Remap the old PER 10-13 Darksight range across PER 8-15.
-		var/perception_ratio = (perception - 8) / 7
-		var/perception_bonus = 1 + (perception_ratio * 3)
-		var/vision_ratio = perception_bonus / 6
-		var/darksight_alpha = round(LIGHTING_PLANE_ALPHA_DARKVISION * (1 - vision_ratio))
-		var/darkvision_accessibility = client?.prefs ? client.prefs.darkvision_accessibility : 0
-		var/min_darkvision_potency = DARKVISION_BASE_POTENCY + (DARKVISION_ACCESSIBILITY_MIN / 100)
-		var/max_darkvision_potency = DARKVISION_BASE_POTENCY + (DARKVISION_ACCESSIBILITY_MAX / 100)
-		var/darkvision_potency = clamp(DARKVISION_BASE_POTENCY + (darkvision_accessibility / 100), min_darkvision_potency, max_darkvision_potency)
-		var/darkvision_effect = LIGHTING_PLANE_ALPHA_VISIBLE - darksight_alpha
-		var/darksight_level = 9 + round(perception_bonus * darkvision_potency)
-		// Scale the alpha reduction so the default is substantially darker while accessibility can restore strength.
-		darksight_alpha = round(LIGHTING_PLANE_ALPHA_VISIBLE - (darkvision_effect * darkvision_potency))
-
-		lighting_alpha = min(lighting_alpha, darksight_alpha)
-		see_in_dark = max(see_in_dark, darksight_level)
-	// OV Edit End
+	if(HAS_TRAIT(src, TRAIT_DARKVISION))
+		lighting_alpha = min(lighting_alpha, LIGHTING_PLANE_ALPHA_DARKVISION)
+		see_in_dark = max(see_in_dark, 12)
 
 	if(HAS_TRAIT(src, TRAIT_NITEVISION))
 		lighting_alpha = min(lighting_alpha, LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE)
@@ -865,6 +832,10 @@
 
 	if(HAS_TRAIT(src, TRAIT_XRAY_VISION))
 		sight |= (SEE_TURFS|SEE_MOBS|SEE_OBJS)
+		see_in_dark = max(see_in_dark, 8)
+
+	if(HAS_TRAIT(src, TRAIT_ZIZOSIGHT))
+		lighting_alpha = min(lighting_alpha, LIGHTING_PLANE_ALPHA_ZIZOVISION)
 		see_in_dark = max(see_in_dark, 8)
 
 	if(see_override)

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
@@ -18,7 +18,7 @@
 		allowed_types = list(/obj/item/rogueweapon/woodstaff,
 											/obj/item/storage/belt
 											)
-	
+
 	drop_all_held_items() //Drop what were in your hands
 
 	for(var/obj/item/I in src)
@@ -59,7 +59,12 @@
 	playsound(W.loc, pick('sound/combat/gib (1).ogg','sound/combat/gib (2).ogg'), 200, FALSE, 3)
 	//W.spawn_gibs(FALSE) //Caustic Edit - Turned off the gibs on Wildshaping
 	src.forceMove(W)
+	// re-equip our stored neck and ring items, if we have them
+	if (stored_ring)
+		W.equip_to_slot_if_possible(stored_ring, SLOT_RING) // have to do this because we can wear psycrosses as rings even though we shouldn't be able to
 
+	if (stored_neck)
+		W.equip_to_slot_if_possible(stored_neck, SLOT_NECK)
 	W.after_creation()
 	W.stored_language = new
 	W.stored_language.copy_known_languages_from(src)
@@ -88,14 +93,14 @@
 	if(woundlist.len)
 		for(var/datum/wound/wound in woundlist)
 			if (istype(wound, /datum/wound/dismemberment))
-				continue				
+				continue
 			var/target_zone = wound.bodypart_owner.body_zone
 			if (target_zone == BODY_ZONE_TAUR)
 				target_zone = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
-			
+
 			var/bleedrate = wound.bleed_rate
 			var/obj/item/bodypart/w_bp = W.get_bodypart(target_zone)
-			
+
 			wound.apply_to_bodypart(w_bp, silent = TRUE, crit_message = FALSE)
 			wound.set_bleed_rate(bleedrate) // restore bleed rate, since apply_to_bodypart resets it.
 
@@ -131,17 +136,14 @@
 	ADD_TRAIT(src, TRAIT_NOSLEEP, TRAIT_SOURCE_WILDSHAPE)
 	ADD_TRAIT(src, TRAIT_NOBREATH, TRAIT_SOURCE_WILDSHAPE)
 	ADD_TRAIT(src, TRAIT_NOPAIN, TRAIT_SOURCE_WILDSHAPE)
-	ADD_TRAIT(src, TRAIT_TOXIMMUNE, TRAIT_SOURCE_WILDSHAPE)	
+	ADD_TRAIT(src, TRAIT_TOXIMMUNE, TRAIT_SOURCE_WILDSHAPE)
 	ADD_TRAIT(src, TRAIT_NOHUNGER, TRAIT_SOURCE_WILDSHAPE)
 	ADD_TRAIT(src, TRAIT_NOMOOD, TRAIT_SOURCE_WILDSHAPE)
 	ADD_TRAIT(src, TRAIT_PACIFISM, TRAIT_SOURCE_WILDSHAPE) // just an extra layer of protection in case something will go wrong
 	src.status_flags |= GODMODE // so they won't die by any means
 	invisibility = oldinv
 
-	// OV Edit Start
 	W.gain_inherent_skills()
-	W.update_sight()
-	// OV Edit End
 
 /mob/living/carbon/human/proc/wildshape_untransform(dead,gibbed)
 	if(!stored_mob)
@@ -171,7 +173,12 @@
 	REMOVE_TRAIT(W, TRAIT_NOMOOD, TRAIT_SOURCE_WILDSHAPE)
 	REMOVE_TRAIT(W, TRAIT_PACIFISM, TRAIT_SOURCE_WILDSHAPE)
 	W.status_flags &= ~GODMODE
+	// re-equip our stored neck and ring items, if we have them
+	if (stored_ring)
+		W.equip_to_slot_if_possible(stored_ring, SLOT_RING) // have to do this because we can wear psycrosses as rings even though we shouldn't be able to
 
+	if (stored_neck)
+		W.equip_to_slot_if_possible(stored_neck, SLOT_NECK)
 	if(dead)
 		W.death()
 
@@ -183,10 +190,10 @@
 	if(woundlist.len)
 		for(var/datum/wound/wound in woundlist)
 			var/target_zone = wound.bodypart_owner.body_zone
-			
+
 			var/bleedrate = wound.bleed_rate
 			var/obj/item/bodypart/w_bp = W.get_bodypart(target_zone)
-			
+
 			wound.apply_to_bodypart(w_bp, silent = TRUE, crit_message = FALSE)
 			wound.set_bleed_rate(bleedrate)
 
@@ -232,10 +239,7 @@
 			if(wildspell != originspell)
 				W.RemoveSpell(wildspell)
 
-	// OV Edit Start
 	W.regenerate_icons()
-	W.update_sight()
-	// OV Edit End
 	to_chat(W, span_userdanger("I return to my old form."))
 
 	qdel(src)

--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -106,9 +106,6 @@
 
 				H.eye_color = "ff0000"
 				H.voice_color = "ff0000"
-	// OV Edit Start
-	update_sight()
-	// OV Edit End
 
 /mob/living/proc/get_stat(stat)
 	if(!stat)
@@ -191,9 +188,6 @@
 			STAPER = newamt
 
 			update_fov_angles()
-			// OV Edit Start
-			update_sight()
-			// OV Edit End
 
 		if(STATKEY_INT)
 			newamt = STAINT + amt
@@ -410,7 +404,4 @@
 	STAWIL = 10
 	STASPD = 10
 	STALUC = 10
-	// OV Edit Start
-	update_sight()
-	// OV Edit End
 	return

--- a/modular_causticcove/code/modules/spells/animagus/animagus_transformation.dm
+++ b/modular_causticcove/code/modules/spells/animagus/animagus_transformation.dm
@@ -85,17 +85,14 @@
 	ADD_TRAIT(src, TRAIT_NOSLEEP, TRAIT_SOURCE_ANIMAGUS)
 	ADD_TRAIT(src, TRAIT_NOBREATH, TRAIT_SOURCE_ANIMAGUS)
 	ADD_TRAIT(src, TRAIT_NOPAIN, TRAIT_SOURCE_ANIMAGUS)
-	ADD_TRAIT(src, TRAIT_TOXIMMUNE, TRAIT_SOURCE_ANIMAGUS)	
+	ADD_TRAIT(src, TRAIT_TOXIMMUNE, TRAIT_SOURCE_ANIMAGUS)
 	ADD_TRAIT(src, TRAIT_NOHUNGER, TRAIT_SOURCE_ANIMAGUS)
 	ADD_TRAIT(src, TRAIT_NOMOOD, TRAIT_SOURCE_ANIMAGUS)
 	ADD_TRAIT(src, TRAIT_PACIFISM, TRAIT_SOURCE_ANIMAGUS) // just an extra layer of protection in case something will go wrong
 	src.status_flags |= GODMODE // so they won't die by any means
 	invisibility = oldinv
 
-	// OV Edit Start
 	W.gain_inherent_skills()
-	W.update_sight()
-	// OV Edit End
 
 /mob/living/carbon/human/proc/animagus_untransform(dead,gibbed)
 	if(!stored_mob)
@@ -173,10 +170,7 @@
 			if(wildspell != originspell)
 				W.RemoveSpell(wildspell)
 
-	// OV Edit Start
 	W.regenerate_icons()
-	W.update_sight()
-	// OV Edit End
 	to_chat(W, span_userdanger("I return to my old form."))
 
 	qdel(src)

--- a/modular_ochrevalley/virtues/utility.dm
+++ b/modular_ochrevalley/virtues/utility.dm
@@ -138,3 +138,7 @@
 	desc = "You have trained and become fit enough to function as a suitable mount. People may ride you as they would a saiga."
 	added_traits = list(TRAIT_MOUNTABLE)
 
+/datum/virtue/utility/niteyes
+	name = "Nite Eyes"
+	desc = "I don't need a light source when I'm travelling through darkened areas - my eyes are well used to the gloom of nite."
+	added_traits = list(TRAIT_NITEVISION)

--- a/tgui/packages/tgui/interfaces/NumberInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/NumberInputModal.tsx
@@ -6,7 +6,6 @@ import {
   Button,
   RestrictedInput,
   Section,
-  Slider,
   Stack,
 } from 'tgui-core/components';
 import { isEscape, KEY } from 'tgui-core/keys';
@@ -41,14 +40,12 @@ export function NumberInputModal(props) {
 
   const [value, setValue] = useState(init_value);
   const [isValid, setIsValid] = useState(true);
-  const hasSlider = Number.isFinite(min_value) && Number.isFinite(max_value);
 
   // Dynamically changes the window height based on the message.
   const windowHeight =
     190 +
     (message.length > 30 ? Math.ceil(message.length / 3) : 0) +
-    (message.length && large_buttons ? 5 : 0) +
-    (hasSlider ? 30 : 0);
+    (message.length && large_buttons ? 5 : 0);
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
     if (event.key === KEY.Enter && isValid) {
@@ -131,21 +128,6 @@ export function NumberInputModal(props) {
                 </Stack.Item>
               </Stack>
             </Stack.Item>
-            {hasSlider && (
-              <Stack.Item>
-                <Slider
-                  width="100%"
-                  minValue={min_value}
-                  maxValue={max_value}
-                  step={round_value ? 1 : 0.01}
-                  stepPixelSize={5}
-                  value={value}
-                  onChange={(e, value: number) =>
-                    setValue(round_value ? Math.round(value) : value)
-                  }
-                />
-              </Stack.Item>
-            )}
             <Stack.Item>
               <InputButtons input={value} disabled={!isValid} />
             </Stack.Item>


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->
ADDS NEW VIRTUE: Nite Eyes
Uses TRAIT_NITEVISION to give people a single-virtue pick of better darkvision compared to prowler

Reverts: https://github.com/Ochre-Valley/Ochre-Valley/pull/264 back to AP Standard

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [x] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->
Day
<img width="616" height="439" alt="image" src="https://github.com/user-attachments/assets/e4f967ae-b37c-4e36-a152-da40be9fa52b" />

Night
<img width="583" height="415" alt="image" src="https://github.com/user-attachments/assets/b6208836-7dbd-4507-935a-22c715f85941" />

Light for contrast
<img width="617" height="773" alt="image" src="https://github.com/user-attachments/assets/566e00a6-ae2f-40c6-9673-2470e3499ad4" />

Night w/Nite Eyes
<img width="614" height="597" alt="image" src="https://github.com/user-attachments/assets/aca3d2e1-6774-45e2-bfd8-894e3bd45029" />


## Why It's Good For The Game

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->
Removes the scalar which was making basic Darkvision outcompete the Nitevision exclusive to virtues with harsher downsides, while still letting Darkvision be useable. Needs test merging for flavor, as I'd rather directly adjust the alpha values if this proves too harsh.

Adds a single-pick trait for those who ONLY want good night vision, without the complication of a scalar.
<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: added Nite Eyes Virtue
balance: reverted Darkvision to AP Standard
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
