### PR TITLE
[TM only] Sets wretch cap to 12 regardless of gamemode + Hide Peasant Rebellion

### DIFF
--- a/code/datums/storytellers/_base.dm
+++ b/code/datums/storytellers/_base.dm
@@ -89,7 +89,7 @@
 	/// Which kind of gnoll scaling this preset prefers, default is 1 gnoll spawn.
 	var/preferred_gnoll_mode = GNOLL_SCALING_SINGLE
 	/// Hard cap on wretch job slots this preset will ever open. Default 10 = T1 max - lower clamps T1 and skips T2.
-	var/wretch_slot_cap = 10
+	var/wretch_slot_cap = 12 // OV Edit - 12 wretch cap (was 10)
 
 	// --- Gamemode preset configuration ---
 	/// Which vote pool this preset belongs to (GAMEMODE_POOL_*). Presets sharing a pool are excluded together the round after one wins.

--- a/code/datums/storytellers/presets.dm
+++ b/code/datums/storytellers/presets.dm
@@ -21,7 +21,7 @@
 	block_soft = TRUE
 	allow_dreamwalker = FALSE
 	preferred_gnoll_mode = GNOLL_SCALING_NONE
-	wretch_slot_cap = 0
+	// wretch_slot_cap = 0 // OV Remove
 	roundstart_prob = 0
 	guarantees_roundstart_roleset = FALSE
 	starting_point_multipliers = list(
@@ -62,7 +62,7 @@
 	guarantees_roundstart_roleset = FALSE
 	roundstart_prob = 0
 	preferred_gnoll_mode = GNOLL_SCALING_DYNAMIC	// max 3
-	wretch_slot_cap = 12
+	// wretch_slot_cap = 12  // OV Remove
 
 	starting_point_multipliers = list(
 		EVENT_TRACK_MUNDANE = 1,
@@ -100,7 +100,7 @@
 	block_soft = FALSE
 	allow_dreamwalker = TRUE
 	preferred_gnoll_mode = GNOLL_SCALING_FLAT	// max 2
-	wretch_slot_cap = 9
+	// wretch_slot_cap = 9 // OV Remove
 
 /datum/storyteller/gamemode/guaranteed_antag/low_wretch
 	name = "Tempered Intensity"
@@ -111,7 +111,7 @@
 	block_soft = FALSE
 	allow_dreamwalker = FALSE
 	preferred_gnoll_mode = GNOLL_SCALING_SINGLE	// max 1
-	wretch_slot_cap = 4
+	// wretch_slot_cap = 4  // OV Remove
 
 // ----------------------------------------------------------------------------------------------------------
 // TEN pool - no hard antags, soft antags only. Standard is the lighter option, Medium the default fallback.
@@ -127,7 +127,7 @@
 	block_soft = FALSE
 	allow_dreamwalker = FALSE
 	preferred_gnoll_mode = GNOLL_SCALING_DYNAMIC	// max 3
-	wretch_slot_cap = 12
+	// wretch_slot_cap = 12  // OV Remove
 	roundstart_prob = 50
 	guarantees_roundstart_roleset = FALSE
 
@@ -138,7 +138,7 @@
 	color_theme = "#37b3a6"
 	allow_dreamwalker = FALSE
 	preferred_gnoll_mode = GNOLL_SCALING_FLAT	// max 2
-	wretch_slot_cap = 6
+	// wretch_slot_cap = 6  // OV Remove
 
 // Low Intensity - votes in the PSYDON pool (see preset_pool) despite being a no_antag subtype.
 /datum/storyteller/gamemode/no_antag/small_wretch
@@ -149,7 +149,7 @@
 	preset_pool = GAMEMODE_POOL_EXTENDED
 	allow_dreamwalker = FALSE
 	preferred_gnoll_mode = GNOLL_SCALING_NONE
-	wretch_slot_cap = 4
+	// wretch_slot_cap = 4  // OV Remove
 	roundstart_prob = 0
 
 	starting_point_multipliers = list(

--- a/code/modules/events/antagonist/solo/rebels.dm
+++ b/code/modules/events/antagonist/solo/rebels.dm
@@ -4,7 +4,7 @@
 		TAG_COMBAT,
 		TAG_VILLIAN,
 	)
-	roundstart = TRUE
+	roundstart = FALSE // OV Edit - disabled.
 	antag_flag = ROLE_PREBEL
 	shared_occurence_type = SHARED_HIGH_THREAT
 	storyteller_antag_flags = STORYTELLER_ANTAG_VILLAIN | STORYTELLER_ANTAG_ROUNDSTART


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->

See title.
The only exception to this is extended, which I kept at having no wretches due to low intensity now existing as a Psydon option.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [X] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [X] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [X] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

<img width="900" height="600" alt="2026-08-24_04-20-20" src="https://github.com/user-attachments/assets/b051bd67-adf3-4e96-bef2-bf854ae4fc76" />



## Why It's Good For The Game

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

Our approach to antagonism, and by extension wretches, is influenced by our more restrictive PVP policy. We do not have the same worries as our upstream regarding there being "Too many" wretches, and therefore we do not need to worry ourselves as much with a hard cap on this role.

Also Rebellion is disabled for us, so let's hide it!

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Wretches are always capped at 12, regardless of game mode.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
