### PR TITLE
[WIP, DNM] Ochre Valley gamemode presets

### DIFF
--- a/code/datums/storytellers/presets.dm
+++ b/code/datums/storytellers/presets.dm
@@ -1,3 +1,7 @@
+// OV Add Start: We use our own gamemode presets (See modular_ochrevalley/code/datums/storytellers/presets.dm)
+#error This file has been deliberately disabled by Ochre Valley and must remain unticked!
+// OV Add End
+
 /// Code-defined gamemode presets. These replace the old storyteller gods. Players vote between them (grouped
 /// into three pools - see GAMEMODE_POOL_* in __DEFINES/storytellers.dm) or admins fine-tune the roundstart
 /// antag config directly. A preset's vote pool is set by preset_pool, independent of its type hierarchy.

--- a/modular_ochrevalley/code/datums/storytellers/presets.dm
+++ b/modular_ochrevalley/code/datums/storytellers/presets.dm
@@ -1,0 +1,165 @@
+/// Code-defined gamemode presets. These replace the old storyteller gods. Players vote between them (grouped
+/// into three pools - see GAMEMODE_POOL_* in __DEFINES/storytellers.dm) or admins fine-tune the roundstart
+/// antag config directly. A preset's vote pool is set by preset_pool, independent of its type hierarchy.
+
+/datum/storyteller/gamemode
+	always_votable = TRUE
+	hag_slots = 1
+
+// ----------------------------------------------------------------------------------------------------------
+// PSYDON pool - lowest intensity. No hard antags. Extended opens nothing; Low Intensity opens a few wretches.
+// (Low Intensity is defined further down as no_antag/small_wretch but votes in this pool via preset_pool.)
+// ----------------------------------------------------------------------------------------------------------
+/datum/storyteller/gamemode/extended
+	name = "Extended"
+	vote_desc = "Maybe we were the true antagonists after all."
+	desc = "No hard antags, no soft antags (wretch/gnoll/assassin). Hag present."
+	welcome_text = "A temperate breeze rolls through the quiet streets.."
+	color_theme = "#80ced8"
+	preset_pool = GAMEMODE_POOL_EXTENDED
+	block_hard = TRUE
+	block_soft = TRUE
+	allow_dreamwalker = FALSE
+	preferred_gnoll_mode = GNOLL_SCALING_NONE
+	roundstart_prob = 0
+	guarantees_roundstart_roleset = FALSE
+	starting_point_multipliers = list(
+		EVENT_TRACK_MUNDANE = 1,
+		EVENT_TRACK_PERSONAL = 1,
+		EVENT_TRACK_MODERATE = 1,
+		EVENT_TRACK_INTERVENTION = 1,
+		EVENT_TRACK_CHARACTER_INJECTION = 0,
+		EVENT_TRACK_OMENS = 1,
+		EVENT_TRACK_RAIDS = 0,
+	)
+	point_gains_multipliers = list(
+		EVENT_TRACK_MUNDANE = 1,
+		EVENT_TRACK_PERSONAL = 1,
+		EVENT_TRACK_MODERATE = 1,
+		EVENT_TRACK_INTERVENTION = 1,
+		EVENT_TRACK_CHARACTER_INJECTION = 0,
+		EVENT_TRACK_OMENS = 1,
+		EVENT_TRACK_RAIDS = 0,
+	)
+
+// ----------------------------------------------------------------------------------------------------------
+// Admin sandbox - NOT votable. Admins pick before the 120s mark to disable player vote and
+// insert their own antags in.
+// ----------------------------------------------------------------------------------------------------------
+/datum/storyteller/gamemode/admin
+	name = "Admin Sandbox"
+	vote_desc = "The Gods among us have taken the wheel."
+	desc = "Admin sandbox. Soft antags default to the standard No-Antag baseline; admins open hard antags and adjust slots directly."
+	welcome_text = "The threads of fate bend to an unseen hand.."
+	color_theme = "#c8a13a"
+	preset_pool = null
+	always_votable = FALSE
+	block_hard = FALSE
+	block_soft = FALSE
+	allow_dreamwalker = TRUE
+	guaranteed_hard = FALSE
+	guarantees_roundstart_roleset = FALSE
+	roundstart_prob = 0
+	preferred_gnoll_mode = GNOLL_SCALING_DYNAMIC	// max 3
+
+	starting_point_multipliers = list(
+		EVENT_TRACK_MUNDANE = 1,
+		EVENT_TRACK_PERSONAL = 1,
+		EVENT_TRACK_MODERATE = 1,
+		EVENT_TRACK_INTERVENTION = 1,
+		EVENT_TRACK_CHARACTER_INJECTION = 0,
+		EVENT_TRACK_OMENS = 1,
+		EVENT_TRACK_RAIDS = 0,
+	)
+	point_gains_multipliers = list(
+		EVENT_TRACK_MUNDANE = 1,
+		EVENT_TRACK_PERSONAL = 1,
+		EVENT_TRACK_MODERATE = 1,
+		EVENT_TRACK_INTERVENTION = 1,
+		EVENT_TRACK_CHARACTER_INJECTION = 0,
+		EVENT_TRACK_OMENS = 1,
+		EVENT_TRACK_RAIDS = 0,
+	)
+
+// ----------------------------------------------------------------------------------------------------------
+// ASCENDANT pool - guaranteed roundstart hard antag. At least one main antag will be selected.
+// ----------------------------------------------------------------------------------------------------------
+/datum/storyteller/gamemode/guaranteed_antag
+	name = "High Intensity"
+	vote_desc = "Guaranteed hard antagonist. Some soft antagonists remain."
+	desc = "Guaranteed roundstart hard antag. Gnolls max 2. Hag present."
+	welcome_text = "A cold dread settles over the town.."
+	color_theme = "#a43c3c"
+	preset_pool = GAMEMODE_POOL_GUARANTEED
+	guaranteed_hard = FALSE //OV EDIT
+	guarantees_roundstart_roleset = FALSE //OV Edit
+	roundstart_prob = 100
+	block_hard = FALSE
+	block_soft = FALSE
+	allow_dreamwalker = FALSE
+	preferred_gnoll_mode = GNOLL_SCALING_FLAT	// max 2
+
+/datum/storyteller/gamemode/guaranteed_antag/wretches_only
+	name = "Tempered Intensity"
+	vote_desc = "Guaranteed hard antagonist of a random variety. Wretches are the only appearing soft antagonists."
+	desc = "Guaranteed roundstart hard antag with more aggressive pop scaling. Hag present."
+	color_theme = "#7a1f1f"
+	hard_mult = 2
+	block_soft = FALSE
+	allow_dreamwalker = FALSE
+	preferred_gnoll_mode = GNOLL_SCALING_NONE
+
+// ----------------------------------------------------------------------------------------------------------
+// TEN pool - no hard antags, soft antags only. Standard is the lighter option, Medium the default fallback.
+// ----------------------------------------------------------------------------------------------------------
+/datum/storyteller/gamemode/no_antag	// DEFAULT (inconclusive-vote fallback)
+	name = "Medium Intensity"
+	vote_desc = "No hard antagonists. Soft antagonists scale reasonably."
+	desc = "No hard antags. Wretches scale normally (5 -> 12). Gnolls max 3. Hag present. Dreamwalker may roll."
+	welcome_text = "The warmth of daelight rouses you from your slumber.."
+	color_theme = "#2b8c87"
+	preset_pool = GAMEMODE_POOL_NOANTAG
+	block_hard = TRUE
+	block_soft = FALSE
+	allow_dreamwalker = FALSE
+	preferred_gnoll_mode = GNOLL_SCALING_DYNAMIC	// max 3
+	roundstart_prob = 50
+	guarantees_roundstart_roleset = FALSE
+
+/datum/storyteller/gamemode/no_antag/standard
+	name = "Standard Intensity"
+	vote_desc = "No hard antagonists. A moderate spread of soft antagonists."
+	desc = "No hard antags. No Gnolls. Hag present."
+	color_theme = "#37b3a6"
+	allow_dreamwalker = FALSE
+	preferred_gnoll_mode = GNOLL_SCALING_NONE
+
+// Low Intensity - votes in the PSYDON pool (see preset_pool) despite being a no_antag subtype.
+/datum/storyteller/gamemode/no_antag/small_wretch
+	name = "Low Intensity"
+	vote_desc = "No hard antagonists. Only a handful of soft antagonists are present.."
+	desc = "No hard antags. No gnolls. Hag present."
+	color_theme = "#1f6b67"
+	preset_pool = GAMEMODE_POOL_EXTENDED
+	allow_dreamwalker = FALSE
+	preferred_gnoll_mode = GNOLL_SCALING_NONE
+	roundstart_prob = 0
+
+	starting_point_multipliers = list(
+		EVENT_TRACK_MUNDANE = 1,
+		EVENT_TRACK_PERSONAL = 1,
+		EVENT_TRACK_MODERATE = 1,
+		EVENT_TRACK_INTERVENTION = 1,
+		EVENT_TRACK_CHARACTER_INJECTION = 0,
+		EVENT_TRACK_OMENS = 1,
+		EVENT_TRACK_RAIDS = 0,
+	)
+	point_gains_multipliers = list(
+		EVENT_TRACK_MUNDANE = 1,
+		EVENT_TRACK_PERSONAL = 1,
+		EVENT_TRACK_MODERATE = 1,
+		EVENT_TRACK_INTERVENTION = 1,
+		EVENT_TRACK_CHARACTER_INJECTION = 0,
+		EVENT_TRACK_OMENS = 1,
+		EVENT_TRACK_RAIDS = 0,
+	)

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3681,6 +3681,7 @@
 #include "modular\Neu_Food\code\recipes\veggies_recipes.dm"
 #include "modular\Neu_teas_and_brews\code\drink_mix_recipes.dm"
 #include "modular\Neu_teas_and_brews\code\drink_mixes.dm"
+#include "modular_ochrevalley\code\datums\storytellers\presets.dm"
 #include "modular\Neu_teas_and_brews\code\drink_reagents_tea.dm"
 #include "modular\Neu_teas_and_brews\code\drink_reagents_tea_recipes.dm"
 #include "modular\piercing\carbon_defines.dm"

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1097,7 +1097,6 @@
 #include "code\datums\status_effects\rogue\roguestatus.dm"
 #include "code\datums\storytellers\_base.dm"
 #include "code\datums\storytellers\gods.dm"
-#include "code\datums\storytellers\presets.dm"
 #include "code\datums\stress\_stressevent.dm"
 #include "code\datums\stress\negative_events.dm"
 #include "code\datums\stress\positive_events.dm"

--- a/tools/ticked_file_enforcement/schemas/roguetown_dme.json
+++ b/tools/ticked_file_enforcement/schemas/roguetown_dme.json
@@ -7,6 +7,7 @@
         "code/modules/events/raids/goblin.dm",
         "code/modules/events/raids/skeleton.dm",
 		"code/modules/events/antagonist/solo/dreamwalker.dm",
+		"code/datums/storytellers/presets.dm",
 		"code/modules/tgs/**/*.dm",
 		"code/modules/unit_tests/[!_]*.dm"
 	]


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->

Adds a new lineup of replacement gamemodes that are catered to our server's different approach to PVP and by extension antagonists.

Currently VERY WIP, prone to change, and left as a draft to open for feedback!

### TODO:

- [ ] No infecting werewolves/vampires may appear in any gamemode. Conversion antags do not mix with opt-in PVP. (Currently waiting on https://github.com/Azure-Peak/Azure-Peak/pull/8712 to be merged upstream for this)
- [ ] Cull the frequency of gnolls, (probably by making them only appear in ascendant gamemodes so that they aren't guaranteed every single round.)
               (Is this even necessary? Players have expressed exhaustion with the frequency of gnolls, but this may well be a bad move since it doesn't feel good to deny someone a role they like. Discuss!!)
- [ ] Always allow a high hardcap of wretches in all gamemodes except Psydon's Extended where they remain disabled, (Psydon's Low Intensity will still allow them though.) 
- [ ] Make Werewolves more frequent than they are currently, (again, making sure they're the "lite" non-infecting variant)

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [X] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [X] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [X] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

Not tested yet, Will test once we figure out our priorities and the design for these.

## Why It's Good For The Game

<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

Our server has different priorities when it comes to antagonists and PVP, most of which I've explained already in the above sections.

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl: Ryumi
add: Game modes have been dramatically changed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
