### PR TITLE
Protect Scenes From Visions

### DIFF
--- a/code/modules/roguetown/roguemachine/abyssorcult/dream_visions.dm
+++ b/code/modules/roguetown/roguemachine/abyssorcult/dream_visions.dm
@@ -80,7 +80,7 @@
 			if(!isbelly(content_obj))
 				non_belly++
 			else
-				var/our_belly = content_obj
+				var/obj/belly/our_belly = content_obj
 				if(our_belly.contents) //If we have any human prey in our bellies, exclude us
 					for(var/mob/living/carbon/human/our_prey in our_belly.contents)
 						return FALSE

--- a/code/modules/roguetown/roguemachine/abyssorcult/dream_visions.dm
+++ b/code/modules/roguetown/roguemachine/abyssorcult/dream_visions.dm
@@ -73,8 +73,35 @@
 		return FALSE
 	// I'm- not sure how else to prevent abyssorites from seeing emotional roleplay too often.
 	// So we'll assume anyone wearing three items or less is doing emotional roleplay.
-	if(target.contents && target.contents.len < 4)
+	//OV EDIT - Expand contents check to exclude bellies
+	if(target.contents)
+		var/non_belly = 0
+		for(var/obj/content_obj in target.contents)
+			if(!isbelly(content_obj))
+				non_belly++
+			else
+				var/our_belly = content_obj
+				if(our_belly.contents) //If we have any human prey in our bellies, exclude us
+					for(var/mob/living/carbon/human/our_prey in our_belly.contents)
+						return FALSE
+		if(non_belly < 4)
+			return FALSE
+	//OV EDIT END
+
+	//OV EDIT - Make sure they aren't in a scene using checks specific to our server
+	if(isbelly(target.loc)) //Exclude prey in bellies
 		return FALSE
+
+	if(target.do_not_disturb) //Exclude people who have toggled scene privacy
+		return FALSE
+
+	for(var/datum/sex_session/session as anything in GLOB.sex_sessions) //Check if they are currently in an active sex session
+		if(session.user != target)
+			return FALSE
+		if(session.target != target)
+			return FALSE
+	//OV EDIT END
+
 	if(length(valid_roles))
 		if(target.mind.assigned_role in valid_roles)
 			return TRUE


### PR DESCRIPTION


## About The Pull Request

Adds a bunch of additional checks to vision quest targets for painters, to protect them and the people they look at from accidental scene intrusion. These are things that are not really a concern for upstream, I expect, but here are a more significant issue. These protections include:

* Excludes anyone with less than 4 items in their contents EXCLUDING vore bellies.
* Excludes anyone currently in a belly.
* Excludes anyone with a human currently in a belly.
* Excludes anyone with scene privacy toggled on.
* Excludes anyone currently in an active sex session.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [ ] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Not currently tested, did this quickly whilst at work.

## Why It's Good For The Game

This is important for protecting people from being exposed for their scenes, and also protecting painters from potentially being squicked without warning.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: Adds a bunch of additional checks to vision quest targets for painters, to protect them and the people they look at from accidental scene intrusion. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
