### PR TITLE
Vore deaths do not trigger squire/knight death mood nukes

### DIFF
--- a/code/modules/spells/spell_types/skills/invoked_single_target/takeprotege.dm
+++ b/code/modules/spells/spell_types/skills/invoked_single_target/takeprotege.dm
@@ -143,6 +143,12 @@
 	SIGNAL_HANDLER
 	if(QDELETED(src))
 		return
+	//OV EDIT
+	if(isbelly(source.loc))
+		return
+	if((source.x == 1) && (source.y == 1) && (source.z == 1))
+		return
+	//OV EDIT END
 	// 5-minute grace period: a revive-die-revive-die loop within 5 min of the last death
 	// counts as continuing trauma, not fresh trauma, so we skip the stack.
 	var/datum/stressevent/existing = get_stress_event(/datum/stressevent/protege_dead)
@@ -156,6 +162,12 @@
 	SIGNAL_HANDLER
 	if(QDELETED(src))
 		return
+	//OV EDIT
+	if(isbelly(source.loc))
+		return
+	if((source.x == 1) && (source.y == 1) && (source.z == 1))
+		return
+	//OV EDIT END
 	var/datum/stressevent/existing = get_stress_event(/datum/stressevent/protege_lord_dead)
 	if(existing && (world.time - existing.time_added) < 5 MINUTES)
 		return


### PR DESCRIPTION


## About The Pull Request

Stopped digestion deaths from triggering mood nukes of squires or knights that have a bond with the dead person.

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [x] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [x] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [ ] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence

Not tested personally yet.

## Why It's Good For The Game

Players shouldn't be punished for other people having a scene, and people shouldn't have to avoid scenes because it'll punish someone unrelated.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: Stopped digestion deaths from triggering mood nukes of squires or knights that have a bond with the dead person.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
