### PR TITLE
removes tablepass from micro and small size categories

### DIFF
--- a/modular_causticcove/code/modules/size_scaling/sizecat_types.dm
+++ b/modular_causticcove/code/modules/size_scaling/sizecat_types.dm
@@ -48,11 +48,9 @@
 	recipient.change_stat(STATKEY_CON, -2) //OV Edit: If we're taking away passthrough, throw smalls a bone
 	recipient.change_stat(STATKEY_SPD, 2)
 	recipient.add_movespeed_modifier(MOVESPEED_ID_MACROMICRO, update=TRUE, priority=100, multiplicative_slowdown=0.3, movetypes=GROUND) //They're more agile, not faster. Smaller sprite, smaller clickbox. Speed the same as 9 speed base TOTAL.
-	
-	passtable_on(recipient, MAGIC_TRAIT)
-	recipient.pass_flags |= SIZEPASS //OV Edit: More selective flag for micro passing
-	//recipient.adjust_skillrank(/datum/skill/misc/sneaking, 1, TRUE) //Sadly might have to keep this gone to prevent weirdness from it being regularly applied and removed? Can't really reasonably remove this after it's been applied...
-	//recipient.adjust_skillrank(/datum/skill/misc/stealing, 1, TRUE)
+
+	// passtable_on(recipient, MAGIC_TRAIT)
+	// recipient.pass_flags |= SIZEPASS //OV Edit: More selective flag for micro passing
 
 /datum/sizecat/small/remove_sizecat_from_living(mob/living/recipient)
 	recipient.change_stat(STATKEY_STR, 2)
@@ -60,8 +58,8 @@
 	recipient.change_stat(STATKEY_CON, 2) //OV Edit: If we're taking away passthrough, throw smalls a bone
 	recipient.change_stat(STATKEY_SPD, -2)
 
-	passtable_off(recipient, MAGIC_TRAIT)
-	recipient.pass_flags &= ~SIZEPASS //OV Edit: More selective flag for micro passing
+	// passtable_off(recipient, MAGIC_TRAIT)
+	// recipient.pass_flags &= ~SIZEPASS //OV Edit: More selective flag for micro passing
 
 /datum/sizecat/micro
 	name = "Micro"
@@ -75,11 +73,9 @@
 	recipient.change_stat(STATKEY_CON, -5)
 	recipient.change_stat(STATKEY_SPD, 5) // Multiplicative slowdown should cover the move speed while still letting micros dodge. Even at their fastest (which they should be with this modifier) they'll move as fast as a speed 0 character.
 	recipient.add_movespeed_modifier(MOVESPEED_ID_MACROMICRO, update=TRUE, priority=100, multiplicative_slowdown=1.2, movetypes=GROUND) //OV Edit: Some movespeed, as a treat. - Base slowdown is increased to the equivalent of having -5 speed. With the +5 speed added, it lowers it by .5 for a base total of 1
-	
-	passtable_on(recipient, MAGIC_TRAIT)
-	recipient.pass_flags |= SIZEPASS //OV Edit: More selective flag for micro passing
-	//recipient.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
-	//recipient.adjust_skillrank(/datum/skill/misc/stealing, 2, TRUE)
+
+	// passtable_on(recipient, MAGIC_TRAIT)
+	// recipient.pass_flags |= SIZEPASS //OV Edit: More selective flag for micro passing
 
 /datum/sizecat/micro/remove_sizecat_from_living(mob/living/recipient)
 	recipient.change_stat(STATKEY_STR, 5)
@@ -87,5 +83,5 @@
 	recipient.change_stat(STATKEY_CON, 5)
 	recipient.change_stat(STATKEY_SPD, -5)
 
-	passtable_off(recipient, MAGIC_TRAIT)
-	recipient.pass_flags &= ~SIZEPASS //OV Edit: More selective flag for micro passing
+	// passtable_off(recipient, MAGIC_TRAIT)
+	// recipient.pass_flags &= ~SIZEPASS //OV Edit: More selective flag for micro passing


### PR DESCRIPTION
## About The Pull Request
really its from all size categories since these were the only two to use it
long and short of it, no more burning from standing in braziers, no more walking over tables or open windows, no more going through murder-holes-that-mappers-use-as-glassless-windows-i-stg. Micro passthrough on mobs does, as far as I can tell, still work correctly but its hard to test that.

Also removed some commented out code about size categories making you a better sneak thief. That is 100% never being enabled here ever again so I see no reason not to clean that up while I'm here.

Only touches caustic modular files.
<!-- Describe your pull request here! Please describe and document all of the changes made in full. It helps maintainers go over everything and ensure that merges will run smoothly if needed, and that nothing is lost as more changes are made in the future! Last edited 1/14/26 by Jon -->

## Developer's checklist
<!--
Just a reminder to keep up the best practices, and to ensure that everyone has an easier time as a result! Please doublecheck that they were done!
-->
- [X] Try to modularize as much as possible. <!--  Do this by putting stuff in the modular ochre folder, and modifying Azure code by calling your code from the places where you could put the code, for an example-->
- [X] Mark the start and end of edits outside the ochre modular folder (if applicable) for changes made.
<!--
Do this one like so

Azure
///OV edit
Your code
///OV edit end
Azure

This makes it easier for maintainers to keep track of what's ours.
-->
- [X] Ensure that it compiles locally, and test new features (when applicable, please record if not!), or potential issues with related features.

## Testing Evidence
Verified smalls and micros could not walk through solid murder hole windows anymore, as well as not walking over braziers. Climbing onto braziers and through open windows still works.
<!-- Please provide evidence of testing features here, when applicable! If it is not, a quick note of this is fine. -->

## Why It's Good For The Game
This has been a positive and negative to playing a smaller character for a very long time. You can walk into places without exploding doors or opening windows but also you take a million damage from briefly kissing a brazier. Table cheese was also something small characters could use with less obvious downsides compared to micro. 

So yeah the flavor of being able to be a bird or fairy and just fly up onto a table is *nice*, the actual everything else it came with tended to kinda suck. If you want to lock a person out of an area, you lock the door. If they are micro or small, they can just pick one of the many mapped in murder-hole-windows to enter anyways. Or even shrink/grow for it.

So! Removal. For now at least. If someone brings this back but with a much narrower band of things they can walk over/on/through/whatever then they can bring it back that way. But for now its best to just remove it because its a trait that is more headache than benefit.
<!-- What benefits does this bring to our server? How can it help players enjoy themselves more, or help lead players to more scenes? If it wasn't already chatted about over the Discord, feel free to explain your resoning and desire here for the change! Or feel free to add a link to the Discord's Suggestion thread for this change! -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- Please fill in any proper tags here that are valid for your PR! This is for the auto-changelog that is generated automatically and shown ingame. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: removed table passer trait from small and micro size category characters. Micros can still walk between legs while not in combat mode.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
